### PR TITLE
Move people management into Settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { AuthProvider, useAuth } from './lib/auth';
 import { DialogProvider } from './components/Dialog';
@@ -8,7 +8,6 @@ import { Tasks } from './pages/Tasks';
 import { Notes } from './pages/Notes';
 import { Calendar } from './pages/Calendar';
 import { Settings } from './pages/Settings';
-import { Users } from './pages/Users';
 import { Money } from './pages/Money';
 
 function Gate() {
@@ -29,7 +28,8 @@ function Gate() {
         <Route path="notes" element={<Notes />} />
         <Route path="money" element={<Money />} />
         <Route path="settings" element={<Settings />} />
-        {user.role === 'admin' && <Route path="users" element={<Users />} />}
+        {/* People management moved into Settings; old bookmarks land there */}
+        <Route path="users" element={<Navigate to="/settings" replace />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -87,18 +87,6 @@ const SECONDARY: NavItem[] = [
   },
 ];
 
-const ADMIN_NAV: NavItem = {
-  to: '/users',
-  label: t('Пользователи'),
-  icon: (
-    <svg viewBox="0 0 24 24" {...stroke}>
-      <circle cx="9" cy="8" r="3.2" />
-      <path d="M3.5 19c0-3 2.5-4.8 5.5-4.8s5.5 1.8 5.5 4.8" />
-      <path d="M16 5.4a3.2 3.2 0 0 1 0 5.2M17.5 14.6c1.9.5 3 2.2 3 4.4" />
-    </svg>
-  ),
-};
-
 function useTheme() {
   const [dark, setDark] = useState(() => {
     const saved = localStorage.getItem('hub.theme');
@@ -169,11 +157,7 @@ export function AppShell() {
   // а боковой панели там нет вовсе.
   const [searchOpen, setSearchOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
-  const sidebarNav = [
-    ...NAV,
-    ...SECONDARY,
-    ...(user?.role === 'admin' ? [ADMIN_NAV] : []),
-  ];
+  const sidebarNav = [...NAV, ...SECONDARY];
 
   return (
     <div className="min-h-dvh md:flex">
@@ -301,7 +285,7 @@ export function AppShell() {
               {t('Поиск')}
             </button>
 
-            {[...SECONDARY, ...(user?.role === 'admin' ? [ADMIN_NAV] : [])].map((item) => (
+            {SECONDARY.map((item) => (
               <NavLink
                 key={item.to}
                 to={item.to}

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -1,10 +1,10 @@
 import { t } from '../lib/i18n';
 import { useEffect, useState } from 'react';
 import { api } from '../lib/api';
-import { Empty, Page } from '../components/Page';
+import { Empty } from './Page';
 import { onEnter } from '../lib/keys';
-import { EntityDialog } from '../components/EntityDialog';
-import { useDialogs } from '../components/Dialog';
+import { EntityDialog } from './EntityDialog';
+import { useDialogs } from './Dialog';
 
 interface ManagedUser {
   id: string;
@@ -146,7 +146,13 @@ function InvitesBlock() {
   );
 }
 
-export function Users() {
+/**
+ * People management, formerly a standalone /users page. User feedback:
+ * managing the household happens a few times a year — it does not deserve
+ * a navigation item. It now lives in Settings (admin only) and spans both
+ * columns there.
+ */
+export function PeopleSection() {
   const [users, setUsers] = useState<ManagedUser[] | null>(null);
   const [password, setPassword] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -193,7 +199,8 @@ export function Users() {
   }
 
   return (
-    <Page title={t('Пользователи')} eyebrow={t('Кто живёт в доме')}>
+    <section>
+      <h2 className="eyebrow mb-4">{t('Пользователи')}</h2>
       <InvitesBlock />
 
       {password && <PasswordOnce password={password} onClose={() => setPassword(null)} />}
@@ -293,6 +300,6 @@ export function Users() {
       <p className="mt-5 text-sm text-muted">
         {t('Администратор управляет учётками и настройками, но не видит чужие приватные заметки — выборки фильтруются по владельцу без исключений для роли.')}
       </p>
-    </Page>
+    </section>
   );
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 import { lang, setLang, t } from '../lib/i18n';
 import { setWeekStart, weekStart } from '../lib/format';
 import { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { useDialogs } from '../components/Dialog';
@@ -9,6 +8,7 @@ import { plural } from '../lib/format';
 import { Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
 import { PALETTE, addToPalette, loadCustomPalette, removeFromPalette } from '../lib/palette';
+import { PeopleSection } from '../components/PeopleSection';
 
 /**
  * The hub's custom colors on top of the stock palette. The list also grows
@@ -357,18 +357,16 @@ export function Settings() {
         </section>
       )}
 
-      {user?.role === 'admin' && (
-        <Link
-          to="/users"
-          className="block rounded-card border border-line bg-surface px-5 py-4 text-sm text-ink hover:border-accent"
-        >
-          {t('Пользователи')}
-          <span className="mt-1 block text-xs text-muted">
-            {t('Завести учётку, сбросить пароль, отключить доступ')}
-          </span>
-        </Link>
-      )}
       </div>
+
+      {/* People management spans both columns: it is a rare-visit admin
+          block, wide lists inside, and user feedback asked for exactly
+          this instead of a dedicated navigation section */}
+      {user?.role === 'admin' && (
+        <div className="lg:col-span-2">
+          <PeopleSection />
+        </div>
+      )}
       </div>
     </Page>
   );


### PR DESCRIPTION
From user feedback: household management is a few-times-a-year task and does not deserve a navigation section.

- The Users page becomes **PeopleSection** inside Settings (admin only), spanning both settings columns — invites, manual account creation and the member list work exactly as before.
- `/users` now redirects to `/settings` (old bookmarks keep working).
- The People item is removed from the sidebar and the mobile More sheet.

Verified live in the demo: redirect works, the section renders below the settings grid, non-admin sees nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)