### PR TITLE
Bug fixes and mobile polish from the first day of public feedback

### DIFF
--- a/server/src/routes/notes.test.ts
+++ b/server/src/routes/notes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { excerptOf } from './notes.js';
+
+describe('excerptOf', () => {
+  it('снимает markdown-разметку, оставляя текст', () => {
+    expect(excerptOf('**500 g** flour · `10 g` salt')).toBe('500 g flour · 10 g salt');
+    expect(excerptOf('- Milk\n- Eggs\n- Paint tape (see [[Repaint the hallway]])')).toBe(
+      'Milk Eggs Paint tape (see Repaint the hallway)',
+    );
+    expect(excerptOf('# Заголовок\n> цитата\n1. пункт [ссылка](https://x.y)')).toBe(
+      'Заголовок цитата пункт ссылка',
+    );
+    expect(excerptOf('![фото](img.png) текст после картинки')).toBe('текст после картинки');
+    expect(excerptOf('- [ ] купить\n- [x] сделано')).toBe('купить сделано');
+  });
+
+  it('режет до 120 символов и схлопывает пробелы', () => {
+    expect(excerptOf(`а${'  \n'.repeat(10)}б`)).toBe('а б');
+    expect(excerptOf('я'.repeat(500))).toHaveLength(120);
+  });
+});

--- a/server/src/routes/notes.test.ts
+++ b/server/src/routes/notes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { excerptOf } from './notes.js';
 
 describe('excerptOf', () => {
-  it('снимает markdown-разметку, оставляя текст', () => {
+  it('strips markdown syntax, keeps the text (Cyrillic content included)', () => {
     expect(excerptOf('**500 g** flour · `10 g` salt')).toBe('500 g flour · 10 g salt');
     expect(excerptOf('- Milk\n- Eggs\n- Paint tape (see [[Repaint the hallway]])')).toBe(
       'Milk Eggs Paint tape (see Repaint the hallway)',
@@ -14,7 +14,7 @@ describe('excerptOf', () => {
     expect(excerptOf('- [ ] купить\n- [x] сделано')).toBe('купить сделано');
   });
 
-  it('режет до 120 символов и схлопывает пробелы', () => {
+  it('cuts to 120 chars and collapses whitespace', () => {
     expect(excerptOf(`а${'  \n'.repeat(10)}б`)).toBe('а б');
     expect(excerptOf('я'.repeat(500))).toHaveLength(120);
   });

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -27,20 +27,20 @@ interface NoteRow {
 const VISIBLE = "(n.visibility = 'shared' OR n.owner_id = ?)";
 
 /**
- * Превью заметки для списка: markdown-разметка вычищается, остаётся текст.
- * Разбирать markdown по-настоящему здесь незачем — превью живёт одну строку;
- * достаточно снять то, что бросается в глаза: картинки, ссылки, вики-ссылки,
- * маркеры списков и инлайновые значки.
+ * Note preview for the list: markdown syntax is stripped, text remains.
+ * A real markdown parser is overkill here — the preview lives on a single
+ * line; it is enough to remove what catches the eye: images, links,
+ * wiki-links, list markers and inline markers.
  */
 export function excerptOf(body: string): string {
   return body
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // картинки — целиком
-    .replace(/\[\[([^\]]+)\]\]/g, '$1') // [[вики-ссылка]] → её название
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // [ссылка](url) → текст
-    .replace(/^\s*(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s*)?/gm, '') // маркеры списков и чекбоксы
-    .replace(/^\s*#{1,6}\s+/gm, '') // заголовки
-    .replace(/^\s*>\s?/gm, '') // цитаты
-    .replace(/[*_`~]/g, '') // жирный/курсив/код/зачёркнутое
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // images — whole
+    .replace(/\[\[([^\]]+)\]\]/g, '$1') // [[wiki-link]] → its title
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // [link](url) → text
+    .replace(/^\s*(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s*)?/gm, '') // list markers and checkboxes
+    .replace(/^\s*#{1,6}\s+/gm, '') // headings
+    .replace(/^\s*>\s?/gm, '') // quotes
+    .replace(/[*_`~]/g, '') // bold/italic/code/strikethrough
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 120);
@@ -287,8 +287,8 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
       )
       .all(...args) as Record<string, unknown>[];
 
-    // Превью очищается от разметки здесь, а не в SQL: раньше запрос резал
-    // сырой markdown, и в списке торчали **звёздочки** и [[скобки]]
+    // The preview is cleaned here, not in SQL: the query used to cut raw
+    // markdown, and the list showed **asterisks** and [[brackets]]
     return rows.map((r) => ({ ...r, excerpt: excerptOf(String(r.excerpt ?? '')) }));
   });
 

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -26,6 +26,26 @@ interface NoteRow {
  */
 const VISIBLE = "(n.visibility = 'shared' OR n.owner_id = ?)";
 
+/**
+ * Превью заметки для списка: markdown-разметка вычищается, остаётся текст.
+ * Разбирать markdown по-настоящему здесь незачем — превью живёт одну строку;
+ * достаточно снять то, что бросается в глаза: картинки, ссылки, вики-ссылки,
+ * маркеры списков и инлайновые значки.
+ */
+export function excerptOf(body: string): string {
+  return body
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // картинки — целиком
+    .replace(/\[\[([^\]]+)\]\]/g, '$1') // [[вики-ссылка]] → её название
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // [ссылка](url) → текст
+    .replace(/^\s*(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s*)?/gm, '') // маркеры списков и чекбоксы
+    .replace(/^\s*#{1,6}\s+/gm, '') // заголовки
+    .replace(/^\s*>\s?/gm, '') // цитаты
+    .replace(/[*_`~]/g, '') // жирный/курсив/код/зачёркнутое
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120);
+}
+
 function loadVisible(noteId: string, userId: string): NoteRow | null {
   const row = db
     .prepare(`SELECT n.* FROM notes n WHERE n.id = ? AND ${VISIBLE}`)
@@ -255,17 +275,21 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
       args.push(q.q, q.q);
     }
 
-    return db
+    const rows = db
       .prepare(
         `SELECT n.id, n.title, n.folder_id, n.visibility, n.owner_id, n.pinned,
                 n.daily_date, n.is_template, n.updated_at, u.name AS owner_name,
-                substr(replace(replace(n.body_md, '#', ''), char(10), ' '), 1, 120) AS excerpt
+                substr(n.body_md, 1, 400) AS excerpt
            FROM notes n
            LEFT JOIN users u ON u.id = n.owner_id
           WHERE ${where.join(' AND ')}
           ORDER BY n.pinned DESC, n.updated_at DESC`,
       )
-      .all(...args);
+      .all(...args) as Record<string, unknown>[];
+
+    // Превью очищается от разметки здесь, а не в SQL: раньше запрос резал
+    // сырой markdown, и в списке торчали **звёздочки** и [[скобки]]
+    return rows.map((r) => ({ ...r, excerpt: excerptOf(String(r.excerpt ?? '')) }));
   });
 
   // ── Одна заметка со связями ─────────────────────────────────────────────

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -157,8 +157,11 @@ export function AppShell() {
           Липкая и со своим скроллом: на длинном списке задач страница
           прокручивается, а панель с разделами остаётся на месте. */}
       <aside className="hidden w-56 shrink-0 flex-col border-r border-line bg-surface px-4 py-6 md:sticky md:top-0 md:flex md:h-dvh md:overflow-y-auto 3xl:w-64">
-        <div className="mb-8 px-2">
+        {/* Переключатель темы живёт в шапке: рядом с «Выйти» по нему
+            мисклики разлогинивали — цена промаха несоразмерна кнопке */}
+        <div className="mb-8 flex items-center justify-between px-2">
           <span className="font-display text-lg font-bold tracking-tight text-ink">{t('Дом')}</span>
+          <ThemeToggle />
         </div>
 
         <div className="mb-4">
@@ -195,8 +198,7 @@ export function AppShell() {
             />
             <span className="min-w-0 flex-1 truncate text-sm text-ink">{user?.name}</span>
           </div>
-          <div className="flex items-center gap-2 px-2">
-            <ThemeToggle />
+          <div className="px-2">
             <button
               type="button"
               onClick={() => void logout()}

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -143,8 +143,8 @@ function ThemeToggle() {
   );
 }
 
-/** Строка темы в мобильной шторке: сайдбара с тумблером на телефоне нет,
-    и без этой строки тему с телефона было не переключить вовсе. */
+/** Theme row for the mobile More sheet: phones have no sidebar with the
+    toggle, and without this row the theme could not be switched at all. */
 function ThemeRow() {
   const { dark, toggle } = useTheme();
   return (
@@ -181,8 +181,8 @@ export function AppShell() {
           Липкая и со своим скроллом: на длинном списке задач страница
           прокручивается, а панель с разделами остаётся на месте. */}
       <aside className="hidden w-56 shrink-0 flex-col border-r border-line bg-surface px-4 py-6 md:sticky md:top-0 md:flex md:h-dvh md:overflow-y-auto 3xl:w-64">
-        {/* Переключатель темы живёт в шапке: рядом с «Выйти» по нему
-            мисклики разлогинивали — цена промаха несоразмерна кнопке */}
+        {/* The theme toggle lives in the header: next to Sign out a missed
+            click cost a whole session — a price out of scale for the button */}
         <div className="mb-8 flex items-center justify-between px-2">
           <span className="font-display text-lg font-bold tracking-tight text-ink">{t('Дом')}</span>
           <ThemeToggle />

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -114,6 +114,21 @@ function useTheme() {
   return { dark, toggle: () => setDark((v) => !v) };
 }
 
+function ThemeIcon({ dark, className }: { dark: boolean; className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} {...stroke}>
+      {dark ? (
+        <>
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M22 12h-2M4 12H2M18.4 5.6 17 7M7 17l-1.4 1.4M18.4 18.4 17 17M7 7 5.6 5.6" />
+        </>
+      ) : (
+        <path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />
+      )}
+    </svg>
+  );
+}
+
 function ThemeToggle() {
   const { dark, toggle } = useTheme();
   return (
@@ -123,16 +138,25 @@ function ThemeToggle() {
       className="rounded-full border border-line p-2 text-muted transition-colors hover:text-ink"
       aria-label={dark ? t('Включить светлую тему') : t('Включить тёмную тему')}
     >
-      <svg viewBox="0 0 24 24" className="size-4" {...stroke}>
-        {dark ? (
-          <>
-            <circle cx="12" cy="12" r="4" />
-            <path d="M12 2v2M12 20v2M22 12h-2M4 12H2M18.4 5.6 17 7M7 17l-1.4 1.4M18.4 18.4 17 17M7 7 5.6 5.6" />
-          </>
-        ) : (
-          <path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />
-        )}
-      </svg>
+      <ThemeIcon dark={dark} className="size-4" />
+    </button>
+  );
+}
+
+/** Строка темы в мобильной шторке: сайдбара с тумблером на телефоне нет,
+    и без этой строки тему с телефона было не переключить вовсе. */
+function ThemeRow() {
+  const { dark, toggle } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="flex w-full items-center gap-3 border-b border-line px-5 py-3.5 text-sm text-ink"
+    >
+      <span className="size-5 text-muted">
+        <ThemeIcon dark={dark} className="size-5" />
+      </span>
+      {dark ? t('Включить светлую тему') : t('Включить тёмную тему')}
     </button>
   );
 }
@@ -288,6 +312,8 @@ export function AppShell() {
                 {item.label}
               </NavLink>
             ))}
+
+            <ThemeRow />
 
             <div className="flex items-center justify-between px-5 py-3.5">
               <span className="text-sm text-muted">{user?.name}</span>

--- a/web/src/components/CalendarViews.tsx
+++ b/web/src/components/CalendarViews.tsx
@@ -206,15 +206,19 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
 
   return (
     <div>
-      <div className="mb-1 hidden grid-cols-7 gap-2 sm:grid">
+      {/* Сетка месяца — 7 колонок на любом экране. Раньше на телефоне она
+          складывалась в одну колонку: месяц превращался в ленту из 35
+          пустых карточек высотой в пол-экрана. Теперь на телефоне ячейка
+          компактная — число и точки событий, тап открывает день. */}
+      <div className="mb-1 grid grid-cols-7 gap-1 sm:gap-2">
         {WEEKDAYS_SHORT.map((label) => (
-          <span key={label} className="eyebrow px-1">
+          <span key={label} className="eyebrow px-1 text-center sm:text-left">
             {label}
           </span>
         ))}
       </div>
 
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-7">
+      <div className="grid grid-cols-7 gap-1 sm:gap-2">
         {days.map((date) => {
           const entry = grouped.get(date);
           const isToday = date === today;
@@ -225,12 +229,14 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
             <div
               key={date}
               onClick={() => onPickDay(date)}
-              className={`group min-h-24 cursor-pointer rounded-lg border p-1.5 text-left align-top transition-colors ${
+              className={`group cursor-pointer rounded-lg border p-1 text-left align-top transition-colors sm:min-h-24 sm:p-1.5 ${
                 isToday ? 'border-accent bg-accent-soft/30' : 'border-line bg-surface'
               } ${outside ? 'opacity-45' : ''} hover:border-accent`}
             >
-              <span className="mb-1 flex items-baseline justify-between gap-1">
-                <AddInDay date={date} onPickDay={onPickDay} />
+              <span className="mb-0.5 flex items-baseline justify-center gap-1 sm:mb-1 sm:justify-between">
+                <span className="hidden sm:inline-flex">
+                  <AddInDay date={date} onPickDay={onPickDay} />
+                </span>
                 <span
                   className={`font-mono text-xs ${isToday ? 'text-accent' : 'text-muted'}`}
                 >
@@ -238,7 +244,25 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
                 </span>
               </span>
 
-              <div className="space-y-0.5">
+              {/* Телефон: до трёх точек цвета календаря + точка задач */}
+              <span className="flex min-h-2 items-center justify-center gap-0.5 pb-0.5 sm:hidden">
+                {items.slice(0, 3).map((o) => (
+                  <span
+                    key={`${o.id}-${date}-dot`}
+                    className="size-1.5 rounded-full"
+                    style={{ backgroundColor: o.calendar_color }}
+                    aria-hidden
+                  />
+                ))}
+                {(entry?.tasks.length ?? 0) > 0 && (
+                  <span
+                    className="size-1.5 rounded-full bg-[var(--c-text-muted)]"
+                    aria-hidden
+                  />
+                )}
+              </span>
+
+              <div className="hidden space-y-0.5 sm:block">
                 {items.slice(0, 3).map((o) => (
                   <EventChip key={`${o.id}-${date}`} occurrence={o} onOpen={onOpen} compact />
                 ))}

--- a/web/src/components/CalendarViews.tsx
+++ b/web/src/components/CalendarViews.tsx
@@ -206,10 +206,10 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
 
   return (
     <div>
-      {/* Сетка месяца — 7 колонок на любом экране. Раньше на телефоне она
-          складывалась в одну колонку: месяц превращался в ленту из 35
-          пустых карточек высотой в пол-экрана. Теперь на телефоне ячейка
-          компактная — число и точки событий, тап открывает день. */}
+      {/* The month grid keeps 7 columns on every screen. It used to collapse
+          to a single column on phones: a month became a strip of ~35 empty
+          half-screen cards. On phones a cell is now compact — the day number
+          and event dots; a tap opens the day. */}
       <div className="mb-1 grid grid-cols-7 gap-1 sm:gap-2">
         {WEEKDAYS_SHORT.map((label) => (
           <span key={label} className="eyebrow px-1 text-center sm:text-left">
@@ -244,7 +244,7 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
                 </span>
               </span>
 
-              {/* Телефон: до трёх точек цвета календаря + точка задач */}
+              {/* Phones: up to three dots in calendar colors + a task dot */}
               <span className="flex min-h-2 items-center justify-center gap-0.5 pb-0.5 sm:hidden">
                 {items.slice(0, 3).map((o) => (
                   <span

--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -31,9 +31,9 @@ export function Page({
 }) {
   return (
     <div className={`mx-auto w-full ${WIDTH[width]} px-5 py-7 sm:px-8 sm:py-9 3xl:px-12`}>
-      {/* flex-wrap: на телефоне широкий блок действий (например,
-          переключатель видов календаря) переносится под заголовок,
-          а не обрезается краем экрана */}
+      {/* flex-wrap: on phones a wide action block (say, the calendar view
+          switcher) wraps below the title instead of being cut off by the
+          screen edge */}
       <header className="mb-7 flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
         <div>
           {eyebrow && <p className="eyebrow mb-1.5">{eyebrow}</p>}

--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -31,7 +31,10 @@ export function Page({
 }) {
   return (
     <div className={`mx-auto w-full ${WIDTH[width]} px-5 py-7 sm:px-8 sm:py-9 3xl:px-12`}>
-      <header className="mb-7 flex items-end justify-between gap-4">
+      {/* flex-wrap: на телефоне широкий блок действий (например,
+          переключатель видов календаря) переносится под заголовок,
+          а не обрезается краем экрана */}
+      <header className="mb-7 flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
         <div>
           {eyebrow && <p className="eyebrow mb-1.5">{eyebrow}</p>}
           <h1 className="font-display text-2xl font-semibold tracking-tight text-ink">{title}</h1>

--- a/web/src/components/RecurringPanel.tsx
+++ b/web/src/components/RecurringPanel.tsx
@@ -13,7 +13,7 @@ import { Empty } from './Page';
 import { onEnter } from '../lib/keys';
 import { formatDate } from '../lib/format';
 import { RECURRENCE_OPTIONS } from '../lib/tasks';
-import { describeRule } from '../lib/money';
+import { describeRule, normalizeRule } from '../lib/money';
 import {
   TX_KIND_LABEL,
   formatAmountInput,
@@ -270,7 +270,9 @@ function RuleDialog({
     title: rule?.title ?? '',
     kind: rule?.kind ?? ('expense' as TxKind),
     start_on: rule?.start_on ?? today,
-    recurrence_rule: rule?.recurrence_rule ?? 'FREQ=MONTHLY',
+    // Нормализация обязательна: правило из базы может быть в форме
+    // «FREQ=MONTHLY;INTERVAL=1», которой нет среди опций select
+    recurrence_rule: normalizeRule(rule?.recurrence_rule ?? 'FREQ=MONTHLY'),
     account_id: rule?.account_id ?? accounts[0]!.id,
     amount: rule ? formatAmountInput(rule.amount) : '',
     to_account_id: rule?.to_account_id ?? '',

--- a/web/src/components/RecurringPanel.tsx
+++ b/web/src/components/RecurringPanel.tsx
@@ -270,8 +270,8 @@ function RuleDialog({
     title: rule?.title ?? '',
     kind: rule?.kind ?? ('expense' as TxKind),
     start_on: rule?.start_on ?? today,
-    // Нормализация обязательна: правило из базы может быть в форме
-    // «FREQ=MONTHLY;INTERVAL=1», которой нет среди опций select
+    // Normalization is mandatory: the stored rule may come in the
+    // "FREQ=MONTHLY;INTERVAL=1" form that matches no select option
     recurrence_rule: normalizeRule(rule?.recurrence_rule ?? 'FREQ=MONTHLY'),
     account_id: rule?.account_id ?? accounts[0]!.id,
     amount: rule ? formatAmountInput(rule.amount) : '',

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -68,20 +68,23 @@ function TaskItem({
     <>
       <li
         className="group flex items-center gap-3 border-b border-line px-4 py-2.5 last:border-0"
-        style={{ paddingLeft: `${1 + depth * 1.5}rem` }}
+        // 1.5rem базы: стрелке (w-4, -ml-4) нужно место целиком внутри строки
+        // и воздух от края — с базой 1rem она начиналась на −4px и обрезалась
+        // карточкой, с 1.25rem стояла впритык к краю
+        style={{ paddingLeft: `${1.5 + depth * 1.5}rem` }}
       >
         {node.children.length > 0 ? (
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
             aria-label={expanded ? t('Свернуть') : t('Развернуть')}
-            className="-ml-5 w-4 text-muted transition-transform hover:text-ink"
+            className="-ml-4 w-4 text-muted transition-transform hover:text-ink"
             style={{ transform: expanded ? 'rotate(90deg)' : 'none' }}
           >
             ›
           </button>
         ) : (
-          <span className="-ml-5 w-4" aria-hidden />
+          <span className="-ml-4 w-4" aria-hidden />
         )}
 
         <input

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -114,24 +114,40 @@ function TaskItem({
           </span>
         )}
 
+        {/* Приоритет — пилюлей, а не голым словом: без рамки и заливки
+            «HIGH» читался как случайная пометка, а не как приоритет */}
         {node.priority !== 'normal' && !closed && (
           <span
-            className={`hidden font-mono text-[0.625rem] tracking-wide uppercase sm:inline ${
-              node.priority === 'urgent' || node.priority === 'high' ? 'text-urgent' : 'text-muted'
+            className={`hidden shrink-0 items-center rounded-full border px-2 py-0.5 font-mono text-[0.625rem] tracking-wide uppercase sm:inline-flex ${
+              node.priority === 'urgent' || node.priority === 'high'
+                ? 'border-urgent/40 bg-urgent/10 text-urgent'
+                : 'border-line bg-surface-2 text-muted'
             }`}
           >
             {PRIORITY_LABEL[node.priority]}
           </span>
         )}
 
+        {/* Исполнитель: на широком экране — имя целиком (буква «М» не
+            различает Марка и Марию, а место есть), на планшете — аватар */}
         {node.assignee_name && (
-          <span
-            className="hidden size-5 shrink-0 place-items-center rounded-full text-[0.625rem] font-medium text-white sm:grid"
-            style={{ backgroundColor: node.assignee_color ?? 'var(--c-accent)' }}
-            title={node.assignee_name}
-          >
-            {node.assignee_name.slice(0, 1)}
-          </span>
+          <>
+            <span
+              className="hidden size-5 shrink-0 place-items-center rounded-full text-[0.625rem] font-medium text-white sm:grid lg:hidden"
+              style={{ backgroundColor: node.assignee_color ?? 'var(--c-accent)' }}
+              title={node.assignee_name}
+            >
+              {node.assignee_name.slice(0, 1)}
+            </span>
+            <span className="hidden max-w-40 shrink-0 items-center gap-1.5 rounded-full border border-line bg-surface-2 py-0.5 pr-2.5 pl-2 text-xs text-muted lg:inline-flex">
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: node.assignee_color ?? 'var(--c-accent)' }}
+                aria-hidden
+              />
+              <span className="truncate">{node.assignee_name}</span>
+            </span>
+          </>
         )}
 
         {node.due_date && (

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -68,9 +68,9 @@ function TaskItem({
     <>
       <li
         className="group flex items-center gap-3 border-b border-line px-4 py-2.5 last:border-0"
-        // 1.5rem базы: стрелке (w-4, -ml-4) нужно место целиком внутри строки
-        // и воздух от края — с базой 1rem она начиналась на −4px и обрезалась
-        // карточкой, с 1.25rem стояла впритык к краю
+        // 1.5rem base: the chevron (w-4, -ml-4) needs to sit fully inside the
+        // row with some air from the edge — with a 1rem base it started at
+        // −4px and got clipped by the card, with 1.25rem it sat flush
         style={{ paddingLeft: `${1.5 + depth * 1.5}rem` }}
       >
         {node.children.length > 0 ? (
@@ -114,8 +114,8 @@ function TaskItem({
           </span>
         )}
 
-        {/* Приоритет — пилюлей, а не голым словом: без рамки и заливки
-            «HIGH» читался как случайная пометка, а не как приоритет */}
+        {/* Priority as a pill, not a bare word: without a border and tint
+            "HIGH" read as a stray mark rather than a priority */}
         {node.priority !== 'normal' && !closed && (
           <span
             className={`hidden shrink-0 items-center rounded-full border px-2 py-0.5 font-mono text-[0.625rem] tracking-wide uppercase sm:inline-flex ${
@@ -128,8 +128,8 @@ function TaskItem({
           </span>
         )}
 
-        {/* Исполнитель: на широком экране — имя целиком (буква «М» не
-            различает Марка и Марию, а место есть), на планшете — аватар */}
+        {/* Assignee: full name on wide screens (a single "M" cannot tell
+            Mark from Maria, and the space is there), avatar on tablets */}
         {node.assignee_name && (
           <>
             <span

--- a/web/src/lib/i18n.en.ts
+++ b/web/src/lib/i18n.en.ts
@@ -626,6 +626,7 @@ export const en: Record<string, string> = {
   'Понедельник': 'Monday',
   'Воскресенье': 'Sunday',
   'Демо': 'Demo',
+  'Каждые': 'Every',
   'Общий': 'Shared',
   'Проверьте, что сервер хаба запущен, и обновите страницу.':
     'Check that the hub server is running, then reload the page.',
@@ -647,6 +648,9 @@ for (const key of Object.keys(en)) {
 /** Английские пары множественного числа: ключ — русская форма единственного. */
 export const enPlurals: Record<string, [string, string]> = {
   'день': ['day', 'days'],
+  'неделю': ['week', 'weeks'],
+  'месяц': ['month', 'months'],
+  'год': ['year', 'years'],
   'операция': ['transaction', 'transactions'],
   'событие': ['event', 'events'],
   'задача': ['task', 'tasks'],

--- a/web/src/lib/money.test.ts
+++ b/web/src/lib/money.test.ts
@@ -66,19 +66,19 @@ describe('formatAmountInput → parseAmount: round-trip', () => {
 });
 
 describe('normalizeRule / describeRule', () => {
-  it('INTERVAL=1 сводится к канонической форме без интервала', () => {
-    // База и сидинг хранят с ;INTERVAL=1, интерфейс — без: формы эквивалентны
+  it('INTERVAL=1 reduces to the canonical interval-free form', () => {
+    // The db and seeding store ;INTERVAL=1, the UI goes without: equivalent forms
     expect(normalizeRule('FREQ=MONTHLY;INTERVAL=1')).toBe('FREQ=MONTHLY');
     expect(normalizeRule('freq=weekly;interval=1')).toBe('FREQ=WEEKLY');
     expect(normalizeRule('FREQ=MONTHLY;INTERVAL=3')).toBe('FREQ=MONTHLY;INTERVAL=3');
   });
 
-  it('не-RRULE возвращается как есть', () => {
+  it('non-RRULE strings pass through unchanged', () => {
     expect(normalizeRule('каждый вторник')).toBe('каждый вторник');
   });
 
-  it('описание не показывает сырой RRULE человеку', () => {
-    // Тесты идут с языком en (дефолт без localStorage)
+  it('the description never shows raw RRULE to a human', () => {
+    // Tests run with lang en (the default without localStorage)
     expect(describeRule('FREQ=MONTHLY;INTERVAL=1')).toBe('Every month');
     expect(describeRule('FREQ=MONTHLY')).toBe('Every month');
     expect(describeRule('FREQ=MONTHLY;INTERVAL=6')).toBe('Every 6 months');

--- a/web/src/lib/money.test.ts
+++ b/web/src/lib/money.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { formatAmountInput, orderCategories, parseAmount, type Category } from './money';
+import {
+  describeRule,
+  formatAmountInput,
+  normalizeRule,
+  orderCategories,
+  parseAmount,
+  type Category,
+} from './money';
 
 describe('parseAmount', () => {
   it('целые и дробные, оба разделителя', () => {
@@ -55,6 +62,27 @@ describe('formatAmountInput → parseAmount: round-trip', () => {
   it('формат без локали и группировки', () => {
     expect(formatAmountInput(150000)).toBe('1500');
     expect(formatAmountInput(123456)).toBe('1234.56');
+  });
+});
+
+describe('normalizeRule / describeRule', () => {
+  it('INTERVAL=1 сводится к канонической форме без интервала', () => {
+    // База и сидинг хранят с ;INTERVAL=1, интерфейс — без: формы эквивалентны
+    expect(normalizeRule('FREQ=MONTHLY;INTERVAL=1')).toBe('FREQ=MONTHLY');
+    expect(normalizeRule('freq=weekly;interval=1')).toBe('FREQ=WEEKLY');
+    expect(normalizeRule('FREQ=MONTHLY;INTERVAL=3')).toBe('FREQ=MONTHLY;INTERVAL=3');
+  });
+
+  it('не-RRULE возвращается как есть', () => {
+    expect(normalizeRule('каждый вторник')).toBe('каждый вторник');
+  });
+
+  it('описание не показывает сырой RRULE человеку', () => {
+    // Тесты идут с языком en (дефолт без localStorage)
+    expect(describeRule('FREQ=MONTHLY;INTERVAL=1')).toBe('Every month');
+    expect(describeRule('FREQ=MONTHLY')).toBe('Every month');
+    expect(describeRule('FREQ=MONTHLY;INTERVAL=6')).toBe('Every 6 months');
+    expect(describeRule('FREQ=DAILY;INTERVAL=10')).toBe('Every 10 days');
   });
 });
 

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -237,11 +237,11 @@ const RULE_UNITS: Record<string, [string, string, string]> = {
 };
 
 /**
- * Каноническая форма правила: INTERVAL=1 опускается.
- * Сервер и сидинг хранят «FREQ=MONTHLY;INTERVAL=1», интерфейсные списки
- * оперируют «FREQ=MONTHLY» — формы эквивалентны, но строкового равенства
- * между ними нет, и без нормализации подпись показывала сырой RRULE,
- * а select редактирования не находил свою опцию.
+ * Canonical rule form: INTERVAL=1 is dropped.
+ * The server and seeding store "FREQ=MONTHLY;INTERVAL=1" while the UI lists
+ * operate on "FREQ=MONTHLY" — the forms are equivalent but not string-equal,
+ * and without normalization the label showed raw RRULE and the edit dialog's
+ * select could not find its option.
  */
 export function normalizeRule(rule: string): string {
   const m = /^FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)(?:;INTERVAL=(\d+))?$/.exec(
@@ -257,8 +257,8 @@ export function describeRule(rule: string): string {
   const known = RULE_LABEL[canonical];
   if (known) return known;
 
-  // Правило вне готового списка (например, «раз в 6 месяцев» из API) —
-  // собираем честное описание, а не показываем RRULE человеку
+  // A rule outside the preset list (say, "every 6 months" via the API) —
+  // build an honest description instead of showing RRULE to a human
   const m = /^FREQ=([A-Z]+);INTERVAL=(\d+)$/.exec(canonical);
   const units = m ? RULE_UNITS[m[1]!] : undefined;
   if (!m || !units) return rule;

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -1,4 +1,5 @@
 import { intlLocale, t } from './i18n';
+import { plural } from './format';
 export type AccountKind = 'cash' | 'card' | 'savings';
 export type TxKind = 'expense' | 'income' | 'transfer';
 
@@ -228,6 +229,39 @@ const RULE_LABEL: Record<string, string> = {
   'FREQ=YEARLY': t('Каждый год'),
 };
 
+const RULE_UNITS: Record<string, [string, string, string]> = {
+  DAILY: ['день', 'дня', 'дней'],
+  WEEKLY: ['неделю', 'недели', 'недель'],
+  MONTHLY: ['месяц', 'месяца', 'месяцев'],
+  YEARLY: ['год', 'года', 'лет'],
+};
+
+/**
+ * Каноническая форма правила: INTERVAL=1 опускается.
+ * Сервер и сидинг хранят «FREQ=MONTHLY;INTERVAL=1», интерфейсные списки
+ * оперируют «FREQ=MONTHLY» — формы эквивалентны, но строкового равенства
+ * между ними нет, и без нормализации подпись показывала сырой RRULE,
+ * а select редактирования не находил свою опцию.
+ */
+export function normalizeRule(rule: string): string {
+  const m = /^FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)(?:;INTERVAL=(\d+))?$/.exec(
+    rule.trim().toUpperCase(),
+  );
+  if (!m) return rule;
+  const interval = Number(m[2] ?? 1);
+  return interval === 1 ? `FREQ=${m[1]}` : `FREQ=${m[1]};INTERVAL=${interval}`;
+}
+
 export function describeRule(rule: string): string {
-  return RULE_LABEL[rule] ?? rule;
+  const canonical = normalizeRule(rule);
+  const known = RULE_LABEL[canonical];
+  if (known) return known;
+
+  // Правило вне готового списка (например, «раз в 6 месяцев» из API) —
+  // собираем честное описание, а не показываем RRULE человеку
+  const m = /^FREQ=([A-Z]+);INTERVAL=(\d+)$/.exec(canonical);
+  const units = m ? RULE_UNITS[m[1]!] : undefined;
+  if (!m || !units) return rule;
+  const n = Number(m[2]);
+  return `${t('Каждые')} ${n} ${plural(n, ...units)}`;
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -32,7 +32,7 @@ function TaskRow({ task, overdue }: { task: Task; overdue?: boolean }) {
       />
       <span className="min-w-0 flex-1 truncate text-sm text-ink">{task.title}</span>
       {task.priority === 'urgent' && (
-        <span className="font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
+        <span className="shrink-0 rounded-full border border-urgent/40 bg-urgent/10 px-2 py-0.5 font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
           {PRIORITY_LABEL.urgent}
         </span>
       )}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -486,7 +486,10 @@ export function Notes() {
         </p>
       )}
 
-      <div className="grid gap-5 lg:grid-cols-[20rem_minmax(0,1fr)] 2xl:grid-cols-[22rem_minmax(0,1fr)_20rem] 3xl:gap-6">
+      {/* minmax(0,…) и в базовой колонке: у grid-элементов min-width:auto,
+          и без нуля nowrap-превью заметок диктовало ширину колонки — на
+          телефоне список распирал страницу в горизонтальный скролл */}
+      <div className="grid grid-cols-[minmax(0,1fr)] gap-5 lg:grid-cols-[20rem_minmax(0,1fr)] 2xl:grid-cols-[22rem_minmax(0,1fr)_20rem] 3xl:gap-6">
         <div className={note ? 'hidden lg:block' : ''}>
           <input
             value={query}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -486,9 +486,10 @@ export function Notes() {
         </p>
       )}
 
-      {/* minmax(0,…) и в базовой колонке: у grid-элементов min-width:auto,
-          и без нуля nowrap-превью заметок диктовало ширину колонки — на
-          телефоне список распирал страницу в горизонтальный скролл */}
+      {/* minmax(0,…) in the base column too: grid items default to
+          min-width:auto, and without the zero the nowrap note previews
+          dictated the column width — on phones the list pushed the page
+          into a horizontal scroll */}
       <div className="grid grid-cols-[minmax(0,1fr)] gap-5 lg:grid-cols-[20rem_minmax(0,1fr)] 2xl:grid-cols-[22rem_minmax(0,1fr)_20rem] 3xl:gap-6">
         <div className={note ? 'hidden lg:block' : ''}>
           <input

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -57,7 +57,7 @@ function SignInSection() {
     'rounded-lg border border-line px-3 py-1.5 text-sm text-ink transition-colors hover:bg-surface-2';
 
   return (
-    <section className="mt-5 max-w-md rounded-card border border-line bg-surface p-5">
+    <section className="rounded-card border border-line bg-surface p-5">
       <h2 className="eyebrow mb-4">{t('Вход в учётку')}</h2>
 
       <div className="flex items-center justify-between gap-3">
@@ -181,7 +181,13 @@ export function Settings() {
 
   return (
     <Page title={t('Настройки')} eyebrow={t('Табло и виджеты')}>
-      <div className="max-w-md space-y-5 rounded-card border border-line bg-surface p-5">
+      {/* Две колонки на широком экране: одна узкая лента оставляла пустой
+          правую половину и заставляла скроллить. На мобильном — колонка,
+          порядок секций тот же. */}
+      {/* До lg — одна колонка прежней ширины max-w-md, шире — две колонки:
+          без ограничения формы растягивались на всю max-w-4xl на планшете */}
+      <div className="grid max-w-md items-start gap-5 lg:max-w-4xl lg:grid-cols-2">
+      <div className="space-y-5 rounded-card border border-line bg-surface p-5">
         {FIELDS.map((f) => (
           <label key={f.key} className="block">
             <span className="mb-1.5 block text-sm font-medium text-ink">{f.label}</span>
@@ -208,7 +214,8 @@ export function Settings() {
         </div>
       </div>
 
-      <section className="mt-5 max-w-md rounded-card border border-line bg-surface p-5">
+      <div className="space-y-5">
+      <section className="rounded-card border border-line bg-surface p-5">
         <h2 className="eyebrow mb-4">{t('Язык')} / Language</h2>
         <div className="flex gap-2">
           <button
@@ -260,7 +267,7 @@ export function Settings() {
       <SignInSection />
 
       {usage && (
-        <section className="mt-5 max-w-md rounded-card border border-line bg-surface p-5">
+        <section className="rounded-card border border-line bg-surface p-5">
           <h2 className="eyebrow mb-3">{t('Вложения')}</h2>
           <p className="text-sm text-ink">
             {usage.files} {plural(usage.files, 'файл', 'файла', 'файлов')} ·{' '}
@@ -281,7 +288,7 @@ export function Settings() {
       {user?.role === 'admin' && (
         <Link
           to="/users"
-          className="mt-5 block max-w-md rounded-card border border-line bg-surface px-5 py-4 text-sm text-ink hover:border-accent"
+          className="block rounded-card border border-line bg-surface px-5 py-4 text-sm text-ink hover:border-accent"
         >
           {t('Пользователи')}
           <span className="mt-1 block text-xs text-muted">
@@ -289,6 +296,8 @@ export function Settings() {
           </span>
         </Link>
       )}
+      </div>
+      </div>
     </Page>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -181,11 +181,10 @@ export function Settings() {
 
   return (
     <Page title={t('Настройки')} eyebrow={t('Табло и виджеты')}>
-      {/* Две колонки на широком экране: одна узкая лента оставляла пустой
-          правую половину и заставляла скроллить. На мобильном — колонка,
-          порядок секций тот же. */}
-      {/* До lg — одна колонка прежней ширины max-w-md, шире — две колонки:
-          без ограничения формы растягивались на всю max-w-4xl на планшете */}
+      {/* Two columns on wide screens: a single narrow ribbon left the right
+          half empty and forced scrolling. Below lg — one column of the old
+          max-w-md width (without the cap the forms stretched across the
+          whole max-w-4xl on tablets), same section order. */}
       <div className="grid max-w-md items-start gap-5 lg:max-w-4xl lg:grid-cols-2">
       <div className="space-y-5 rounded-card border border-line bg-surface p-5">
         {FIELDS.map((f) => (

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -266,21 +266,23 @@ export function Tasks() {
         )}
       </div>
 
-      {/* Быстрый ввод */}
+      {/* Быстрый ввод. flex-wrap обязателен: на телефоне строка целиком
+          не помещается, и без переноса селект с кнопкой распирали страницу
+          до горизонтального скролла */}
       {view === 'list' && !showArchived && (
-        <div className="mb-4 flex gap-2">
+        <div className="mb-4 flex flex-wrap gap-2">
           <input
             value={newTitle}
             placeholder={projectId ? t('Новая задача в этом проекте') : t('Новая задача')}
             onChange={(e) => setNewTitle(e.target.value)}
             onKeyDown={onEnter(() => void addTask())}
-            className="flex-1 rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent sm:w-auto sm:flex-1"
           />
           {!projectId && (
             <select
               value={newProject}
               onChange={(e) => setNewProject(e.target.value)}
-              className={control}
+              className={`${control} min-w-0 flex-1 sm:flex-none`}
             >
               {projects.map((p) => (
                 <option key={p.id} value={p.id}>

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -266,9 +266,9 @@ export function Tasks() {
         )}
       </div>
 
-      {/* Быстрый ввод. flex-wrap обязателен: на телефоне строка целиком
-          не помещается, и без переноса селект с кнопкой распирали страницу
-          до горизонтального скролла */}
+      {/* Quick add. flex-wrap is mandatory: the row does not fit a phone
+          screen whole, and without wrapping the select and the button pushed
+          the page into a horizontal scroll */}
       {view === 'list' && !showArchived && (
         <div className="mb-4 flex flex-wrap gap-2">
           <input

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -66,6 +66,24 @@
   --breakpoint-4xl: 160rem;
 }
 
+/*
+  Своя стрелка у select: нативная не уважает padding поля и прилипает
+  к правому краю (а в тёмной теме ещё и красится системой по-своему).
+  Цвет #848f98 подобран серединным — читается на обеих темах; переменную
+  внутрь data:-URI не передать, это ограничение CSS.
+  Правило НАРОЧНО вне @layer: слои Tailwind уступают вне-слойному CSS,
+  иначе padding-right проиграл бы утилите px-* на конкретном селекте
+  (внутри @layer base так и происходило).
+*/
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23848f98' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='m4 6 4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.5rem center;
+  background-size: 1rem;
+  padding-right: 1.875rem;
+}
+
 @layer base {
   html {
     -webkit-text-size-adjust: 100%;
@@ -86,6 +104,7 @@
     outline-offset: 2px;
     border-radius: 2px;
   }
+
 
   /* Метки разделов: моноширинный, разрядка, верхний регистр.
      Служебный слой типографики, отделённый от контента. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -67,13 +67,13 @@
 }
 
 /*
-  Своя стрелка у select: нативная не уважает padding поля и прилипает
-  к правому краю (а в тёмной теме ещё и красится системой по-своему).
-  Цвет #848f98 подобран серединным — читается на обеих темах; переменную
-  внутрь data:-URI не передать, это ограничение CSS.
-  Правило НАРОЧНО вне @layer: слои Tailwind уступают вне-слойному CSS,
-  иначе padding-right проиграл бы утилите px-* на конкретном селекте
-  (внутри @layer base так и происходило).
+  Custom select arrow: the native glyph ignores the field's padding and
+  sticks to the right edge (and the OS recolors it on the dark theme).
+  #848f98 is picked as a middle tone readable on both themes; a CSS
+  variable cannot be passed into a data: URI — a CSS limitation.
+  The rule is DELIBERATELY outside @layer: Tailwind's layers lose to
+  unlayered CSS, otherwise padding-right would lose to a px-* utility on
+  a given select (which is exactly what happened inside @layer base).
 */
 select {
   appearance: none;


### PR DESCRIPTION
Thirteen fixes collected from demo feedback and a systematic walk
through the mobile layout (which turned out to be in demand and
under-loved).

**Desktop / general:**
- custom select arrows — the native glyph ignored field padding and hugged the edge
- task-tree expand chevron was clipped by the card edge
- recurring payments showed raw `FREQ=MONTHLY;INTERVAL=1` instead of "Every month" (+ the edit dialog select had no matching option)
- Settings uses two columns on wide screens instead of one narrow scrolling ribbon
- theme toggle moved away from Sign out (misclick cost a session)
- task list metadata is readable: assignee chips with full names, priority pills

**Mobile:**
- quick-add row and notes list no longer force a horizontal page scroll
- month view is a real 7-column grid (was: a strip of 35 half-screen cells)
- page-header actions wrap instead of being cut off (calendar view switcher)
- theme is switchable from the phone at all (More sheet row)
- dashboard urgent marker matches the list pill

**Notes:**
- previews show text, not raw markdown (`**500 g**`, `[[...]]` cleaned server-side, with tests)

Tests: 34 passing, typecheck and lint clean. Every fix verified in the
live demo at desktop and mobile widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)