### PR TITLE
Custom entity colors with a per-hub palette

### DIFF
--- a/web/src/components/EntityDialog.tsx
+++ b/web/src/components/EntityDialog.tsx
@@ -1,5 +1,5 @@
 import { t } from '../lib/i18n';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   Modal,
   dialogDanger,
@@ -9,6 +9,7 @@ import {
   dialogPrimary,
 } from './Dialog';
 import { onEnter } from '../lib/keys';
+import { PALETTE, addToPalette, loadCustomPalette } from '../lib/palette';
 
 /**
  * Проекты, папки и календари — разные сущности, но правятся одинаково:
@@ -16,16 +17,7 @@ import { onEnter } from '../lib/keys';
  * Один диалог на всех вместо трёх почти одинаковых.
  */
 
-export const PALETTE = [
-  '#1F6E8C',
-  '#6B8F5E',
-  '#C4842B',
-  '#8C4A6B',
-  '#4A6B8C',
-  '#8C6B4A',
-  '#5A6A74',
-  '#7A5C9E',
-];
+export { PALETTE } from '../lib/palette';
 
 export interface EntityDraft {
   name: string;
@@ -68,6 +60,32 @@ export function EntityDialog({
   const [draft, setDraft] = useState<EntityDraft>(initial);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // Hub-wide custom palette on top of the stock eight. Loaded on dialog
+  // open — the dialog is rare enough that a fetch here is simpler than
+  // any shared state.
+  const [custom, setCustom] = useState<string[]>([]);
+  // The native color input fires change on every drag tick — the palette
+  // write is debounced so one picking session lands as one save.
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (initial.color === undefined) return;
+    let alive = true;
+    void loadCustomPalette().then((colors) => {
+      if (alive) setCustom(colors);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [initial.color]);
+
+  function pickCustom(color: string) {
+    setDraft((d) => ({ ...d, color }));
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      void addToPalette(color).then(setCustom);
+    }, 800);
+  }
 
   async function run(action: () => Promise<void> | void) {
     setBusy(true);
@@ -130,8 +148,8 @@ export function EntityDialog({
         {draft.color !== undefined && (
           <div>
             <span className={dialogLabel}>{t('Цвет')}</span>
-            <div className="flex flex-wrap gap-2">
-              {PALETTE.map((color) => (
+            <div className="flex flex-wrap items-center gap-2">
+              {[...PALETTE, ...custom].map((color) => (
                 <button
                   key={color}
                   type="button"
@@ -145,6 +163,22 @@ export function EntityDialog({
                   }`}
                 />
               ))}
+              {/* The native picker: any color at all. What gets picked here
+                  lands in the hub palette automatically, so favourites
+                  accumulate; pruning lives in Settings. */}
+              <label
+                className="grid size-7 cursor-pointer place-items-center rounded-full border border-dashed border-line text-sm text-muted transition-colors hover:border-accent hover:text-accent"
+                title={t('Свой цвет')}
+              >
+                +
+                <input
+                  type="color"
+                  value={draft.color ?? PALETTE[0]}
+                  onChange={(e) => pickCustom(e.target.value)}
+                  className="sr-only"
+                  aria-label={t('Свой цвет')}
+                />
+              </label>
             </div>
           </div>
         )}

--- a/web/src/lib/i18n.en.ts
+++ b/web/src/lib/i18n.en.ts
@@ -626,6 +626,13 @@ export const en: Record<string, string> = {
   'Понедельник': 'Monday',
   'Воскресенье': 'Sunday',
   'Демо': 'Demo',
+  'Палитра': 'Palette',
+  'Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.':
+    'Your own colors for projects, accounts, categories and calendars — on top of the stock ones. Grows from here and from the "+" button right in the color picker.',
+  'Стандартный цвет': 'Stock color',
+  'Убрать {color}': 'Remove {color}',
+  'Добавить цвет': 'Add color',
+  'Свой цвет': 'Custom color',
   'Каждые': 'Every',
   'Общий': 'Shared',
   'Проверьте, что сервер хаба запущен, и обновите страницу.':

--- a/web/src/lib/palette.test.ts
+++ b/web/src/lib/palette.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { PALETTE_MAX, parsePalette } from './palette';
+
+describe('parsePalette', () => {
+  it('parses a stored JSON array of hex colors', () => {
+    expect(parsePalette('["#AABBCC", "#123456"]')).toEqual(['#aabbcc', '#123456']);
+  });
+
+  it('is defensive: settings are free-form strings', () => {
+    expect(parsePalette(undefined)).toEqual([]);
+    expect(parsePalette('')).toEqual([]);
+    expect(parsePalette('not json')).toEqual([]);
+    expect(parsePalette('{"a":1}')).toEqual([]);
+    expect(parsePalette('["red", "#12345", "#1234567", 42, "#abcdef"]')).toEqual(['#abcdef']);
+  });
+
+  it('dedupes case-insensitively and enforces the cap', () => {
+    expect(parsePalette('["#AABBCC", "#aabbcc"]')).toEqual(['#aabbcc']);
+    const many = JSON.stringify(
+      Array.from({ length: 40 }, (_, i) => `#${String(100000 + i).slice(0, 6)}`),
+    );
+    expect(parsePalette(many)).toHaveLength(PALETTE_MAX);
+  });
+});

--- a/web/src/lib/palette.ts
+++ b/web/src/lib/palette.ts
@@ -1,0 +1,69 @@
+import { api } from './api';
+
+/**
+ * Colors for entities (projects, calendars, accounts, categories).
+ *
+ * The stock palette is deliberately small and muted — it keeps the UI calm.
+ * On top of it every hub keeps its own custom palette in the shared settings
+ * (one hub-wide list, like the default currency): the stock eight turned out
+ * to be nowhere near enough. PEOPLE WANT MORE.
+ */
+
+export const PALETTE = [
+  '#1F6E8C',
+  '#6B8F5E',
+  '#C4842B',
+  '#8C4A6B',
+  '#4A6B8C',
+  '#8C6B4A',
+  '#5A6A74',
+  '#7A5C9E',
+];
+
+export const PALETTE_KEY = 'palette.custom';
+
+/** Hard cap: the settings value is limited to 500 chars server-side. */
+export const PALETTE_MAX = 24;
+
+const HEX = /^#[0-9a-f]{6}$/i;
+
+/** Parse the stored palette defensively: settings are free-form strings. */
+export function parsePalette(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.map((c) => String(c).toLowerCase()).filter((c) => HEX.test(c)))].slice(
+      0,
+      PALETTE_MAX,
+    );
+  } catch {
+    return [];
+  }
+}
+
+export async function loadCustomPalette(): Promise<string[]> {
+  const settings = await api.get<Record<string, string>>('/settings');
+  return parsePalette(settings[PALETTE_KEY]);
+}
+
+/**
+ * Add a color to the hub palette. Stock colors and duplicates are skipped —
+ * the palette only accumulates what is genuinely new.
+ */
+export async function addToPalette(color: string): Promise<string[]> {
+  const hex = color.toLowerCase();
+  if (!HEX.test(hex)) return loadCustomPalette();
+  const current = await loadCustomPalette();
+  if (current.includes(hex) || PALETTE.some((c) => c.toLowerCase() === hex)) return current;
+  const next = [...current, hex].slice(0, PALETTE_MAX);
+  await api.patch('/settings', { [PALETTE_KEY]: JSON.stringify(next) });
+  return next;
+}
+
+export async function removeFromPalette(color: string): Promise<string[]> {
+  const current = await loadCustomPalette();
+  const next = current.filter((c) => c !== color.toLowerCase());
+  await api.patch('/settings', { [PALETTE_KEY]: JSON.stringify(next) });
+  return next;
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { lang, setLang, t } from '../lib/i18n';
 import { setWeekStart, weekStart } from '../lib/format';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
@@ -8,6 +8,77 @@ import { useDialogs } from '../components/Dialog';
 import { plural } from '../lib/format';
 import { Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
+import { PALETTE, addToPalette, loadCustomPalette, removeFromPalette } from '../lib/palette';
+
+/**
+ * The hub's custom colors on top of the stock palette. The list also grows
+ * from the color pickers in entity dialogs; this is where it gets pruned.
+ */
+function PaletteSection() {
+  const [custom, setCustom] = useState<string[] | null>(null);
+  // The native color input fires change per drag tick — debounce the save
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    void loadCustomPalette()
+      .then(setCustom)
+      .catch(() => setCustom([]));
+  }, []);
+
+  function add(color: string) {
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => {
+      void addToPalette(color).then(setCustom);
+    }, 800);
+  }
+
+  return (
+    <section className="rounded-card border border-line bg-surface p-5">
+      <h2 className="eyebrow mb-3">{t('Палитра')}</h2>
+      <p className="mb-3 text-xs text-muted">
+        {t('Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.')}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {PALETTE.map((color) => (
+          <span
+            key={color}
+            className="size-7 rounded-full opacity-60"
+            style={{ backgroundColor: color }}
+            title={t('Стандартный цвет')}
+          />
+        ))}
+        {(custom ?? []).map((color) => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => void removeFromPalette(color).then(setCustom)}
+            style={{ backgroundColor: color }}
+            title={t('Убрать {color}', { color })}
+            aria-label={t('Убрать {color}', { color })}
+            className="group relative size-7 rounded-full"
+          >
+            <span className="absolute inset-0 grid place-items-center rounded-full bg-black/40 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
+              ×
+            </span>
+          </button>
+        ))}
+        <label
+          className="grid size-7 cursor-pointer place-items-center rounded-full border border-dashed border-line text-sm text-muted transition-colors hover:border-accent hover:text-accent"
+          title={t('Добавить цвет')}
+        >
+          +
+          <input
+            type="color"
+            onChange={(e) => add(e.target.value)}
+            className="sr-only"
+            aria-label={t('Добавить цвет')}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}
 
 /** Сообщения после возврата от Google на привязке — код в ?google= */
 const LINK_MESSAGES: Record<string, string> = {
@@ -262,6 +333,8 @@ export function Settings() {
           </button>
         </div>
       </section>
+
+      <PaletteSection />
 
       <SignInSection />
 


### PR DESCRIPTION
From user feedback: the eight stock pastels are not enough.

- Every color picker (projects, accounts, categories, calendars — all served by the shared EntityDialog) now ends with a dashed **+** button backed by the native color input: pick anything, it applies immediately and lands in the hub palette.
- The hub palette (settings key `palette.custom`, JSON hex array, capped at 24) is shared by the whole family — favourites accumulate from the dialogs on their own.
- Settings has a new **Palette** section: stock colors shown muted, custom ones removable — the pruning place.
- Palette writes are debounced (the native input fires per drag tick).
- No server changes: the backend always accepted any hex.

`parsePalette` covered with tests; verified live end-to-end in the demo.

**Stacked on #1** — the base will switch to master once #1 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)