### PR TITLE
English-first, stage A: comments, logs and script output

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,5 @@
-# Имя берётся из переменной HUB_HOST — править этот файл руками не нужно.
-# Сертификат выпускает scripts/setup-https.sh, в интернет за ним не ходим.
+# The name comes from the HUB_HOST variable — no need to hand-edit this file.
+# The certificate is issued by scripts/setup-https.sh, no internet involved.
 
 {$HUB_HOST:hub.local} {
 	tls /certs/hub.pem /certs/hub-key.pem
@@ -7,7 +7,7 @@
 	reverse_proxy app:8787
 }
 
-# Тот же сертификат по IP — на случай, когда имя не разрешается
+# The same certificate over the IP — for when the name doesn't resolve
 :443 {
 	tls /certs/hub.pem /certs/hub-key.pem
 	encode zstd gzip

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
-// Линтер настроен узко и по делу: рекомендованный TypeScript-набор плюс
-// react-hooks — нестабильные идентичности хуков уже приводили к тихим
-// циклам запросов, это главные грабли проекта. Стилистику держит сам
-// TypeScript и код-ревью, правил-вкусовщины здесь нет.
+// The linter is scoped narrowly and deliberately: the recommended TypeScript
+// set plus react-hooks — unstable hook identities have already caused silent
+// request loops, the project's main trap. Style is held by TypeScript itself
+// and code review; there are no taste rules here.
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 
@@ -13,18 +13,18 @@ export default tseslint.config(
     plugins: { 'react-hooks': reactHooks },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      // «Загрузить при монтировании и положить в state» — основной способ
-      // получения данных в этом приложении; правило метит каждое такое место.
-      // Реальные грабли (циклы из-за нестабильных зависимостей) ловит
-      // exhaustive-deps — он остаётся ошибкой.
+      // "Load on mount and put into state" is this app's primary way of
+      // fetching data; the rule flags every such place. The real trap
+      // (loops from unstable dependencies) is caught by exhaustive-deps —
+      // which stays an error.
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/exhaustive-deps': 'error',
     },
   },
   {
     rules: {
-      // Пустой catch — осознанный паттерн проекта («нет localStorage — ну и
-      // ладно»), но переменная ошибки без использования — мусор
+      // An empty catch is a deliberate project pattern ("no localStorage —
+      // fine"), but an unused error variable is litter
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrors: 'none' },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web"
   ],
   "scripts": {
-    "dev": "concurrently -n сервер,интерфейс -c blue,magenta \"npm:dev --workspace=server\" \"npm:dev --workspace=web\"",
+    "dev": "concurrently -n server,web -c blue,magenta \"npm:dev --workspace=server\" \"npm:dev --workspace=web\"",
     "build": "npm run build --workspace=web && npm run build --workspace=server",
     "start": "npm run start --workspace=server",
     "typecheck": "npm run typecheck --workspace=server && npm run typecheck --workspace=web",

--- a/scripts/admin-reset.mjs
+++ b/scripts/admin-reset.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 /**
- * Выдача нового пароля администратору.
+ * Issue a new password to the admin.
  *
- * Пароль хранится хешем, и восстановить его нельзя — только заменить.
- * До этого скрипта единственным способом попасть в систему при потерянном
- * пароле было удаление базы, то есть потеря всего.
+ * The password is stored as a hash and can't be recovered — only replaced.
+ * Before this script, the only way into the system with a lost password
+ * was deleting the database, i.e. losing everything.
  *
- * Запуск: npm run admin:reset
- *         npm run admin:reset -- denis@hub.local
- * В Docker: docker compose exec app node scripts/admin-reset.mjs
+ * Usage: npm run admin:reset
+ *        npm run admin:reset -- denis@hub.local
+ * In Docker: docker compose exec app node scripts/admin-reset.mjs
  */
 import Database from 'better-sqlite3';
 import { existsSync } from 'node:fs';
@@ -17,7 +17,7 @@ import { join, resolve } from 'node:path';
 
 const dist = resolve(import.meta.dirname, '..', 'server', 'dist', 'lib', 'password.js');
 if (!existsSync(dist)) {
-  console.error('Сервер не собран. Сначала: npm run build');
+  console.error('The server is not built. First: npm run build');
   process.exit(1);
 }
 const { generatePassword, hashPassword } = await import(dist);
@@ -26,8 +26,8 @@ const dataDir = resolve(process.env.DATA_DIR ?? join(homedir(), '.family-hub'));
 const dbPath = join(dataDir, 'hub.db');
 
 if (!existsSync(dbPath)) {
-  console.error(`Базы нет: ${dbPath}`);
-  console.error('Запустите приложение хотя бы раз — оно создаст базу и напечатает пароль само.');
+  console.error(`No database at: ${dbPath}`);
+  console.error('Run the app at least once — it will create the database and print the password itself.');
   process.exit(1);
 }
 
@@ -42,12 +42,12 @@ const user = wanted
 
 if (!user) {
   const all = db.prepare('SELECT email, role FROM users ORDER BY role, email').all();
-  console.error(wanted ? `Учётки ${wanted} нет.` : 'Администратора в базе нет.');
+  console.error(wanted ? `No account ${wanted}.` : 'No admin in the database.');
   if (all.length > 0) {
-    console.error('Есть такие учётки:');
+    console.error('These accounts exist:');
     for (const u of all) console.error(`  ${u.email} · ${u.role}`);
   } else {
-    console.error('В базе вообще нет пользователей — удалите hub.db и запустите приложение заново.');
+    console.error('The database has no users at all — delete hub.db and start the app again.');
   }
   process.exit(1);
 }
@@ -59,7 +59,7 @@ db.prepare(
   'UPDATE users SET password_hash = ?, must_change_password = 1, disabled_at = NULL WHERE id = ?',
 ).run(hash, user.id);
 
-// Прежние сессии закрываем: если пароль сбрасывают, доверять им нельзя
+// Close previous sessions: if the password is being reset, they can't be trusted
 const closed = db.prepare('DELETE FROM sessions WHERE user_id = ?').run(user.id).changes;
 db.close();
 
@@ -67,15 +67,15 @@ const line = '─'.repeat(64);
 const out = [
   '',
   line,
-  `  Новый пароль для ${user.name} (${user.email})`,
+  `  New password for ${user.name} (${user.email})`,
   '',
-  `    Логин:  ${user.email}`,
-  `    Пароль: ${password}`,
+  `    Login:    ${user.email}`,
+  `    Password: ${password}`,
   '',
-  '  Пароль показан один раз и требует смены при первом входе.',
+  '  The password is shown once and must be changed on first login.',
 ];
 if (closed > 0) {
-  out.push(`  Прежние сессии закрыты: ${closed} — войти придётся заново везде.`);
+  out.push(`  Previous sessions closed: ${closed} — you will have to sign in again everywhere.`);
 }
 out.push(line, '');
 console.log(out.join('\n'));

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Ночной бэкап: снимок базы, экспорт заметок в markdown, шифрование, пуш в git.
-# Ставится в cron на 03:00. Вложения сюда не входят — они идут в Time Machine.
+# Nightly backup: database snapshot, notes export to markdown, encryption, git push.
+# Goes into cron at 03:00. Attachments are not included — Time Machine covers them.
 set -euo pipefail
 
 DATA_DIR="${DATA_DIR:-$HOME/.family-hub}"
@@ -11,21 +11,21 @@ STAMP=$(date +%Y-%m-%d)
 
 mkdir -p "$BACKUP_DIR"
 
-# 1. Консистентный снимок базы (безопасно при работающем приложении)
+# 1. Consistent database snapshot (safe while the app is running)
 sqlite3 "$DATA_DIR/hub.db" ".backup '$BACKUP_DIR/hub-$STAMP.db'"
 
-# 2. Экспорт заметок в markdown — страховка на случай смерти приложения
+# 2. Notes export to markdown — insurance in case the app dies
 NOTES_DIR="$BACKUP_DIR/notes-$STAMP"
 mkdir -p "$NOTES_DIR"
-# Перевод строки в заголовке ломал бы построчное чтение — заменяем пробелом
+# A newline in a title would break line-by-line reading — replace with a space
 sqlite3 "$BACKUP_DIR/hub-$STAMP.db" \
   "SELECT id || '|' || replace(replace(replace(title, '|', '-'), char(10), ' '), char(13), ' ') FROM notes;" |
 while IFS='|' read -r note_id note_title; do
   [ -z "$note_id" ] && continue
   safe_title=$(echo "$note_title" | tr '/' '-')
   target="$NOTES_DIR/$safe_title.md"
-  # Заголовки могут совпадать: без суффикса вторая заметка молча
-  # перетирала бы первую, и из экспорта пропадало бы содержимое
+  # Titles may collide: without a suffix the second note would silently
+  # overwrite the first, and content would vanish from the export
   if [ -e "$target" ]; then
     target="$NOTES_DIR/$safe_title-${note_id:0:8}.md"
   fi
@@ -33,7 +33,7 @@ while IFS='|' read -r note_id note_title; do
     "SELECT body_md FROM notes WHERE id = '$note_id';" > "$target"
 done
 
-# 3. Архив и шифрование
+# 3. Archive and encrypt
 tar -czf "$BACKUP_DIR/hub-$STAMP.tar.gz" -C "$BACKUP_DIR" "hub-$STAMP.db" "notes-$STAMP"
 
 if [ -n "$AGE_RECIPIENT" ]; then
@@ -41,21 +41,21 @@ if [ -n "$AGE_RECIPIENT" ]; then
   ARTIFACT="$BACKUP_DIR/hub-$STAMP.tar.gz.age"
   rm -f "$BACKUP_DIR/hub-$STAMP.tar.gz"
 else
-  echo "AGE_RECIPIENT не задан — бэкап не зашифрован. В приватный репозиторий не отправляю." >&2
+  echo "AGE_RECIPIENT is not set — the backup is unencrypted. Not pushing to the private repository." >&2
   exit 1
 fi
 
-# 4. Пуш в приватный репозиторий
+# 4. Push to the private repository
 if [ -d "$REPO_DIR/.git" ]; then
   cp "$ARTIFACT" "$REPO_DIR/"
   cd "$REPO_DIR"
   git add -A
-  git commit -m "Бэкап $STAMP" --quiet || true
+  git commit -m "Backup $STAMP" --quiet || true
   git push --quiet
 fi
 
-# 5. Локально держим две недели
+# 5. Keep two weeks locally
 find "$BACKUP_DIR" -name 'hub-*.db' -mtime +14 -delete
 find "$BACKUP_DIR" -name 'notes-*' -type d -mtime +14 -exec rm -rf {} + 2>/dev/null || true
 
-echo "Бэкап $STAMP готов."
+echo "Backup $STAMP is ready."

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 /**
- * Выгрузка всех данных в один переносимый архив.
+ * Export all data into one portable archive.
  *
- * Копировать hub.db файловым способом нельзя: база работает в режиме WAL,
- * и свежие записи лежат в соседнем журнале. Поэтому база открывается как
- * база и выгружается через VACUUM INTO — на выходе один согласованный файл,
- * и это безопасно даже при работающем сервере.
+ * hub.db can't be copied as a plain file: the database runs in WAL mode,
+ * and fresh writes live in the sibling journal. So the database is opened
+ * as a database and exported via VACUUM INTO — the output is one consistent
+ * file, and it's safe even while the server is running.
  *
- * Запуск: npm run export
- *         npm run export -- ~/Desktop
+ * Usage: npm run export
+ *        npm run export -- ~/Desktop
  */
 import Database from 'better-sqlite3';
 import { execFileSync } from 'node:child_process';
@@ -22,8 +22,8 @@ const outDir = resolve(process.argv[2] ?? process.cwd());
 const dbPath = join(dataDir, 'hub.db');
 
 if (!existsSync(dbPath)) {
-  console.error(`Базы нет: ${dbPath}`);
-  console.error('Проверьте DATA_DIR или запустите приложение хотя бы раз.');
+  console.error(`No database at: ${dbPath}`);
+  console.error('Check DATA_DIR or run the app at least once.');
   process.exit(1);
 }
 
@@ -54,7 +54,7 @@ function dirSize(dir) {
 try {
   const source = new Database(dbPath, { readonly: true });
 
-  // Согласованный снимок одним файлом, журнал сворачивается внутрь
+  // Consistent snapshot as a single file, the journal is folded in
   source.exec(`VACUUM INTO '${join(staging, 'hub.db').replace(/'/g, "''")}'`);
 
   const manifest = {
@@ -105,15 +105,15 @@ try {
     .map(([table, n]) => `${table}: ${n}`);
 
   console.log('');
-  console.log(`Архив: ${archive}`);
-  console.log(`Размер: ${(size / 1024 / 1024).toFixed(1)} МБ`);
-  console.log(`Вложений: ${manifest.attachments.files} на ${(manifest.attachments.bytes / 1024 / 1024).toFixed(1)} МБ`);
-  console.log(`Содержимое: ${rows.join(', ')}`);
+  console.log(`Archive: ${archive}`);
+  console.log(`Size: ${(size / 1024 / 1024).toFixed(1)} MB`);
+  console.log(`Attachments: ${manifest.attachments.files} totaling ${(manifest.attachments.bytes / 1024 / 1024).toFixed(1)} MB`);
+  console.log(`Contents: ${rows.join(', ')}`);
   console.log('');
-  console.log('Внутри всё, включая приватные заметки и личные счета.');
-  console.log('Передавайте по AirDrop или кабелем, не почтой.');
+  console.log('Everything is inside, including private notes and personal accounts.');
+  console.log('Transfer via AirDrop or a cable, not email.');
   console.log('');
-  console.log('На новом устройстве: npm install && npm run import -- путь/к/архиву');
+  console.log('On the new device: npm install && npm run import -- path/to/archive');
 } finally {
   rmSync(staging, { recursive: true, force: true });
 }

--- a/scripts/import.mjs
+++ b/scripts/import.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /**
- * Загрузка данных из архива на новом устройстве.
+ * Import data from an archive on a new device.
  *
- * Перед подменой проверяет целостность базы и сходится ли содержимое
- * с описью. Существующие данные не трогает без явного разрешения:
- * молча переписать чужую базу — самый дорогой из возможных сюрпризов.
+ * Before swapping anything in, it verifies database integrity and that
+ * the contents match the manifest. Existing data is never touched without
+ * explicit permission: silently overwriting someone's database is the most
+ * expensive surprise there is.
  *
- * Запуск: npm run import -- путь/к/family-hub-2026-08-03.tar.gz
- *         npm run import -- архив.tar.gz --force
+ * Usage: npm run import -- path/to/family-hub-2026-08-03.tar.gz
+ *        npm run import -- archive.tar.gz --force
  */
 import Database from 'better-sqlite3';
 import { execFileSync } from 'node:child_process';
@@ -29,11 +30,11 @@ const force = args.includes('--force');
 const archive = args.find((a) => !a.startsWith('--'));
 
 if (!archive) {
-  console.error('Укажите архив: npm run import -- путь/к/family-hub-ГГГГ-ММ-ДД.tar.gz');
+  console.error('Provide an archive: npm run import -- path/to/family-hub-YYYY-MM-DD.tar.gz');
   process.exit(1);
 }
 if (!existsSync(archive)) {
-  console.error(`Архива нет: ${resolve(archive)}`);
+  console.error(`No archive at: ${resolve(archive)}`);
   process.exit(1);
 }
 
@@ -46,7 +47,7 @@ try {
 
   const incomingDb = join(staging, 'hub.db');
   if (!existsSync(incomingDb)) {
-    console.error('В архиве нет hub.db — это не выгрузка Дома.');
+    console.error('No hub.db in the archive — this is not a hub export.');
     process.exit(1);
   }
 
@@ -54,11 +55,11 @@ try {
     ? JSON.parse(readFileSync(join(staging, 'manifest.json'), 'utf8'))
     : null;
 
-  // Проверяем до подмены: битую базу лучше не ставить вовсе
+  // Verify before swapping in: better not to install a broken database at all
   const incoming = new Database(incomingDb, { readonly: true });
   const integrity = incoming.pragma('integrity_check', { simple: true });
   if (integrity !== 'ok') {
-    console.error(`База в архиве повреждена: ${integrity}`);
+    console.error(`The database in the archive is corrupted: ${integrity}`);
     process.exit(1);
   }
 
@@ -68,9 +69,9 @@ try {
       if (expected === null) continue;
       try {
         const actual = incoming.prepare(`SELECT count(*) AS n FROM ${table}`).get().n;
-        if (actual !== expected) mismatches.push(`${table}: в описи ${expected}, в базе ${actual}`);
+        if (actual !== expected) mismatches.push(`${table}: manifest says ${expected}, database has ${actual}`);
       } catch {
-        mismatches.push(`${table}: таблицы нет`);
+        mismatches.push(`${table}: table missing`);
       }
     }
   }
@@ -81,20 +82,20 @@ try {
   incoming.close();
 
   if (mismatches.length > 0) {
-    console.error('Содержимое не сходится с описью:');
+    console.error('Contents do not match the manifest:');
     for (const line of mismatches) console.error(`  ${line}`);
     process.exit(1);
   }
 
-  // Существующие данные
+  // Existing data
   const occupied = existsSync(existingDb);
   if (occupied && !force) {
     console.error('');
-    console.error(`В ${dataDir} уже есть база.`);
-    console.error('Загрузка перезапишет её. Если это то, что нужно, добавьте --force:');
+    console.error(`There is already a database in ${dataDir}.`);
+    console.error('Importing will overwrite it. If that is what you want, add --force:');
     console.error(`  npm run import -- ${archive} --force`);
     console.error('');
-    console.error('Прежняя база будет отложена в сторону, а не удалена.');
+    console.error('The previous database will be set aside, not deleted.');
     process.exit(1);
   }
 
@@ -106,7 +107,7 @@ try {
     for (const suffix of ['-wal', '-shm']) {
       if (existsSync(existingDb + suffix)) rmSync(existingDb + suffix);
     }
-    console.log(`Прежняя база отложена: ${backup}`);
+    console.log(`Previous database set aside: ${backup}`);
   }
 
   cpSync(incomingDb, existingDb);
@@ -117,7 +118,7 @@ try {
   }
   mkdirSync(join(dataDir, 'backups'), { recursive: true });
 
-  // Считаем именно файлы: recursive перечисляет и подкаталоги по месяцам
+  // Count files specifically: recursive also lists the per-month subdirectories
   const attachmentsDir = join(dataDir, 'attachments');
   const files = existsSync(attachmentsDir)
     ? readdirSync(attachmentsDir, { recursive: true, withFileTypes: true }).filter((e) =>
@@ -126,21 +127,21 @@ try {
     : 0;
 
   console.log('');
-  console.log(`Данные загружены в ${dataDir}`);
-  console.log(`Миграций в базе: ${applied.length}, последняя ${applied.at(-1) ?? '—'}`);
+  console.log(`Data imported into ${dataDir}`);
+  console.log(`Migrations in the database: ${applied.length}, latest ${applied.at(-1) ?? '—'}`);
   if (manifest) {
     const rows = Object.entries(manifest.counts)
       .filter(([, n]) => n)
       .map(([table, n]) => `${table}: ${n}`);
-    console.log(`Содержимое: ${rows.join(', ')}`);
-    console.log(`Выгружено: ${manifest.exported_at}`);
+    console.log(`Contents: ${rows.join(', ')}`);
+    console.log(`Exported: ${manifest.exported_at}`);
   }
-  console.log(`Файлов вложений на диске: ${files}`);
+  console.log(`Attachment files on disk: ${files}`);
   console.log('');
-  console.log('Дальше:');
-  console.log('  1. npm run dev  — или docker compose up -d --build');
-  console.log('  2. Пароли и учётки перенеслись, первичная настройка не нужна');
-  console.log('  3. Если был HTTPS: ./scripts/setup-https.sh — сертификат нужен свой');
+  console.log('Next:');
+  console.log('  1. npm run dev  — or docker compose up -d --build');
+  console.log('  2. Passwords and accounts came along, no initial setup needed');
+  console.log('  3. If HTTPS was set up: ./scripts/setup-https.sh — this device needs its own certificate');
   console.log('  4. sudo pmset repeat wakeorpoweron MTWRFSU 06:30:00');
 } finally {
   rmSync(staging, { recursive: true, force: true });

--- a/scripts/setup-https.sh
+++ b/scripts/setup-https.sh
@@ -1,78 +1,78 @@
 #!/usr/bin/env bash
 #
-# Выпуск локального сертификата и настройка имени хаба в сети.
-# Запускать на маке-сервере. Нужен mkcert: brew install mkcert
+# Issue a local certificate and set up the hub's name on the network.
+# Run on the Mac server. Requires mkcert: brew install mkcert
 #
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 if ! command -v mkcert >/dev/null; then
-  echo "mkcert не установлен. Выполните: brew install mkcert" >&2
+  echo "mkcert is not installed. Run: brew install mkcert" >&2
   exit 1
 fi
 
-# Желаемое имя: из .env, из аргумента или hub.local по умолчанию
+# Desired name: from .env, from the argument, or hub.local by default
 HUB_HOST="${1:-$(grep -E '^HUB_HOST=' .env 2>/dev/null | cut -d= -f2 || true)}"
 HUB_HOST="${HUB_HOST:-hub.local}"
 
 LOCAL_NAME="$(scutil --get LocalHostName 2>/dev/null || echo "")"
 LAN_IP="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "")"
 
-echo "Имя хаба:        $HUB_HOST"
-echo "Имя мака в сети: ${LOCAL_NAME:-не определено}.local"
-echo "IP в сети:       ${LAN_IP:-не определён}"
+echo "Hub name:            $HUB_HOST"
+echo "Mac's network name:  ${LOCAL_NAME:-unknown}.local"
+echo "LAN IP:              ${LAN_IP:-unknown}"
 echo
 
-# ── Разрешимость имени ────────────────────────────────────────────────────
+# ── Name resolution ───────────────────────────────────────────────────────
 #
-# Домен .local обслуживает Bonjour, и он отвечает только на собственное имя
-# машины. Произвольное имя вроде hub.local не разрешится само ни на маке,
-# ни на iPad. Правка /etc/hosts помогает только тому маку, где она сделана —
-# для iPad и телефонов она бесполезна.
+# The .local domain is served by Bonjour, and it only answers to the
+# machine's own name. An arbitrary name like hub.local won't resolve by
+# itself on the Mac or on an iPad. Editing /etc/hosts helps only the Mac
+# where it was edited — it's useless for iPads and phones.
 #
-# Поэтому имя хаба должно совпадать с именем мака в сети.
+# So the hub's name must match the Mac's network name.
 #
 SHORT_NAME="${HUB_HOST%.local}"
 
 if [[ "$HUB_HOST" == *.local && "$SHORT_NAME" != "$LOCAL_NAME" ]]; then
-  echo "⚠️  $HUB_HOST не будет разрешаться с других устройств."
+  echo "⚠️  $HUB_HOST will not resolve from other devices."
   echo
-  echo "    Bonjour отвечает только на собственное имя мака: ${LOCAL_NAME}.local"
-  echo "    Есть два выхода."
+  echo "    Bonjour only answers to the Mac's own name: ${LOCAL_NAME}.local"
+  echo "    There are two ways out."
   echo
-  echo "    1. Переименовать мак — тогда $HUB_HOST заработает на всех устройствах"
-  echo "       сразу, без настройки каждого:"
+  echo "    1. Rename the Mac — then $HUB_HOST works on all devices"
+  echo "       at once, with no per-device setup:"
   echo
   echo "         sudo scutil --set LocalHostName $SHORT_NAME"
   echo
-  echo "    2. Использовать имя, которое у мака уже есть. Впишите в .env:"
+  echo "    2. Use the name the Mac already has. Put in .env:"
   echo
   echo "         HUB_HOST=${LOCAL_NAME}.local"
   echo
-  read -r -p "    Переименовать мак в '$SHORT_NAME' сейчас? [y/N] " answer
+  read -r -p "    Rename the Mac to '$SHORT_NAME' now? [y/N] " answer
   if [[ "${answer:-n}" =~ ^[Yy]$ ]]; then
     sudo scutil --set LocalHostName "$SHORT_NAME"
     LOCAL_NAME="$SHORT_NAME"
-    echo "    Готово: мак теперь отзывается на $HUB_HOST"
+    echo "    Done: the Mac now answers to $HUB_HOST"
   else
-    echo "    Оставляю как есть. Сертификат всё равно выпущу — но помните про имя."
+    echo "    Leaving it as is. The certificate will be issued anyway — but keep the name in mind."
   fi
   echo
 fi
 
-# ── Сертификат ────────────────────────────────────────────────────────────
+# ── Certificate ───────────────────────────────────────────────────────────
 mkdir -p certs
 mkcert -install
 
-# Имена в сертификате: имя хаба, имя мака, localhost и IP.
-# Лишние не мешают, а вот отсутствие нужного заставит браузер ругаться.
+# Names in the certificate: hub name, Mac name, localhost and the IP.
+# Extra names don't hurt; a missing one makes the browser complain.
 NAMES=("$HUB_HOST" "localhost" "127.0.0.1")
 [[ -n "$LOCAL_NAME" && "$LOCAL_NAME.local" != "$HUB_HOST" ]] && NAMES+=("$LOCAL_NAME.local")
 [[ -n "$LAN_IP" ]] && NAMES+=("$LAN_IP")
 
 mkcert -cert-file certs/hub.pem -key-file certs/hub-key.pem "${NAMES[@]}"
 
-# Имя для Caddy храним в .env, чтобы конфиг не пришлось править руками
+# Keep the name for Caddy in .env so the config never needs hand-editing
 if [[ -f .env ]]; then
   if grep -qE '^HUB_HOST=' .env; then
     sed -i '' -E "s|^HUB_HOST=.*|HUB_HOST=$HUB_HOST|" .env
@@ -85,25 +85,25 @@ fi
 
 cat <<TXT
 
-Сертификат выпущен на: ${NAMES[*]}
+Certificate issued for: ${NAMES[*]}
 
-Дальше:
+Next:
 
-  1. Поднять Caddy:
+  1. Start Caddy:
        docker compose --profile https up -d
 
-  2. Включить защищённые куки — в .env:
+  2. Enable secure cookies — in .env:
        SECURE_COOKIES=true
-     и перезапустить: docker compose up -d
+     then restart: docker compose up -d
 
-  3. По одному разу на каждое устройство — доверие корневому сертификату:
+  3. Once per device — trust the root certificate:
        $(mkcert -CAROOT)/rootCA.pem
-     Перекинуть на iPad и айфоны через AirDrop, затем
-       Настройки → Профиль загружен → Установить
-       Настройки → Основные → Об этом устройстве → Доверие сертификатам →
-       включить полное доверие для mkcert
+     Send it to iPads and iPhones via AirDrop, then
+       Settings → Profile Downloaded → Install
+       Settings → General → About → Certificate Trust Settings →
+       enable full trust for mkcert
 
-После этого https://$HUB_HOST открывается без предупреждений — порт указывать
-не нужно, 443 подразумевается. Заработают офлайн-режим и иконка на домашнем
-экране: и то и другое требует защищённого соединения.
+After that https://$HUB_HOST opens without warnings — no port needed,
+443 is implied. Offline mode and the home screen icon start working:
+both require a secure connection.
 TXT

--- a/server/scripts/copy-assets.mjs
+++ b/server/scripts/copy-assets.mjs
@@ -1,6 +1,6 @@
 import { cpSync } from 'node:fs';
 
-// tsc переносит только .ts — миграции копируем руками,
-// иначе собранный сервер не найдёт схему.
+// tsc only carries over .ts — migrations are copied by hand,
+// otherwise the built server won't find the schema.
 cpSync('src/db/migrations', 'dist/db/migrations', { recursive: true });
-console.log('[build] миграции скопированы в dist');
+console.log('[build] migrations copied to dist');

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -6,16 +6,16 @@ import { env, legacyDataDir, paths } from '../env.js';
 import { log } from '../lib/log.js';
 
 /**
- * Однократный перенос данных из старого ./data в новое место.
+ * One-time move of data from the old ./data to the new place.
  *
- * Простым копированием файлов это делать нельзя: база работает в режиме WAL,
- * и последние записи лежат не в hub.db, а в соседнем hub.db-wal. Скопировав
- * один hub.db, получишь базу без свежих изменений — и без пароля, который
- * человек только что задал.
+ * Plain file copying won't do: the database runs in WAL mode, and the
+ * latest writes live not in hub.db but in the adjacent hub.db-wal. Copy
+ * hub.db alone and you get a database without the fresh changes — and
+ * without the password the person just set.
  *
- * Поэтому открываем базу как базу и выгружаем цельным файлом: SQLite при
- * открытии учитывает журнал, и на выходе получается согласованная копия.
- * Исходное не удаляем — если что-то пойдёт не так, оно останется на месте.
+ * So we open the database as a database and export it as a whole file:
+ * SQLite honors the journal on open, and the output is a consistent copy.
+ * The original is not deleted — if anything goes wrong, it stays put.
  */
 function adoptLegacyData(): void {
   if (existsSync(paths.db)) return;
@@ -40,9 +40,9 @@ function adoptLegacyData(): void {
 
   log.block([
     '',
-    `  Данные перенесены из ${legacyDataDir}`,
-    `  в ${env.dataDir} — теперь они не зависят от обновлений кода.`,
-    '  Старая копия оставлена на месте, её можно удалить.',
+    `  Data moved from ${legacyDataDir}`,
+    `  to ${env.dataDir} — it no longer depends on code updates.`,
+    '  The old copy is left in place; it is safe to delete.',
     '',
   ]);
 }
@@ -54,24 +54,24 @@ mkdirSync(paths.attachments, { recursive: true });
 mkdirSync(paths.backups, { recursive: true });
 
 /**
- * Открытие базы вынесено в функцию, потому что баз может быть больше одной:
- * демо-режим держит по песочнице на посетителя, и каждая должна получить
- * те же pragma и те же зарегистрированные функции, что и основная, —
- * иначе запросы с ci_contains будут падать только в песочницах.
+ * Opening the database is a function because there can be more than one:
+ * demo mode keeps a sandbox per visitor, and each must get the same
+ * pragmas and the same registered functions as the main one — otherwise
+ * queries using ci_contains would fail only inside sandboxes.
  */
 export function openDatabase(file: string): Database.Database {
   const d = new Database(file);
 
-  // WAL — параллельное чтение во время записи, важно для стенда,
-  // который опрашивает дашборд, пока кто-то редактирует заметку.
+  // WAL — concurrent reads during writes, matters for the wall display
+  // polling the dashboard while someone is editing a note.
   d.pragma('journal_mode = WAL');
   d.pragma('foreign_keys = ON');
   d.pragma('synchronous = NORMAL');
   d.pragma('busy_timeout = 5000');
 
-  // Встроенные lower() и LIKE в SQLite регистронезависимы только для латиницы:
-  // «Справка» по запросу «справ» не находится. Регистрируем свою функцию,
-  // которая приводит регистр средствами JavaScript и потому знает все алфавиты.
+  // SQLite's built-in lower() and LIKE are case-insensitive only for Latin:
+  // «Справка» is not found by the query «справ». We register our own function
+  // that folds case in JavaScript and therefore knows every alphabet.
   d.function('ci_contains', (haystack: unknown, needle: unknown) => {
     if (typeof haystack !== 'string' || typeof needle !== 'string') return 0;
     return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase()) ? 1 : 0;
@@ -83,17 +83,19 @@ export function openDatabase(file: string): Database.Database {
 const mainDb = openDatabase(paths.db);
 
 /*
-  Какая база обслуживает текущий запрос.
+  Which database serves the current request.
 
-  В обычном режиме база одна, и контекст всегда пуст — работает mainDb.
-  В демо-режиме каждый посетитель живёт в своей песочнице: хук в index.ts
-  кладёт её базу в AsyncLocalStorage на время запроса, и весь код ниже —
-  роуты, auth, миграции, сидинг — прозрачно работает с ней через
-  экспортируемый Proxy. Ни один роут о песочницах не знает.
+  In normal mode there is one database and the context is always empty —
+  mainDb does the work. In demo mode every visitor lives in their own
+  sandbox: the hook in index.ts puts its database into AsyncLocalStorage
+  for the duration of the request, and all code below — routes, auth,
+  migrations, seeding — transparently works with it through the exported
+  Proxy. No route knows about sandboxes.
 
-  Это осознанный прототип будущего hosted-режима «база на семью»:
-  слой уже умеет направлять запрос в свою базу, останется заменить
-  источник соответствия (кука песочницы → постоянная семья).
+  This is a deliberate prototype of the future hosted "database per
+  family" mode: the layer can already route a request to its database,
+  only the mapping source needs replacing (sandbox cookie → permanent
+  family).
 */
 const dbContext = new AsyncLocalStorage<Database.Database>();
 
@@ -101,15 +103,15 @@ export function currentDb(): Database.Database {
   return dbContext.getStore() ?? mainDb;
 }
 
-/** Выполнить fn (в т.ч. async) так, чтобы весь код внутри видел базу d. */
+/** Run fn (async included) so that all code inside sees database d. */
 export function runWithDb<T>(d: Database.Database, fn: () => T): T {
   return dbContext.run(d, fn);
 }
 
 /*
-  Тот же интерфейс better-sqlite3, но методы всегда уходят в базу текущего
-  запроса. Statements нигде в проекте не кэшируются на уровне модулей
-  (проверено), поэтому позднего связывания на уровне вызова достаточно.
+  The same better-sqlite3 interface, but methods always go to the current
+  request's database. Statements are not cached at module level anywhere
+  in the project (verified), so late binding at call time is enough.
 */
 export const db: Database.Database = new Proxy({} as Database.Database, {
   get(_target, prop) {
@@ -128,12 +130,12 @@ export function now(): string {
 }
 
 /**
- * Дата «сегодня» по местным часам процесса (TZ), а не по UTC.
+ * Today's date by the process's local clock (TZ), not UTC.
  *
- * toISOString() даёт дату по Гринвичу: между полуночью и +01/+02 она ещё
- * вчерашняя, и дашборд с регулярными операциями жили бы во «вчера».
- * Фронт (web/src/lib/tasks.ts) считает «сегодня» так же — по местным часам,
- * сервер обязан быть с ним согласован.
+ * toISOString() gives the Greenwich date: between midnight and +01/+02 it
+ * is still yesterday's, and the dashboard and recurring transactions would
+ * live in "yesterday". The frontend (web/src/lib/tasks.ts) computes
+ * "today" the same way — by the local clock; the server must agree.
  */
 export function today(): string {
   const d = new Date();

--- a/server/src/db/migrate.test.ts
+++ b/server/src/db/migrate.test.ts
@@ -6,15 +6,15 @@ import { openDatabase, runWithDb } from './index.js';
 import { migrate } from './migrate.js';
 
 /*
-  Смоук всей схемы: каждая миграция обязана применяться на пустой базе
-  с включёнными foreign_keys. Раньше это проверялось руками перед каждым
-  изменением схемы — теперь прогон входит в CI.
+  A smoke test of the whole schema: every migration must apply on an empty
+  database with foreign_keys enabled. This used to be checked by hand
+  before every schema change — now the run is part of CI.
 */
 
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
 
-describe('миграции', () => {
-  it('все применяются на пустой базе и ровно один раз', () => {
+describe('migrations', () => {
+  it('all apply on an empty database and exactly once', () => {
     const db = openDatabase(':memory:');
     runWithDb(db, () => migrate());
 
@@ -25,14 +25,14 @@ describe('миграции', () => {
 
     expect(applied.map((r) => r.name)).toEqual(files);
 
-    // Повторный прогон — идемпотентен: ничего не применяется заново и не падает
+    // A repeat run is idempotent: nothing re-applies and nothing crashes
     runWithDb(db, () => migrate());
     const again = db.prepare('SELECT count(*) AS n FROM _migrations').get() as { n: number };
     expect(again.n).toBe(files.length);
     db.close();
   });
 
-  it('создаёт ключевые таблицы и служебные строки', () => {
+  it('creates the key tables and the seeded rows', () => {
     const db = openDatabase(':memory:');
     runWithDb(db, () => migrate());
 
@@ -48,18 +48,18 @@ describe('миграции', () => {
       'accounts', 'categories', 'transactions', 'budgets', 'recurring_transactions',
       'settings',
     ]) {
-      expect(tables, `нет таблицы ${table}`).toContain(table);
+      expect(tables, `missing table ${table}`).toContain(table);
     }
 
-    // Засеянные сущности с фиксированными id — на них завязан клиент
+    // Seeded entities with fixed ids — the client depends on them
     const inbox = db
       .prepare('SELECT id FROM projects WHERE id = ?')
       .get('00000000-0000-4000-8000-000000000001');
-    expect(inbox, 'нет проекта «Входящие»').toBeTruthy();
+    expect(inbox, 'missing the Inbox project').toBeTruthy();
     const shared = db
       .prepare('SELECT id FROM calendars WHERE id = ?')
       .get('00000000-0000-4000-8000-000000000201');
-    expect(shared, 'нет общего календаря').toBeTruthy();
+    expect(shared, 'missing the shared calendar').toBeTruthy();
     db.close();
   });
 });

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -7,9 +7,9 @@ import { log } from '../lib/log.js';
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
 
 /**
- * Миграции — обычные .sql файлы, применяются по порядку имени, один раз.
- * Схема живёт в SQL и только в SQL: никакого второго источника правды,
- * который может разъехаться с базой.
+ * Migrations are plain .sql files, applied in name order, once.
+ * The schema lives in SQL and only in SQL: no second source of truth
+ * that could drift away from the database.
  */
 export function migrate(): void {
   db.exec(`
@@ -35,7 +35,7 @@ export function migrate(): void {
       db.prepare('INSERT INTO _migrations (name) VALUES (?)').run(file);
     });
     run();
-    // Миграции печатаются всегда: это единственный след того, что база изменилась
-    log.notice(`миграция применена: ${file}`);
+    // Migrations are always printed: the only trace that the database changed
+    log.notice(`migration applied: ${file}`);
   }
 }

--- a/server/src/db/migrations/001_init.sql
+++ b/server/src/db/migrations/001_init.sql
@@ -1,5 +1,5 @@
--- Family Hub — начальная схема
--- Все временные метки хранятся как ISO-8601 UTC (TEXT), даты — как YYYY-MM-DD.
+-- Family Hub — initial schema
+-- All timestamps are stored as ISO-8601 UTC (TEXT), dates as YYYY-MM-DD.
 
 CREATE TABLE users (
   id            TEXT PRIMARY KEY,
@@ -22,7 +22,7 @@ CREATE TABLE sessions (
 CREATE INDEX idx_sessions_user ON sessions(user_id);
 CREATE INDEX idx_sessions_expires ON sessions(expires_at);
 
--- ── Задачи ──────────────────────────────────────────────────────────────
+-- ── Tasks ───────────────────────────────────────────────────────────────
 
 CREATE TABLE projects (
   id          TEXT PRIMARY KEY,
@@ -41,7 +41,7 @@ CREATE TABLE tasks (
   id          TEXT PRIMARY KEY,
   project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
   parent_id   TEXT REFERENCES tasks(id) ON DELETE CASCADE,
-  -- 0 = стори, 1 = таск, 2 = сабтаск. Глубже нельзя.
+  -- 0 = story, 1 = task, 2 = subtask. No deeper nesting.
   level       INTEGER NOT NULL DEFAULT 0 CHECK (level BETWEEN 0 AND 2),
   title       TEXT NOT NULL,
   description TEXT,
@@ -52,7 +52,7 @@ CREATE TABLE tasks (
   due_date    TEXT,
   assignee_id TEXT REFERENCES users(id) ON DELETE SET NULL,
   position    REAL NOT NULL DEFAULT 0,
-  -- Подмножество RRULE, например FREQ=WEEKLY;INTERVAL=2
+  -- RRULE subset, e.g. FREQ=WEEKLY;INTERVAL=2
   recurrence_rule       TEXT,
   recurrence_parent_id  TEXT REFERENCES tasks(id) ON DELETE SET NULL,
   completed_at TEXT,
@@ -66,7 +66,7 @@ CREATE INDEX idx_tasks_due ON tasks(due_date) WHERE due_date IS NOT NULL;
 CREATE INDEX idx_tasks_status ON tasks(status);
 CREATE INDEX idx_tasks_assignee ON tasks(assignee_id);
 
--- ── Заметки ─────────────────────────────────────────────────────────────
+-- ── Notes ───────────────────────────────────────────────────────────────
 
 CREATE TABLE folders (
   id         TEXT PRIMARY KEY,
@@ -85,7 +85,7 @@ CREATE TABLE notes (
   visibility  TEXT NOT NULL DEFAULT 'shared' CHECK (visibility IN ('shared','private')),
   owner_id    TEXT REFERENCES users(id) ON DELETE SET NULL,
   is_template INTEGER NOT NULL DEFAULT 0,
-  -- daily note: одна на дату
+  -- daily note: one per date
   daily_date  TEXT UNIQUE,
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
@@ -103,8 +103,8 @@ CREATE TABLE note_versions (
 );
 CREATE INDEX idx_note_versions_note ON note_versions(note_id, created_at DESC);
 
--- Связи [[wiki-links]]. Ссылка может указывать на ещё не созданную заметку,
--- поэтому храним и текст цели тоже.
+-- [[wiki-links]]. A link may point to a note that doesn't exist yet,
+-- so we store the target title as text too.
 CREATE TABLE note_links (
   source_note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
   target_note_id TEXT REFERENCES notes(id) ON DELETE CASCADE,
@@ -134,7 +134,7 @@ CREATE TABLE attachments (
 CREATE INDEX idx_attachments_note ON attachments(note_id);
 CREATE INDEX idx_attachments_task ON attachments(task_id);
 
--- ── Календарь ───────────────────────────────────────────────────────────
+-- ── Calendar ────────────────────────────────────────────────────────────
 
 CREATE TABLE calendars (
   id       TEXT PRIMARY KEY,
@@ -162,7 +162,7 @@ CREATE TABLE events (
 CREATE INDEX idx_events_range ON events(starts_at, ends_at);
 CREATE INDEX idx_events_calendar ON events(calendar_id);
 
--- ── Системное ───────────────────────────────────────────────────────────
+-- ── System ──────────────────────────────────────────────────────────────
 
 CREATE TABLE settings (
   key        TEXT PRIMARY KEY,
@@ -180,8 +180,8 @@ CREATE TABLE audit_log (
 );
 CREATE INDEX idx_audit_created ON audit_log(created_at DESC);
 
--- Значения по умолчанию для виджетов дашборда. Нейтральные: свои
--- название события и подписи каждая семья задаёт в настройках.
+-- Dashboard widget defaults. Neutral on purpose: each family sets
+-- its own event name and labels in settings.
 INSERT INTO settings (key, value) VALUES
   ('savings.amount_eur', '0'),
   ('savings.goal_eur', '0'),

--- a/server/src/db/migrations/002_search.sql
+++ b/server/src/db/migrations/002_search.sql
@@ -1,8 +1,8 @@
--- Полнотекстовый поиск.
--- Токенизатор trigram выбран сознательно: он ищет по подстроке и поэтому
--- корректно работает с русской морфологией без стеммера —
--- запрос «переезд» находит «переезда», «переезду», «переездом».
--- Требование: минимум 3 символа в запросе.
+-- Full-text search.
+-- The trigram tokenizer is a deliberate choice: it matches substrings and
+-- therefore handles Russian morphology without a stemmer —
+-- a query for «переезд» finds «переезда», «переезду», «переездом».
+-- Requirement: at least 3 characters per query.
 
 CREATE VIRTUAL TABLE search_index USING fts5(
   entity        UNINDEXED,   -- 'note' | 'task' | 'project'
@@ -14,7 +14,7 @@ CREATE VIRTUAL TABLE search_index USING fts5(
   tokenize = 'trigram'
 );
 
--- Заметки
+-- Notes
 
 CREATE TRIGGER notes_ai AFTER INSERT ON notes BEGIN
   INSERT INTO search_index (entity, entity_id, visibility, owner_id, title, body)
@@ -31,7 +31,7 @@ CREATE TRIGGER notes_au AFTER UPDATE ON notes BEGIN
   VALUES ('note', new.id, new.visibility, coalesce(new.owner_id, ''), new.title, new.body_md);
 END;
 
--- Задачи
+-- Tasks
 
 CREATE TRIGGER tasks_ai AFTER INSERT ON tasks BEGIN
   INSERT INTO search_index (entity, entity_id, visibility, owner_id, title, body)
@@ -48,7 +48,7 @@ CREATE TRIGGER tasks_au AFTER UPDATE ON tasks BEGIN
   VALUES ('task', new.id, 'shared', '', new.title, coalesce(new.description, ''));
 END;
 
--- Проекты
+-- Projects
 
 CREATE TRIGGER projects_ai AFTER INSERT ON projects BEGIN
   INSERT INTO search_index (entity, entity_id, visibility, owner_id, title, body)

--- a/server/src/db/migrations/003_auth.sql
+++ b/server/src/db/migrations/003_auth.sql
@@ -1,12 +1,12 @@
--- Вход и сессии.
+-- Login and sessions.
 
--- Сгенерированный при первом запуске пароль администратора попадает в лог
--- контейнера, поэтому его нужно сменить при первом входе.
+-- The admin password generated on first launch ends up in the container
+-- log, so it must be changed on first login.
 ALTER TABLE users ADD COLUMN must_change_password INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE users ADD COLUMN password_changed_at TEXT;
 ALTER TABLE users ADD COLUMN last_login_at TEXT;
 
--- В таблице хранится sha256 от токена, а не сам токен.
--- Прочитавший базу не сможет выдать себя за другого пользователя.
+-- The table stores a sha256 of the token, not the token itself.
+-- Whoever reads the database can't impersonate another user.
 ALTER TABLE sessions ADD COLUMN token_hash TEXT;
 CREATE INDEX idx_sessions_token ON sessions(token_hash);

--- a/server/src/db/migrations/004_tasks.sql
+++ b/server/src/db/migrations/004_tasks.sql
@@ -1,5 +1,5 @@
--- Проект по умолчанию: у быстрого добавления всегда должно быть куда положить
--- задачу, даже когда ни одного проекта ещё не завели.
+-- Default project: quick-add must always have somewhere to put a task,
+-- even when no projects have been created yet.
 INSERT INTO projects (id, title, description, color, icon, position)
 VALUES (
   '00000000-0000-4000-8000-000000000001',

--- a/server/src/db/migrations/005_notes.sql
+++ b/server/src/db/migrations/005_notes.sql
@@ -1,16 +1,16 @@
--- Заметки: доработки к исходной схеме.
+-- Notes: refinements to the initial schema.
 
--- Заметка может быть шаблоном; поле template_id из первой версии схемы
--- не пригодилось — шаблон применяется при создании, а не привязывается навсегда.
+-- A note can be a template; the template_id field from the first schema
+-- version proved useless — a template is applied at creation, not bound forever.
 ALTER TABLE notes ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
 
 CREATE INDEX idx_notes_owner ON notes(owner_id);
 CREATE INDEX idx_notes_visibility ON notes(visibility);
 CREATE INDEX idx_notes_template ON notes(is_template) WHERE is_template = 1;
 
--- Пара шаблонов на старте, чтобы механика была видна сразу.
--- На английском: язык данных свежего инсталла. Заметка дня ищет свой
--- шаблон по названию 'Day' (и 'День' — для баз, живших до перевода).
+-- A couple of starter templates so the mechanic is visible right away.
+-- In English: the data language of a fresh install. The daily note looks up
+-- its template by title 'Day' (and 'День' — for databases predating the translation).
 INSERT INTO notes (id, title, body_md, visibility, is_template) VALUES
   (
     '00000000-0000-4000-8000-000000000101',

--- a/server/src/db/migrations/006_calendar.sql
+++ b/server/src/db/migrations/006_calendar.sql
@@ -1,9 +1,9 @@
--- Календарь: доработки к исходной схеме.
+-- Calendar: refinements to the initial schema.
 
 ALTER TABLE events ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE SET NULL;
--- За сколько дней поднимать событие в сводку. NULL — не предупреждать.
+-- How many days ahead to surface the event in the digest. NULL — no warning.
 ALTER TABLE events ADD COLUMN remind_days_before INTEGER;
--- Для дней рождения: позволяет показать возраст.
+-- For birthdays: allows showing the age.
 ALTER TABLE events ADD COLUMN birth_year INTEGER;
 
 CREATE TABLE event_participants (
@@ -12,8 +12,8 @@ CREATE TABLE event_participants (
   PRIMARY KEY (event_id, user_id)
 );
 
--- Отменённые экземпляры повторяющейся серии: «в эту пятницу тренировки нет».
--- Сама серия при этом остаётся.
+-- Cancelled instances of a recurring series: "no practice this Friday".
+-- The series itself stays.
 CREATE TABLE event_exceptions (
   event_id      TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
   excluded_date TEXT NOT NULL,
@@ -22,6 +22,6 @@ CREATE TABLE event_exceptions (
 
 CREATE INDEX idx_events_project ON events(project_id);
 
--- Календарь по умолчанию: событию всегда есть куда лечь
+-- Default calendar: an event always has somewhere to land
 INSERT INTO calendars (id, name, color, owner_id, shared, position) VALUES
   ('00000000-0000-4000-8000-000000000201', 'Общий', '#1F6E8C', NULL, 1, 0);

--- a/server/src/db/migrations/007_money.sql
+++ b/server/src/db/migrations/007_money.sql
@@ -1,13 +1,13 @@
--- Деньги: счета, категории, операции.
+-- Money: accounts, categories, transactions.
 
 /*
-  Суммы хранятся в минорных единицах целым числом: 1234.56 → 123456.
-  Числа с плавающей точкой для денег дают ошибки округления, которые
-  копятся в суммах и в итоге расходятся с банком на копейки, а потом
-  на рубли. Обратно в рубли и евро переводим только при отображении.
+  Amounts are stored as integers in minor units: 1234.56 → 123456.
+  Floating point for money produces rounding errors that accumulate
+  across sums and eventually drift from the bank by cents, then by
+  whole units. Conversion back to major units happens only on display.
 
-  Валюта живёт на счёте. Валюты между собой не связаны: курса нет,
-  общего итога нет, суммируем строго внутри одной валюты.
+  Currency lives on the account. Currencies are unrelated: no exchange
+  rate, no grand total, sums are computed strictly within one currency.
 */
 
 CREATE TABLE accounts (
@@ -17,7 +17,7 @@ CREATE TABLE accounts (
   kind            TEXT NOT NULL DEFAULT 'card'
                   CHECK (kind IN ('cash', 'card', 'savings')),
   opening_balance INTEGER NOT NULL DEFAULT 0,
-  -- owner_id пусто + shared=1 → общий счёт; owner_id задан + shared=0 → личный
+  -- owner_id empty + shared=1 → shared account; owner_id set + shared=0 → personal
   owner_id        TEXT REFERENCES users(id) ON DELETE SET NULL,
   shared          INTEGER NOT NULL DEFAULT 1,
   color           TEXT NOT NULL DEFAULT '#1F6E8C',
@@ -41,14 +41,15 @@ CREATE TABLE categories (
 CREATE INDEX idx_categories_kind ON categories(kind);
 
 /*
-  Одна таблица на траты, доходы и переводы.
+  One table for expenses, income and transfers.
 
-  expense:  account_id, amount            → остаток account_id уменьшается
-  income:   account_id, amount            → остаток account_id увеличивается
+  expense:  account_id, amount            → account_id balance decreases
+  income:   account_id, amount            → account_id balance increases
   transfer: account_id, amount + to_account_id, to_amount
 
-  У перевода две суммы, а не одна: счета могут быть в разных валютах,
-  и курса у нас нет. Сколько ушло и сколько пришло — вводится руками.
+  A transfer has two amounts, not one: the accounts may be in different
+  currencies, and we have no exchange rate. What left and what arrived
+  is entered by hand.
 */
 CREATE TABLE transactions (
   id              TEXT PRIMARY KEY,
@@ -65,7 +66,7 @@ CREATE TABLE transactions (
   created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
 
-  -- Перевод обязан иметь вторую сторону, трата и доход — не должны
+  -- A transfer must have a second side, expense and income must not
   CHECK (
     (kind = 'transfer' AND to_account_id IS NOT NULL AND to_amount > 0)
     OR (kind <> 'transfer' AND to_account_id IS NULL AND to_amount IS NULL)
@@ -77,7 +78,7 @@ CREATE INDEX idx_tx_account ON transactions(account_id);
 CREATE INDEX idx_tx_to_account ON transactions(to_account_id);
 CREATE INDEX idx_tx_category ON transactions(category_id);
 
--- Сверка: фактический остаток из банка на дату. Расхождение считается на лету.
+-- Reconciliation: actual bank balance on a date. The discrepancy is computed on the fly.
 CREATE TABLE reconciliations (
   id             TEXT PRIMARY KEY,
   account_id     TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -89,6 +90,6 @@ CREATE TABLE reconciliations (
 );
 CREATE INDEX idx_reconciliations_account ON reconciliations(account_id, checked_on DESC);
 
--- Чеки прикладываются к операции той же машинерией, что вложения к заметкам
+-- Receipts attach to a transaction via the same machinery as note attachments
 ALTER TABLE attachments ADD COLUMN transaction_id TEXT REFERENCES transactions(id) ON DELETE CASCADE;
 CREATE INDEX idx_attachments_transaction ON attachments(transaction_id);

--- a/server/src/db/migrations/008_budgets_recurring.sql
+++ b/server/src/db/migrations/008_budgets_recurring.sql
@@ -1,10 +1,10 @@
--- Лимиты по категориям и регулярные операции.
+-- Category budgets and recurring transactions.
 
 /*
-  Лимит задаётся на категорию в конкретной валюте.
-  month IS NULL — постоянный лимит, действует каждый месяц.
-  month = 'ГГГГ-ММ' — исключение на один месяц, перебивает постоянный.
-  Так «в декабре на подарки больше» не требует переписывать общий лимит.
+  A budget is set per category in a specific currency.
+  month IS NULL — standing budget, applies every month.
+  month = 'YYYY-MM' — one-month exception, overrides the standing one.
+  This way "more for gifts in December" doesn't require rewriting the standing budget.
 */
 CREATE TABLE budgets (
   id          TEXT PRIMARY KEY,
@@ -19,13 +19,13 @@ CREATE UNIQUE INDEX idx_budget_unique
   ON budgets(category_id, currency, coalesce(month, ''));
 
 /*
-  Регулярная операция — это шаблон, а не запись в истории.
-  Фактические операции создаются из него по датам правила повтора.
+  A recurring transaction is a template, not a history entry.
+  Actual transactions are created from it on the recurrence rule's dates.
 
-  auto_create = 1 — создавать самостоятельно (аренда: списывают в срок).
-  auto_create = 0 — предлагать к подтверждению (зарплата: приходит с
-  задержкой, и автоматическая запись испортила бы остаток именно в тот
-  момент, когда на него смотрят).
+  auto_create = 1 — create on its own (rent: charged on schedule).
+  auto_create = 0 — offer for confirmation (salary: arrives late, and an
+  automatic entry would corrupt the balance at exactly the moment
+  someone is looking at it).
 */
 CREATE TABLE recurring_transactions (
   id              TEXT PRIMARY KEY,
@@ -48,8 +48,8 @@ CREATE TABLE recurring_transactions (
 );
 CREATE INDEX idx_recurring_active ON recurring_transactions(active);
 
--- Пропущенный экземпляр: «в этом месяце платежа не было».
--- Само правило при этом остаётся.
+-- A skipped instance: "no payment this month".
+-- The rule itself stays.
 CREATE TABLE recurring_skips (
   recurring_id TEXT NOT NULL REFERENCES recurring_transactions(id) ON DELETE CASCADE,
   occurred_on  TEXT NOT NULL,
@@ -58,11 +58,11 @@ CREATE TABLE recurring_skips (
 
 ALTER TABLE transactions ADD COLUMN recurring_id TEXT
   REFERENCES recurring_transactions(id) ON DELETE SET NULL;
--- Дата экземпляра серии, из которого создана операция
+-- Date of the series instance the transaction was created from
 ALTER TABLE transactions ADD COLUMN recurring_on TEXT;
 
--- Гарантия идемпотентности: один экземпляр серии — не более одной операции.
--- Без этого повторный запуск создателя задваивал бы аренду.
+-- Idempotency guarantee: one series instance — at most one transaction.
+-- Without it, re-running the creator would double the rent.
 CREATE UNIQUE INDEX idx_tx_recurring_once
   ON transactions(recurring_id, recurring_on)
   WHERE recurring_id IS NOT NULL;

--- a/server/src/db/migrations/009_reconcile_unique.sql
+++ b/server/src/db/migrations/009_reconcile_unique.sql
@@ -1,15 +1,16 @@
--- Сверка за день одна: повторная в тот же день обновляет предыдущую.
+-- One reconciliation per day: a repeat on the same day updates the previous one.
 --
--- Раньше каждая сверка добавляла строку, и вторая за день создавала
--- двойника с той же датой. Выборка «последняя сверка» упорядочивалась
--- только по checked_on, при равных датах SQLite возвращал первую попавшуюся
--- — обычно старую. Снаружи это выглядело так: кнопка «Сверить» срабатывает
--- один раз, а дальше игнорируется.
+-- Previously every reconciliation added a row, and a second one that day
+-- created a twin with the same date. The "latest reconciliation" query
+-- ordered only by checked_on; on equal dates SQLite returned whichever came
+-- first — usually the old one. From the outside it looked like the
+-- "Reconcile" button works once and is then ignored.
 --
--- Несколько сверок одного счёта за один день не несут смысла: важен
--- фактический остаток на дату, а не история попыток его ввести.
+-- Multiple reconciliations of one account on one day carry no meaning:
+-- what matters is the actual balance on a date, not the history of attempts
+-- to enter it.
 
--- Существующие двойники убираем, оставляя последнюю введённую
+-- Remove existing twins, keeping the last one entered
 DELETE FROM reconciliations
  WHERE rowid NOT IN (
    SELECT max(rowid) FROM reconciliations GROUP BY account_id, checked_on

--- a/server/src/db/migrations/010_google.sql
+++ b/server/src/db/migrations/010_google.sql
@@ -1,18 +1,18 @@
--- Вход через Google.
+-- Sign-in with Google.
 --
--- google_sub — постоянный идентификатор гугл-аккаунта (claim `sub`).
--- Привязка только по нему: email у Google можно сменить, sub — никогда.
--- Учётки по Google не создаются: хаб семейный, состав известен,
--- чужой аккаунт при входе получает отказ.
+-- google_sub — the permanent Google account identifier (claim `sub`).
+-- Linking goes by it alone: a Google email can change, sub never does.
+-- No accounts are created via Google: the hub is for a family, membership
+-- is known, a foreign account is refused at sign-in.
 --
--- password_login_disabled — добровольный отказ от парольного входа после
--- привязки Google. Инварианты держит сервер: отключить пароль можно только
--- при привязанном Google и никогда — администратору (его пароль — аварийный
--- вход на случай, когда Google недоступен или привязка сломалась).
--- Сброс пароля администратором включает парольный вход обратно.
+-- password_login_disabled — voluntary opt-out of password login after
+-- linking Google. The server holds the invariants: password can be disabled
+-- only with Google linked and never for the admin (their password is the
+-- emergency entrance for when Google is down or the link is broken).
+-- An admin password reset turns password login back on.
 
 ALTER TABLE users ADD COLUMN google_sub TEXT;
 ALTER TABLE users ADD COLUMN password_login_disabled INTEGER NOT NULL DEFAULT 0;
 
--- Один гугл-аккаунт — одна учётка
+-- One Google account — one user account
 CREATE UNIQUE INDEX idx_users_google_sub ON users(google_sub) WHERE google_sub IS NOT NULL;

--- a/server/src/db/migrations/011_invites.sql
+++ b/server/src/db/migrations/011_invites.sql
@@ -1,11 +1,11 @@
--- Приглашения по ссылке.
+-- Invite links.
 --
--- Вместо «администратор завёл учётку и продиктовал одноразовый пароль»:
--- администратор создаёт ссылку, человек открывает её и сам заполняет имя,
--- логин и пароль. Ссылка одноразовая и живёт неделю.
+-- Instead of "the admin created an account and dictated a one-time
+-- password": the admin creates a link, the person opens it and fills in
+-- their own name, login and password. The link is single-use and lives a week.
 --
--- Токен хранится хэшем — как и токены сессий: утечка базы не должна
--- отдавать действующие приглашения.
+-- The token is stored hashed — like session tokens: a database leak must
+-- not hand out working invites.
 
 CREATE TABLE invites (
   id TEXT PRIMARY KEY,
@@ -14,7 +14,7 @@ CREATE TABLE invites (
   created_by TEXT NOT NULL REFERENCES users(id),
   created_at TEXT NOT NULL,
   expires_at TEXT NOT NULL,
-  -- Заполняются при использовании; использованные храним для истории
+  -- Filled in on use; used invites are kept for history
   used_by TEXT REFERENCES users(id),
   used_at TEXT
 );

--- a/server/src/db/migrations/012_subcategories.sql
+++ b/server/src/db/migrations/012_subcategories.sql
@@ -1,12 +1,13 @@
--- Подкатегории трат и доходов: «Автотраты → Топливо, Парковка, Автосервис».
+-- Expense and income subcategories: "Car → Fuel, Parking, Service".
 --
--- Глубина — ровно один уровень, и это осознанное ограничение: дерево
--- произвольной вложенности превращает каждый отчёт в рекурсию, а на
--- практике семье хватает пары «группа → статья». Сервер следит, чтобы
--- подкатегория не становилась родителем.
+-- Depth is exactly one level, and that's a deliberate limit: a tree of
+-- arbitrary nesting turns every report into recursion, while in practice
+-- a family gets by with "group → line item". The server makes sure a
+-- subcategory never becomes a parent.
 --
--- При удалении родителя подкатегории не пропадают, а поднимаются на
--- верхний уровень (ON DELETE SET NULL): разметка операций дороже иерархии.
+-- Deleting a parent doesn't lose the subcategories — they rise to the
+-- top level (ON DELETE SET NULL): transaction labeling is worth more
+-- than the hierarchy.
 
 ALTER TABLE categories ADD COLUMN parent_id TEXT REFERENCES categories(id) ON DELETE SET NULL;
 

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -2,31 +2,32 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 /**
- * По умолчанию данные живут вне папки проекта.
+ * By default the data lives outside the project folder.
  *
- * Раньше база лежала в ./data — то есть внутри каталога, который целиком
- * заменяется при обновлении. Finder на macOS при замене папки не сливает
- * содержимое, а удаляет старую вместе со всем внутри, и база исчезала.
- * Каталог с данными не должен зависеть от того, как обновляют код.
+ * The database used to sit in ./data — inside a directory that gets
+ * replaced wholesale on update. When replacing a folder, Finder on macOS
+ * doesn't merge contents, it deletes the old one with everything inside,
+ * and the database vanished. The data directory must not depend on how
+ * the code is updated.
  *
- * В Docker переменная DATA_DIR задана явно и указывает на том.
+ * In Docker the DATA_DIR variable is set explicitly and points to a volume.
  */
 const DEFAULT_DATA_DIR = join(homedir(), '.family-hub');
 
-/** Старое расположение — из него данные переносятся при первом запуске. */
+/** The old location — data is migrated out of it on first start. */
 export const legacyDataDir = resolve('./data');
 
 /**
- * Числа и флаги из окружения проверяются на месте: опечатка в значении
- * должна останавливать старт или быть видимой, а не молча превращаться
- * в NaN («слушаем порт NaN») или в false («флаг вроде включён, но нет»).
+ * Numbers and flags from the environment are validated on the spot: a typo
+ * in a value must stop startup or be visible, not silently turn into NaN
+ * ("listening on port NaN") or false ("the flag looks enabled, but isn't").
  */
 function intFrom(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === '') return fallback;
   const value = Number(raw);
   if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(`${name}=${raw} — ожидается целое положительное число`);
+    throw new Error(`${name}=${raw} — expected a positive integer`);
   }
   return value;
 }
@@ -35,7 +36,7 @@ function boolFrom(name: string): boolean {
   const raw = process.env[name];
   if (raw === undefined || raw === '' || raw === 'false') return false;
   if (raw === 'true') return true;
-  throw new Error(`${name}=${raw} — ожидается true или false`);
+  throw new Error(`${name}=${raw} — expected true or false`);
 }
 
 export const env = {
@@ -44,28 +45,29 @@ export const env = {
   dataDir: resolve(process.env.DATA_DIR ?? DEFAULT_DATA_DIR),
   webDist: resolve(process.env.WEB_DIST ?? '../web/dist'),
   isProd: process.env.NODE_ENV === 'production',
-  // Включать только после того, как заработал HTTPS (scripts/setup-https.sh).
-  // Если включить раньше, браузер не примет куку и вход перестанет работать.
+  // Enable only after HTTPS is working (scripts/setup-https.sh).
+  // Enabled too early, the browser rejects the cookie and login breaks.
   secureCookies: boolFrom('SECURE_COOKIES'),
-  // Включается, когда приложение стоит за обратным прокси (Caddy на VPS):
-  // адрес клиента тогда берётся из X-Forwarded-For, иначе все запросы
-  // выглядят пришедшими с адреса прокси — и лимиты по IP банят самих себя.
-  // В открытой установке без прокси включать нельзя: заголовок подделывается.
+  // Enabled when the app sits behind a reverse proxy (Caddy on the VPS):
+  // the client address then comes from X-Forwarded-For, otherwise every
+  // request looks like it came from the proxy — and per-IP limits ban
+  // ourselves. Must stay off on an exposed install without a proxy:
+  // the header can be forged.
   trustProxy: boolFrom('TRUST_PROXY'),
-  // ── Вход через Google ───────────────────────────────────────────────────
-  // Оба значения выдаёт Google Cloud Console (OAuth client, Web application).
-  // Пустой clientId выключает возможность целиком: кнопки на входе нет,
-  // маршруты отвечают, что вход через Google не настроен.
+  // ── Sign-in with Google ─────────────────────────────────────────────────
+  // Both values come from Google Cloud Console (OAuth client, Web application).
+  // An empty clientId disables the feature entirely: no button on the login
+  // screen, the routes reply that Google sign-in is not configured.
   googleClientId: process.env.GOOGLE_CLIENT_ID ?? '',
   googleClientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
-  // Адрес, по которому хаб виден из браузера, — из него собирается
-  // redirect URI для Google. Для прода: https://hub.example.com
+  // The address the hub is reachable at from a browser — the Google
+  // redirect URI is built from it. For production: https://hub.example.com
   publicUrl: (process.env.PUBLIC_URL ?? '').replace(/\/$/, ''),
-  // Публичная песочница: база-однодневка на посетителя.
-  // См. server/src/lib/sandbox.ts и lib/demo.ts
+  // Public sandbox: a throwaway database per visitor.
+  // See server/src/lib/sandbox.ts and lib/demo.ts
   demoMode: boolFrom('DEMO_MODE'),
-  // debug | info | warn | error | silent. По умолчанию warn:
-  // в обычной работе интересны только предупреждения и ошибки.
+  // debug | info | warn | error | silent. Default warn:
+  // in normal operation only warnings and errors are interesting.
   logLevel: process.env.LOG_LEVEL ?? 'warn',
 } as const;
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,19 +24,19 @@ import { authenticate, announceSetupIfEmpty, pruneSessions } from './lib/auth.js
 import { log, logLevel } from './lib/log.js';
 
 const app = Fastify({
-  // Встроенный журнал выключен целиком: он пишет строку JSON на каждый запрос,
-  // и на домашнем сервере это шум, в котором не видно настоящих ошибок.
-  // При logger: false отдельно отключать запись запросов не нужно.
+  // The built-in logger is off entirely: it writes a JSON line per request,
+  // and on a home server that is noise drowning out real errors.
+  // With logger: false there is no need to disable request logging separately.
   logger: false,
   trustProxy: env.trustProxy,
 });
 
 /*
-  В журнал никогда не попадают значения query-параметров: там живут
-  секреты — токен приглашения (?token=), код и state OAuth-возврата.
-  Неудачная проверка приглашения — это 404 на уровне warn, и без маскировки
-  секрет оказывался в логе по умолчанию. Имена параметров оставляем:
-  для диагностики важно «с каким параметром пришли», не «с каким значением».
+  Query parameter values never reach the log: that is where secrets live —
+  the invite token (?token=), the OAuth callback code and state.
+  A failed invite check is a 404 at warn level, and without masking
+  the secret ended up in the log by default. Parameter names are kept:
+  for diagnostics "which parameter came in" matters, not "with which value".
 */
 export function redactUrl(url: string): string {
   const q = url.indexOf('?');
@@ -47,12 +47,12 @@ export function redactUrl(url: string): string {
 }
 
 /*
-  Пишем сами и только то, что стоит внимания:
-  ошибки сервера — на уровне error, отказы клиента — warn,
-  всё остальное — debug и по умолчанию не показывается.
+  We log ourselves and only what deserves attention:
+  server errors at error level, client rejections at warn,
+  everything else at debug, hidden by default.
 */
 app.addHook('onResponse', (req, reply, done) => {
-  // Обработчик ошибок уже написал подробную строку — не повторяемся
+  // The error handler already wrote a detailed line — don't repeat it
   if (req.errorLogged) return done();
 
   const status = reply.statusCode;
@@ -66,8 +66,8 @@ app.addHook('onResponse', (req, reply, done) => {
 app.setErrorHandler((err: FastifyError, req, reply) => {
   req.errorLogged = true;
 
-  // Некорректные параметры в пути или строке запроса — это ошибка клиента.
-  // Раньше такое падало пятисоткой и попадало в журнал как ошибка сервера.
+  // Bad parameters in the path or query string are a client error.
+  // This used to blow up as a 500 and land in the log as a server error.
   if (err instanceof ZodError) {
     log.warn(`400 ${req.method} ${redactUrl(req.url)}`, err.issues[0]?.message ?? '');
     return reply.code(400).send({ error: 'Некорректные параметры запроса' });
@@ -85,10 +85,10 @@ app.setErrorHandler((err: FastifyError, req, reply) => {
 migrate();
 pruneSessions();
 
-// Прод без Secure-куки — почти наверняка забытый флаг, а не намерение:
-// сессионная кука тогда поедет и по нешифрованному каналу
+// Production without Secure cookies is almost certainly a forgotten flag,
+// not intent: the session cookie would then travel over plaintext too
 if (env.isProd && !env.secureCookies && !env.demoMode) {
-  log.warn('NODE_ENV=production без SECURE_COOKIES=true — включите после настройки HTTPS');
+  log.warn('NODE_ENV=production without SECURE_COOKIES=true — enable it once HTTPS is set up');
 }
 if (env.demoMode) {
   const { initDemo } = await import('./lib/sandbox.js');
@@ -100,13 +100,14 @@ if (env.demoMode) {
 await app.register(fastifyCookie);
 
 /*
-  Демо: направляем запрос в песочницу посетителя. Хук стоит сразу после
-  разбора кук и оборачивает остаток обработки в контекст её базы
-  (AsyncLocalStorage, см. db/index.ts) — дальше весь код, включая проверку
-  сессии, прозрачно работает с базой этой песочницы. Кука без живой
-  песочницы (протухла, вытеснена, рестарт) — контекст не ставится,
-  сессия в основной базе не найдётся, клиент получит честный 401
-  и вернётся на экран входа за новой песочницей.
+  Demo: route the request into the visitor's sandbox. The hook sits right
+  after cookie parsing and wraps the rest of the handling in that sandbox's
+  database context (AsyncLocalStorage, see db/index.ts) — from there all
+  code, session check included, transparently works with that sandbox's
+  database. A cookie without a live sandbox (expired, evicted, restart) —
+  no context is set, the session won't be found in the main database,
+  the client gets an honest 401 and returns to the login screen
+  for a fresh sandbox.
 */
 if (env.demoMode) {
   const { SANDBOX_COOKIE, getSandbox } = await import('./lib/sandbox.js');
@@ -123,11 +124,11 @@ await app.register(fastifyMultipart, {
 });
 
 /*
-  Заголовки безопасности. CSP строгий, потому что можем себе позволить:
-  фронт собран Vite в свои файлы, внешних шрифтов и скриптов нет.
-  'unsafe-inline' только для стилей — React ставит inline-атрибуты style
-  (цвета проектов, аватарки), без него они перестанут применяться.
-  HSTS не включаем сами: за него отвечает прокси, который и терминирует TLS.
+  Security headers. CSP is strict because we can afford it:
+  the frontend is built by Vite into its own files, no external fonts
+  or scripts. 'unsafe-inline' only for styles — React sets inline style
+  attributes (project colors, avatars), without it they stop applying.
+  HSTS is not set here: the proxy that terminates TLS owns it.
 */
 await app.register(fastifyHelmet, {
   contentSecurityPolicy: {
@@ -148,20 +149,21 @@ await app.register(fastifyHelmet, {
 });
 
 /*
-  Общий предохранитель по частоте запросов — только для API. Порог щедрый:
-  семья из нескольких человек в него не упрётся никогда, а вот сканеру
-  и скрипту, молотящему API, он обрубает темп. Ключ — IP клиента
-  (с trustProxy это настоящий адрес, а не адрес Caddy). У входа свой,
-  куда более жёсткий лимит — задан на самом маршруте в auth.ts.
+  A general rate-limit fuse — API only. The threshold is generous:
+  a family of a few people will never hit it, but it cuts the tempo
+  of a scanner or a script hammering the API. Key — client IP
+  (with trustProxy that is the real address, not Caddy's). Login has
+  its own, much stricter limit — set on the route itself in auth.ts.
 
-  Мимо лимита проходят:
-  — статика и страницы приложения: интерфейс из десятков файлов не должен
-    конкурировать с API за бюджет, а ошибка лимита на самой странице
-    выглядит как поломка всего хаба;
-  — чтение вложений: картинки в заметках ходят через /api/attachments,
-    заметка с полусотней фотографий чеков — это полсотни запросов разом,
-    и честное листание семейного архива выедало бы бюджет мгновенно.
-    Вложения прикрыты авторизацией и кэшируются браузером навсегда.
+  Exempt from the limit:
+  — static files and app pages: an interface of dozens of files must not
+    compete with the API for budget, and a rate-limit error on the page
+    itself looks like the whole hub is broken;
+  — attachment reads: note images go through /api/attachments,
+    a note with fifty receipt photos is fifty requests at once,
+    and honest browsing of the family archive would eat the budget
+    instantly. Attachments sit behind auth and are cached by the
+    browser forever.
 */
 await app.register(fastifyRateLimit, {
   max: 300,
@@ -176,8 +178,8 @@ await app.register(fastifyRateLimit, {
   }),
 });
 
-// Выход и подобные методы вызываются без тела. Fastify по умолчанию
-// отвечает на это 400 — разрешаем пустое тело явно.
+// Logout and similar methods are called without a body. Fastify answers
+// that with a 400 by default — allow an empty body explicitly.
 app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
   const raw = (body as string).trim();
   if (raw === '') return done(null, {});
@@ -189,16 +191,16 @@ app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body,
 });
 
 /*
-  Заслон от CSRF поверх SameSite=Lax: браузер при межсайтовом запросе
-  обязан прислать Origin, и он не совпадёт с нашим Host. Запрос без
-  заголовка (curl, приложения, same-origin GET) проходит — это не браузерный
-  межсайтовый сценарий, от которого защищаемся. Сравниваются только хосты:
-  схему за прокси знает лишь Caddy.
+  A CSRF barrier on top of SameSite=Lax: on a cross-site request the
+  browser must send Origin, and it won't match our Host. A request
+  without the header (curl, apps, same-origin GET) passes — that is not
+  the cross-site browser scenario we defend against. Only hosts are
+  compared: behind the proxy only Caddy knows the scheme.
 
-  Только в проде: дев-прокси Vite переписывает Host на адрес API
-  (localhost:8787), а Origin остаётся фронтовым (localhost:5173) —
-  проверка резала бы каждый законный запрос разработки. В проде Host
-  доезжает нетронутым и при прямом доступе, и из-за Caddy.
+  Production only: the Vite dev proxy rewrites Host to the API address
+  (localhost:8787) while Origin stays the frontend's (localhost:5173) —
+  the check would cut every legitimate dev request. In production Host
+  arrives untouched both on direct access and via Caddy.
 */
 if (env.isProd) {
   app.addHook('onRequest', (req, reply, done) => {
@@ -233,13 +235,13 @@ await registerCalendarRoutes(app);
 await registerMoneyRoutes(app);
 await registerBudgetRoutes(app);
 
-// Регулярные платежи, помеченные «создавать самостоятельно», догоняются
-// при старте: мак мог спать, и пара дат могла пройти без нас
+// Recurring payments marked "create automatically" catch up at startup:
+// the Mac may have been asleep, and a couple of dates may have passed us by
 const createdOnBoot = runAutoCreate();
-if (createdOnBoot > 0) log.info(`регулярные операции: создано ${createdOnBoot}`);
+if (createdOnBoot > 0) log.info(`recurring transactions: created ${createdOnBoot}`);
 await registerRoutes(app);
 
-// В деве фронт живёт на Vite. Чтобы заход на порт API не выглядел поломкой:
+// In dev the frontend lives on Vite. So hitting the API port doesn't look broken:
 if (!env.isProd) {
   app.get('/', (_req, reply) =>
     reply
@@ -248,8 +250,8 @@ if (!env.isProd) {
   );
 }
 
-// В проде тот же процесс раздаёт собранный фронт.
-// В деве фронт живёт на Vite и проксирует /api сюда.
+// In production the same process serves the built frontend.
+// In dev the frontend lives on Vite and proxies /api here.
 if (env.isProd && existsSync(env.webDist)) {
   await app.register(fastifyStatic, { root: env.webDist });
   app.setNotFoundHandler((req, reply) => {
@@ -262,29 +264,29 @@ if (env.isProd && existsSync(env.webDist)) {
 
 try {
   await app.listen({ port: env.port, host: env.host });
-  log.notice(`Дом слушает http://${env.host}:${env.port} · журнал: ${logLevel}`);
+  log.notice(`Hub listening on http://${env.host}:${env.port} · log level: ${logLevel}`);
 } catch (err) {
-  log.error('Не удалось занять порт', err);
+  log.error('Failed to bind the port', err);
   process.exit(1);
 }
 
-// Необработанное падение должно быть видно при любом уровне журнала
-process.on('unhandledRejection', (reason) => log.error('Необработанное отклонение', reason));
+// An unhandled crash must be visible at any log level
+process.on('unhandledRejection', (reason) => log.error('Unhandled rejection', reason));
 process.on('uncaughtException', (err) => {
-  log.error('Необработанное исключение', err);
+  log.error('Uncaught exception', err);
   process.exit(1);
 });
 
 for (const signal of ['SIGINT', 'SIGTERM'] as const) {
   process.on(signal, async () => {
     await app.close();
-    // Явное закрытие делает WAL-checkpoint: база остаётся одним файлом,
-    // без -wal/-shm рядом — копировать и переносить её так безопаснее
+    // An explicit close runs a WAL checkpoint: the database stays a single
+    // file, no -wal/-shm next to it — safer to copy and move around
     try {
       const { currentDb } = await import('./db/index.js');
       currentDb().close();
     } catch {
-      // База уже закрыта или не открылась — на выходе это не ошибка
+      // The database is already closed or never opened — not an error on exit
     }
     process.exit(0);
   });

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -14,7 +14,7 @@ export interface AuthUser {
   role: 'admin' | 'member' | 'kid';
   color: string;
   must_change_password: number;
-  /** Привязан ли Google — фронту хватает факта, сам sub наружу не ходит. */
+  /** Whether Google is linked — the fact is enough for the frontend, the sub itself never leaves. */
   google_linked: number;
   password_login_disabled: number;
 }
@@ -29,7 +29,7 @@ export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 
-// ── Сессии ────────────────────────────────────────────────────────────────
+// ── Sessions ──────────────────────────────────────────────────────────────
 
 export function createSession(userId: string, userAgent: string | undefined): string {
   const token = randomBytes(32).toString('base64url');
@@ -78,19 +78,19 @@ export function clearSessionCookie(reply: FastifyReply): void {
   reply.clearCookie(SESSION_COOKIE, { path: '/' });
 }
 
-// ── Защита маршрутов ──────────────────────────────────────────────────────
+// ── Route protection ──────────────────────────────────────────────────────
 
 const PUBLIC_PATHS = new Set([
   '/api/health',
   '/api/auth/login',
   '/api/auth/state',
-  // Вход в демо: создаёт песочницу и сессию, живёт до них обеих
+  // Demo login: creates the sandbox and the session, so it predates both
   '/api/auth/demo',
-  // Вход через Google: начало и возврат живут до сессии.
-  // Привязки (/google/link) здесь нет намеренно — она требует сессии.
+  // Google sign-in: start and callback predate the session.
+  // Linking (/google/link) is deliberately absent — it requires a session.
   '/api/auth/google/start',
   '/api/auth/google/callback',
-  // Онбординг: первичная настройка и вход по приглашению — до сессии
+  // Onboarding: initial setup and invite login — before any session
   '/api/auth/setup',
   '/api/auth/invite',
   '/api/auth/join',
@@ -107,13 +107,13 @@ export async function authenticate(req: FastifyRequest, reply: FastifyReply): Pr
     return reply.code(401).send({ error: 'Нужно войти' });
   }
 
-  // Пока пароль не сменён, доступен только сам метод смены
+  // Until the password is changed, only the change endpoint is available
   if (user.must_change_password && path !== '/api/auth/change-password' && path !== '/api/auth/me') {
     return reply.code(403).send({ error: 'Сначала смените пароль', code: 'must_change_password' });
   }
 
-  // Публичная песочница: смена паролей, состава семьи и загрузка файлов
-  // отключены — остальное нарочно живое
+  // Public sandbox: password changes, family membership and file uploads
+  // are disabled — everything else is deliberately live
   if (env.demoMode) {
     const { demoBlocked } = await import('./demo.js');
     if (demoBlocked(req.method, path)) {
@@ -132,13 +132,14 @@ export function requireAdmin(req: FastifyRequest, reply: FastifyReply): boolean 
   return true;
 }
 
-// ── Первый запуск ─────────────────────────────────────────────────────────
+// ── First start ───────────────────────────────────────────────────────────
 
 /**
- * Пустая база — не повод писать пароли в журнал. Первую учётку человек
- * создаёт сам через браузер (экран первичной настройки), сервер лишь
- * подсказывает об этом в лог. Печать одноразового пароля администратора
- * ушла вместе со служебной учёткой: первый настроивший и есть администратор.
+ * An empty database is no reason to write passwords into the log. The
+ * person creates the first account themselves in the browser (the initial
+ * setup screen); the server only hints at it in the log. Printing a
+ * one-time admin password left together with the service account:
+ * whoever sets up first is the admin.
  */
 export function announceSetupIfEmpty(): void {
   const count = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
@@ -153,7 +154,7 @@ export function announceSetupIfEmpty(): void {
   ]);
 }
 
-/** Протухшие сессии убираем при старте, чтобы таблица не росла бесконечно. */
+/** Expired sessions are removed at startup so the table doesn't grow forever. */
 export function pruneSessions(): void {
   db.prepare('DELETE FROM sessions WHERE expires_at <= ?').run(new Date().toISOString());
 }

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -3,20 +3,22 @@ import { db, now, today } from '../db/index.js';
 import { hashPassword } from './password.js';
 
 /*
-  Демо-режим (DEMO_MODE=true) — публичная песочница «потыкать до установки».
+  Demo mode (DEMO_MODE=true) — a public "try before installing" sandbox.
 
-  Здесь живёт содержимое демо: сидинг правдоподобной семьи (задачи, заметки,
-  календарь, деньги) и список запретов. Жизненный цикл — в sandbox.ts:
-  сидинг наполняет шаблонную базу, а каждый посетитель получает её свежую
-  копию, так что чужого мусора в демо не бывает by design.
+  The demo's content lives here: seeding of a plausible family (tasks,
+  notes, calendar, money) and the list of restrictions. The lifecycle is
+  in sandbox.ts: seeding fills the template database, and every visitor
+  gets a fresh copy of it, so other people's garbage never appears in
+  the demo by design.
 
-  Запреты стали короче, чем при общей базе: портить содержимое посетитель
-  может только себе. Остаются закрытыми смена паролей и состава семьи
-  (в песочнице они бессмысленны, а инвайт-ссылки вводят в заблуждение)
-  и загрузка файлов — диск общий, файлопомойку никто не отменял.
+  The restrictions got shorter than with a shared database: a visitor can
+  only spoil the content for themselves. What stays closed: password and
+  family membership changes (meaningless in a sandbox, and invite links
+  mislead) and file uploads — the disk is shared, and a file dump is
+  still a file dump.
 */
 
-/** Что в демо запрещено. Проверяется в authenticate после входа. */
+/** What the demo forbids. Checked in authenticate after login. */
 export function demoBlocked(method: string, path: string): boolean {
   if (method === 'GET' || method === 'HEAD') return false;
   if (path.startsWith('/api/users')) return true;
@@ -24,7 +26,7 @@ export function demoBlocked(method: string, path: string): boolean {
   if (path === '/api/auth/change-password') return true;
   if (path === '/api/auth/password-login') return true;
   if (path.startsWith('/api/auth/google')) return true;
-  // Все загрузки файлов: вложения заметок и чеки операций
+  // All file uploads: note attachments and transaction receipts
   if (method === 'POST' && path.includes('/attachments')) return true;
   if (method === 'POST' && path.includes('/receipts')) return true;
   return false;
@@ -34,7 +36,7 @@ function id(): string {
   return randomUUID();
 }
 
-/** ISO-дата со сдвигом от сегодня, местное время — как везде в хабе. */
+/** ISO date offset from today, local time — as everywhere in the hub. */
 function day(offset: number): string {
   const base = new Date(`${today()}T00:00:00`);
   base.setDate(base.getDate() + offset);
@@ -44,27 +46,27 @@ function day(offset: number): string {
   return `${y}-${m}-${d}`;
 }
 
-/** Наполняет базу текущего контекста примером семьи. Ожидает пустую базу. */
+/** Fills the current context's database with an example family. Expects an empty database. */
 export async function seedDemo(): Promise<void> {
   const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
   if (n > 0) return;
 
-  // Вход в демо автоматический (POST /api/auth/demo), пароль никому
-  // не сообщается — поэтому он случайный. Захардкоженный demo1234 был
-  // короче собственного минимума хаба и жил в двух местах кода.
+  // Demo login is automatic (POST /api/auth/demo), the password is never
+  // told to anyone — hence random. The hardcoded demo1234 was shorter
+  // than the hub's own minimum and lived in two places in the code.
   const passwordHash = await hashPassword(randomUUID());
   const alex = id();
   const sam = id();
 
   const seed = db.transaction(() => {
-    // ── Семья ──
+    // ── Family ──
     db.prepare(
       `INSERT INTO users (id, email, name, role, password_hash, color, created_at) VALUES
        (?, 'alex@family.hub', 'Alex', 'admin', ?, '#2E6F8E', ?),
        (?, 'sam@family.hub', 'Sam', 'member', ?, '#B4654A', ?)`,
     ).run(alex, passwordHash, now(), sam, passwordHash, now());
 
-    // ── Проекты и задачи ──
+    // ── Projects and tasks ──
     const home = id();
     const trip = id();
     db.prepare(
@@ -90,12 +92,12 @@ export async function seedDemo(): Promise<void> {
       id(), trip, day(12), sam, sam,
       id(), trip, alex,
     );
-    // Вложенность: «купить краску» — под стори покраски
+    // Nesting: "buy paint" goes under the repaint story
     db.prepare(
       `UPDATE tasks SET parent_id = ?, level = 1 WHERE title IN ('Pick the colour together', 'Buy paint and tape')`,
     ).run(paint);
 
-    // ── Заметки ──
+    // ── Notes ──
     const recipes = id();
     db.prepare(
       `INSERT INTO folders (id, name, position) VALUES (?, 'Recipes', 1)`,
@@ -107,8 +109,8 @@ export async function seedDemo(): Promise<void> {
        (?, 'House rules for guests', 'Wi-Fi: *familyhub / pizzafriday*\n\nCoffee machine: one scoop, button, patience.', NULL, ?, 0)`,
     ).run(id(), alex, id(), recipes, sam, id(), alex);
 
-    // ── Календарь ──
-    const shared = '00000000-0000-4000-8000-000000000201'; // «Общий» из миграции
+    // ── Calendar ──
+    const shared = '00000000-0000-4000-8000-000000000201'; // the seeded shared calendar from the migration
     const gym = id();
     const dentist = id();
     const birthday = id();
@@ -126,7 +128,7 @@ export async function seedDemo(): Promise<void> {
       `INSERT INTO event_participants (event_id, user_id) VALUES (?, ?), (?, ?), (?, ?)`,
     ).run(gym, alex, gym, sam, dentist, sam);
 
-    // ── Деньги ──
+    // ── Money ──
     const card = id();
     const cash = id();
     db.prepare(
@@ -176,7 +178,7 @@ export async function seedDemo(): Promise<void> {
        (?, 'Salary', 'income', ?, 'FREQ=MONTHLY;INTERVAL=1', ?, 210000, ?, 0, 1)`,
     ).run(id(), day(-40), card, household, id(), day(-40), card, salary);
 
-    // ── Табло ──
+    // ── Dashboard ──
     db.prepare(
       `INSERT INTO settings (key, value, updated_at) VALUES
        ('move.label', 'Trip countdown', ?),

--- a/server/src/lib/log.ts
+++ b/server/src/lib/log.ts
@@ -1,17 +1,16 @@
 /**
- * Свой журнал вместо pino.
+ * Our own logger instead of pino.
  *
- * Fastify по умолчанию пишет строку JSON на каждый запрос, включая pid и
- * hostname. На домашнем сервере, который опрашивается стендом раз в минуту,
- * это гигабайты бесполезного вывода и полная невозможность заметить в нём
- * настоящую ошибку.
+ * Fastify writes a JSON line per request by default, pid and hostname
+ * included. On a home server polled by a dashboard once a minute, that is
+ * gigabytes of useless output and no chance of spotting a real error in it.
  *
- * Уровень задаётся переменной LOG_LEVEL, по умолчанию warn.
+ * The level comes from the LOG_LEVEL variable, default warn.
  */
 
 declare module 'fastify' {
   interface FastifyRequest {
-    /** Обработчик ошибок уже записал строку — хук ответа не дублирует. */
+    /** The error handler already wrote a line — the response hook won't duplicate it. */
     errorLogged?: boolean;
   }
 }
@@ -62,18 +61,18 @@ export const log = {
   error: (...parts: unknown[]) => write('error', 'ERROR', parts),
 
   /**
-   * Сообщения, которые печатаются независимо от уровня.
+   * Messages printed regardless of the level.
    *
-   * Только для разовых событий, без которых система непригодна к
-   * использованию: выданный при первом запуске пароль администратора
-   * восстановить нельзя, а применённые миграции — единственный след того,
-   * что база изменилась. Обычным сообщениям здесь места нет.
+   * Only for one-off events the system is unusable without: the admin
+   * password issued on first start cannot be recovered, and applied
+   * migrations are the only trace that the database changed.
+   * Ordinary messages have no place here.
    */
   notice: (...parts: unknown[]) => {
     process.stdout.write(`${stamp()} ${parts.map(render).join(' ')}\n`);
   },
 
-  /** Многострочный блок без метки времени — для приветственных сообщений. */
+  /** A multi-line block without a timestamp — for welcome messages. */
   block: (lines: string[]) => {
     process.stdout.write(`${lines.join('\n')}\n`);
   },

--- a/server/src/lib/password.ts
+++ b/server/src/lib/password.ts
@@ -8,10 +8,10 @@ const scryptAsync = promisify(scrypt) as (
   options: { N: number; r: number; p: number; maxmem: number },
 ) => Promise<Buffer>;
 
-// scrypt из стандартной библиотеки Node, не argon2.
-// Он memory-hard, для нашей задачи полностью достаточен, и это на одну
-// нативную зависимость меньше — а её пришлось бы пересобирать при каждом
-// обновлении Node и чинить в Docker.
+// scrypt from Node's standard library, not argon2.
+// It is memory-hard, entirely sufficient for our needs, and one native
+// dependency fewer — one that would need rebuilding on every Node
+// update and fixing in Docker.
 const PARAMS = { N: 32_768, r: 8, p: 1, maxmem: 64 * 1024 * 1024 };
 const KEYLEN = 32;
 
@@ -43,7 +43,7 @@ export async function verifyPassword(password: string, stored: string): Promise<
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
-/** Читаемый пароль для первой выдачи: без похожих друг на друга символов. */
+/** A readable password for first issue: no look-alike characters. */
 export function generatePassword(words = 4): string {
   const alphabet = 'abcdefghijkmnpqrstuvwxyz23456789';
   const bytes = randomBytes(words * 4);

--- a/server/src/lib/recurrence.test.ts
+++ b/server/src/lib/recurrence.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { expandOccurrences, occurrenceAfter, parseRecurrence } from './recurrence.js';
 
 describe('parseRecurrence', () => {
-  it('понимает FREQ и INTERVAL в любом регистре', () => {
+  it('understands FREQ and INTERVAL in any case', () => {
     expect(parseRecurrence('FREQ=MONTHLY;INTERVAL=2')).toEqual({ freq: 'MONTHLY', interval: 2 });
     expect(parseRecurrence('freq=weekly')).toEqual({ freq: 'WEEKLY', interval: 1 });
   });
 
-  it('отклоняет мусор', () => {
+  it('rejects garbage', () => {
     expect(parseRecurrence('FREQ=SOMETIMES')).toBeNull();
     expect(parseRecurrence('INTERVAL=3')).toBeNull();
     expect(parseRecurrence('FREQ=DAILY;INTERVAL=0')).toBeNull();
@@ -17,43 +17,43 @@ describe('parseRecurrence', () => {
   });
 });
 
-describe('семантика якоря серии', () => {
-  it('«каждое 31-е» не съезжает навсегда после февраля', () => {
-    // Отсчёт от якоря, не от предыдущего повтора: 31.01 → 28.02 → 31.03
+describe('series anchor semantics', () => {
+  it('"every 31st" does not slip forever after February', () => {
+    // Counted from the anchor, not the previous occurrence: 31.01 → 28.02 → 31.03
     const dates = expandOccurrences('2026-01-31', 'FREQ=MONTHLY;INTERVAL=1', '2026-01-01', '2026-05-31');
     expect(dates).toEqual(['2026-01-31', '2026-02-28', '2026-03-31', '2026-04-30', '2026-05-31']);
   });
 
-  it('високосный февраль даёт 29-е', () => {
+  it('leap-year February yields the 29th', () => {
     const dates = expandOccurrences('2027-12-31', 'FREQ=MONTHLY;INTERVAL=1', '2028-02-01', '2028-02-29');
     expect(dates).toEqual(['2028-02-29']);
   });
 
-  it('годовой повтор с 29 февраля прижимается к 28-му в невисокосный год', () => {
+  it('a yearly series from Feb 29 clamps to the 28th in a non-leap year', () => {
     const dates = expandOccurrences('2028-02-29', 'FREQ=YEARLY;INTERVAL=1', '2029-01-01', '2029-12-31');
     expect(dates).toEqual(['2029-02-28']);
   });
 });
 
 describe('expandOccurrences', () => {
-  it('без правила — только сам якорь, и только внутри диапазона', () => {
+  it('without a rule — only the anchor itself, and only inside the range', () => {
     expect(expandOccurrences('2026-08-12', null, '2026-08-01', '2026-08-31')).toEqual(['2026-08-12']);
     expect(expandOccurrences('2026-08-12', null, '2026-09-01', '2026-09-30')).toEqual([]);
   });
 
-  it('границы диапазона включаются', () => {
+  it('range bounds are inclusive', () => {
     const dates = expandOccurrences('2026-08-01', 'FREQ=WEEKLY;INTERVAL=1', '2026-08-08', '2026-08-15');
     expect(dates).toEqual(['2026-08-08', '2026-08-15']);
   });
 
-  it('уважает limit', () => {
+  it('respects limit', () => {
     const dates = expandOccurrences('2020-01-01', 'FREQ=DAILY;INTERVAL=1', '2020-01-01', '2030-01-01', 10);
     expect(dates).toHaveLength(10);
   });
 });
 
 describe('occurrenceAfter', () => {
-  it('строго позже указанной даты', () => {
+  it('strictly after the given date', () => {
     expect(occurrenceAfter('2026-01-15', '2026-01-15', 'FREQ=MONTHLY;INTERVAL=1')).toBe('2026-02-15');
     expect(occurrenceAfter('2026-01-15', '2026-02-14', 'FREQ=MONTHLY;INTERVAL=1')).toBe('2026-02-15');
   });

--- a/server/src/lib/recurrence.ts
+++ b/server/src/lib/recurrence.ts
@@ -1,8 +1,8 @@
 /**
- * Подмножество RRULE из RFC 5545: FREQ и INTERVAL.
- * Больше нам не нужно — «раз в месяц оплатить» и «раз в год продлить»
- * покрываются этим полностью, а полный RRULE тянет за собой библиотеку
- * и целый класс краевых случаев.
+ * A subset of RRULE from RFC 5545: FREQ and INTERVAL.
+ * We need no more — "pay once a month" and "renew once a year" are fully
+ * covered by this, while full RRULE drags in a library and a whole class
+ * of edge cases.
  */
 
 export type Freq = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
@@ -37,12 +37,13 @@ export function isValidRecurrence(rule: string): boolean {
 }
 
 /**
- * Дата k-го повтора, считая от начала серии.
+ * The date of the k-th occurrence, counted from the start of the series.
  *
- * Отсчёт всегда ведётся от исходной даты, а не от предыдущего повтора.
- * Иначе «каждое 31 число» после февраля навсегда съезжает на 28-е:
- * 31 января → 28 февраля → 28 марта. Правильно — 31 января → 28 февраля →
- * 31 марта, то есть день месяца прижимается к длине месяца заново каждый раз.
+ * Counting always starts from the original date, not the previous
+ * occurrence. Otherwise "every 31st" slips to the 28th forever after
+ * February: Jan 31 → Feb 28 → Mar 28. Correct is Jan 31 → Feb 28 →
+ * Mar 31, i.e. the day of month is clamped to the month length anew
+ * every time.
  */
 function occurrence(anchor: string, rec: Recurrence, k: number): string | null {
   const date = new Date(`${anchor}T00:00:00Z`);
@@ -69,7 +70,7 @@ function anchorDay(anchor: string): number {
   return Number(anchor.slice(8, 10));
 }
 
-/** Ближайший повтор строго позже даты `after`. */
+/** The nearest occurrence strictly after the date `after`. */
 export function occurrenceAfter(anchor: string, after: string, rule: string): string | null {
   const rec = parseRecurrence(rule);
   if (!rec) return null;
@@ -83,9 +84,9 @@ export function occurrenceAfter(anchor: string, after: string, rule: string): st
 }
 
 /**
- * Прибавление месяцев с прижатием к последнему дню месяца.
- * День берётся из начала серии, поэтому 31 января + 2 месяца = 31 марта,
- * даже если промежуточный повтор пришёлся на 28 февраля.
+ * Adding months with clamping to the last day of the month.
+ * The day comes from the start of the series, so Jan 31 + 2 months =
+ * Mar 31, even if the intermediate occurrence landed on Feb 28.
  */
 function addMonths(date: Date, months: number, day: number): void {
   date.setUTCDate(1);
@@ -121,14 +122,14 @@ export function describeRecurrence(rule: string | null): string | null {
 }
 
 /**
- * Все повторы серии, попадающие в диапазон дат.
+ * All occurrences of a series that fall within a date range.
  *
- * События, в отличие от задач, не «закрываются» — поэтому следующий экземпляр
- * порождать некому, и разворачивать серию приходится на лету при каждом
- * запросе. Материализовать повторы в базу нельзя: «каждый год» без конечной
- * даты — это бесконечная таблица.
+ * Events, unlike tasks, are never "closed" — so nothing gets to spawn
+ * the next instance, and the series has to be expanded on the fly on
+ * every request. Materializing occurrences into the database won't work:
+ * "every year" with no end date is an infinite table.
  *
- * Даты в формате ГГГГ-ММ-ДД, границы включаются.
+ * Dates in YYYY-MM-DD format, bounds inclusive.
  */
 export function expandOccurrences(
   anchor: string,
@@ -144,8 +145,8 @@ export function expandOccurrences(
   if (!rec) return anchor >= from && anchor <= to ? [anchor] : [];
 
   const result: string[] = [];
-  // Потолок на число шагов: защита от «каждый день с 1990 года» и от
-  // правила, которое почему-то не двигает дату вперёд.
+  // A ceiling on the step count: protection against "daily since 1990"
+  // and against a rule that somehow fails to move the date forward.
   const MAX_STEPS = 20_000;
 
   for (let k = 0; k < MAX_STEPS; k++) {

--- a/server/src/lib/sandbox.ts
+++ b/server/src/lib/sandbox.ts
@@ -9,32 +9,33 @@ import { seedDemo } from './demo.js';
 import { log } from './log.js';
 
 /*
-  Песочницы демо-режима: у каждого посетителя — своя копия базы.
+  Demo-mode sandboxes: every visitor gets their own copy of the database.
 
-  Раньше все посетители демо жили в одной базе: первый же шутник заполнял
-  её мусором (или просто всё удалял), и остальные видели это до ночного
-  сброса. Теперь при входе в демо копируется шаблонная база — посетитель
-  получает свежий пример и может делать с ним что угодно: кроме него самого
-  этого никто не увидит.
+  All demo visitors used to live in one database: the first prankster
+  filled it with garbage (or simply deleted everything), and the rest saw
+  that until the nightly reset. Now demo login copies a template database —
+  the visitor gets a fresh example and can do anything with it: nobody
+  but them will ever see it.
 
-  Устройство:
-  — шаблон собирается при старте (миграции + сидинг) и пересобирается раз
-    в сутки, потому что демо-данные датируются относительно «сегодня»;
-  — копия шаблона — миллисекунды и сотни килобайт, песочница создаётся
-    прямо в обработчике входа;
-  — жизненный цикл: простой дольше TTL, превышение размера файла или
-    переполнение реестра (LRU) — песочница закрывается и файл удаляется.
-    Каталог целиком зачищается при старте: рестарт = чистый лист.
+  How it works:
+  — the template is built at startup (migrations + seeding) and rebuilt
+    once a day, because demo data is dated relative to "today";
+  — copying the template is milliseconds and hundreds of kilobytes, the
+    sandbox is created right in the login handler;
+  — lifecycle: idle past TTL, file size overrun or registry overflow
+    (LRU) — the sandbox is closed and its file deleted. The directory is
+    wiped entirely at startup: restart = clean slate.
 */
 
 export const SANDBOX_COOKIE = 'hub_sandbox';
 
-const TTL_MS = 2 * 60 * 60_000; // два часа простоя
+const TTL_MS = 2 * 60 * 60_000; // two hours idle
 const SWEEP_MS = 10 * 60_000;
 const TEMPLATE_REBUILD_MS = 24 * 60 * 60_000;
 const MAX_SANDBOXES = 100;
-// Стоп-кран против раздувания одной песочницы записью в цикле.
-// Шаблон весит сотни килобайт, честное «потыкать» столько не наберёт.
+// An emergency brake against one sandbox ballooning from a write loop.
+// The template weighs hundreds of kilobytes; honest poking around
+// will never accumulate that much.
 const MAX_DB_BYTES = 50 * 1024 * 1024;
 
 const demoDir = join(env.dataDir, 'demo');
@@ -51,7 +52,7 @@ interface Sandbox {
 const sandboxes = new Map<string, Sandbox>();
 
 export async function initDemo(): Promise<void> {
-  // Осиротевшие файлы прошлого запуска бесполезны: реестр живёт в памяти
+  // Orphaned files from the previous run are useless: the registry lives in memory
   rmSync(demoDir, { recursive: true, force: true });
   mkdirSync(sandboxesDir, { recursive: true });
 
@@ -59,7 +60,7 @@ export async function initDemo(): Promise<void> {
 
   setInterval(sweep, SWEEP_MS).unref();
   setInterval(() => {
-    buildTemplate().catch((err) => log.error('демо: пересборка шаблона не удалась', err));
+    buildTemplate().catch((err) => log.error('demo: template rebuild failed', err));
   }, TEMPLATE_REBUILD_MS).unref();
 
   log.block([
@@ -73,9 +74,9 @@ export async function initDemo(): Promise<void> {
 }
 
 /**
- * Шаблон строится во временный файл и подменяется атомарно: создание
- * песочницы в момент пересборки скопирует либо старый шаблон, либо новый —
- * но никогда полусобранный.
+ * The template is built into a temp file and swapped in atomically: a
+ * sandbox created mid-rebuild copies either the old template or the new
+ * one — never a half-built one.
  */
 async function buildTemplate(): Promise<void> {
   const tmp = `${templatePath}.new`;
@@ -88,26 +89,26 @@ async function buildTemplate(): Promise<void> {
       await seedDemo();
     });
   } finally {
-    // close() выкатывает WAL в основной файл — копия будет цельной
+    // close() flushes the WAL into the main file — the copy will be whole
     template.close();
   }
   renameSync(tmp, templatePath);
-  log.info('демо: шаблон собран');
+  log.info('demo: template built');
 }
 
 export function createSandbox(): Sandbox {
   if (sandboxes.size >= MAX_SANDBOXES) evictOldest();
 
-  // Идентификатор — фактически вторая часть авторизации, поэтому
-  // непредсказуемый. В пути файла участвует только сгенерированное здесь
-  // значение, кука посетителя ищется исключительно как ключ реестра.
+  // The identifier is effectively the second half of authorization, hence
+  // unpredictable. Only the value generated here goes into the file path;
+  // the visitor's cookie is looked up strictly as a registry key.
   const id = randomBytes(16).toString('base64url');
   const file = join(sandboxesDir, `${id}.db`);
   copyFileSync(templatePath, file);
 
   const sandbox: Sandbox = { id, db: openDatabase(file), file, lastSeen: Date.now() };
   sandboxes.set(id, sandbox);
-  log.info(`демо: песочница создана (${sandboxes.size} активных)`);
+  log.info(`demo: sandbox created (${sandboxes.size} active)`);
   return sandbox;
 }
 
@@ -125,7 +126,7 @@ export function destroySandbox(id: string): void {
   try {
     sandbox.db.close();
   } catch (err) {
-    log.warn('демо: база песочницы не закрылась', err);
+    log.warn('demo: sandbox database failed to close', err);
   }
   for (const suffix of ['', '-wal', '-shm']) {
     rmSync(`${sandbox.file}${suffix}`, { force: true });

--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -8,24 +8,24 @@ import { z } from 'zod';
 import { db, id, now, today } from '../db/index.js';
 import { paths } from '../env.js';
 
-/** Потолок на файл. Больше — это уже не заметка, а файловое хранилище. */
+/** The per-file ceiling. Beyond it this is no longer a note but file storage. */
 export const MAX_FILE_BYTES = 50 * 1024 * 1024;
 
-/** Бюджет хранилища: до него — предупреждаем в UI, после — отказываем. */
+/** The storage budget: below it — warn in the UI, above it — refuse. */
 const BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
 
 const IMAGE_MIME = /^image\/(png|jpeg|gif|webp|avif|heic|svg\+xml)$/;
 
 /*
-  Отдавать inline можно только растровые форматы. SVG — это документ со
-  скриптами: открытый напрямую по /api/attachments/:id, он исполнился бы
-  с origin хаба. CSP script-src 'self' это уже глушит, но защита не должна
-  держаться на одном слое. В <img> заметок SVG продолжает показываться —
-  картинкам заголовок Content-Disposition безразличен.
+  Only raster formats may be served inline. SVG is a document with
+  scripts: opened directly at /api/attachments/:id, it would execute
+  with the hub's origin. CSP script-src 'self' already mutes that, but
+  defense must not rest on a single layer. SVG keeps showing in note
+  <img> tags — images don't care about the Content-Disposition header.
 */
 const INLINE_MIME = /^image\/(png|jpeg|gif|webp|avif|heic)$/;
 
-/** MIME приходит от клиента: что не похоже на MIME — становится octet-stream. */
+/** MIME comes from the client: whatever doesn't look like MIME becomes octet-stream. */
 function safeMime(mime: string): string {
   return /^[\w.+-]{1,80}\/[\w.+-]{1,80}$/.test(mime) ? mime : 'application/octet-stream';
 }
@@ -42,16 +42,17 @@ interface AttachmentRow {
 }
 
 /**
- * Имя файла от человека не участвует в пути на диске никогда.
- * Файл кладётся под сгенерированным именем, а исходное имя живёт в базе —
- * иначе «../../» в имени увело бы запись куда угодно.
+ * A human-supplied filename never takes part in the on-disk path.
+ * The file is stored under a generated name while the original name
+ * lives in the database — otherwise "../../" in a name would steer
+ * the write anywhere.
  */
 function storageNameFor(originalName: string): string {
   const ext = extname(originalName).toLowerCase().replace(/[^.a-z0-9]/g, '');
   return `${id()}${ext.slice(0, 12)}`;
 }
 
-/** Заголовок для отдачи: имя может быть на любом языке. */
+/** The header for serving: the name may be in any language. */
 function contentDisposition(filename: string, inline: boolean): string {
   const ascii = filename.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '');
   return `${inline ? 'inline' : 'attachment'}; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(
@@ -59,7 +60,7 @@ function contentDisposition(filename: string, inline: boolean): string {
   )}`;
 }
 
-/** Вложение видно тем же, кому видна заметка, к которой оно приложено. */
+/** An attachment is visible to whoever can see the note it is attached to. */
 function loadVisible(attachmentId: string, userId: string): AttachmentRow | null {
   const row = db
     .prepare(
@@ -85,11 +86,12 @@ interface UploadedInfo {
 }
 
 /**
- * Приём файлов одним куском: либо сохранились все, либо ни один.
+ * Files are accepted as one piece: either all are saved, or none.
  *
- * Раньше превышение лимита на втором файле возвращало 413, но первый уже
- * лежал на диске и в базе — клиент видел ошибку, а половина вложений тихо
- * прикреплялась. Теперь при отказе откатываются и записи, и файлы.
+ * Exceeding the limit on the second file used to return a 413, but the
+ * first one already sat on disk and in the database — the client saw an
+ * error while half the attachments quietly attached. Now a refusal rolls
+ * back both the records and the files.
  */
 async function receiveFiles(
   req: FastifyRequest,
@@ -108,8 +110,9 @@ async function receiveFiles(
     for (const path of savedPaths) await unlink(path).catch(() => {});
   };
 
-  // Бюджет проверяется на входе: уже принятое не отзываем, но следующий
-  // запрос поверх переполненного хранилища получает отказ, а не диск до дна
+  // The budget is checked on entry: what's already accepted isn't recalled,
+  // but the next request atop an overflowing store gets a refusal instead
+  // of the disk drained to the bottom
   const { used } = db
     .prepare('SELECT coalesce(sum(size_bytes), 0) AS used FROM attachments')
     .get() as { used: number };
@@ -120,7 +123,7 @@ async function receiveFiles(
 
   for await (const part of req.files()) {
     const storageName = storageNameFor(part.filename);
-    // Папка месяца — по местным часам, как и всё остальное в приложении
+    // The month folder — by the local clock, like everything else in the app
     const month = today().slice(0, 7);
     const folder = join(paths.attachments, month);
     await mkdir(folder, { recursive: true });
@@ -128,7 +131,7 @@ async function receiveFiles(
 
     await pipeline(part.file, createWriteStream(fullPath));
 
-    // Превышение лимита multipart обрубает поток, а не бросает исключение
+    // Exceeding the multipart limit truncates the stream rather than throwing
     if (part.file.truncated) {
       await unlink(fullPath).catch(() => {});
       await rollback();
@@ -149,7 +152,7 @@ async function receiveFiles(
       part.filename,
       safeMime(part.mimetype),
       size,
-      // В базе только относительный путь: каталог данных может переехать
+      // Only the relative path goes in the database: the data directory may move
       join(month, storageName),
       target.note_id,
       target.transaction_id,
@@ -230,7 +233,7 @@ export async function registerAttachmentRoutes(app: FastifyInstance): Promise<vo
     if (!attachment) return reply.code(404).send({ error: 'Файл не найден' });
 
     const fullPath = resolve(paths.attachments, attachment.storage_path);
-    // Страховка от выхода за пределы каталога вложений
+    // Insurance against escaping the attachments directory
     if (!fullPath.startsWith(resolve(paths.attachments))) {
       return reply.code(400).send({ error: 'Некорректный путь' });
     }
@@ -245,7 +248,7 @@ export async function registerAttachmentRoutes(app: FastifyInstance): Promise<vo
     return reply
       .header('Content-Type', safeMime(attachment.mime))
       .header('Content-Disposition', contentDisposition(attachment.filename, inline))
-      // Содержимое по идентификатору неизменно, можно кэшировать надолго
+      // Content under an id never changes; safe to cache for a long time
       .header('Cache-Control', 'private, max-age=31536000, immutable')
       .send(createReadStream(fullPath));
   });
@@ -257,7 +260,7 @@ export async function registerAttachmentRoutes(app: FastifyInstance): Promise<vo
     if (!attachment) return reply.code(404).send({ error: 'Файл не найден' });
 
     db.prepare('DELETE FROM attachments WHERE id = ?').run(attachmentId);
-    // Запись удалена в любом случае; отсутствующий на диске файл не повод падать
+    // The record is deleted either way; a file missing from disk is no reason to crash
     await unlink(resolve(paths.attachments, attachment.storage_path)).catch(() => {});
 
     return { ok: true };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -15,25 +15,27 @@ import {
 } from '../lib/auth.js';
 
 /*
-  Тормоз на подбор пароля — в двух измерениях.
+  A brake on password guessing — in two dimensions.
 
-  По логину: пять неверных попыток запирают его на 15 минут, откуда бы
-  попытки ни шли. По адресу: двадцать неверных попыток с одного IP запирают
-  адрес — это ловит перебор по словарю логинов, где каждый логин пробуется
-  по разу и по-логинный счётчик не набирается. Порог по адресу выше,
-  чтобы семья за одним домашним NAT не заперла друг друга случайно.
+  Per login: five wrong attempts lock it for 15 minutes, wherever the
+  attempts come from. Per address: twenty wrong attempts from one IP lock
+  the address — this catches a dictionary sweep of logins, where each
+  login is tried once and the per-login counter never accumulates. The
+  address threshold is higher so a family behind one home NAT doesn't
+  lock each other out by accident.
 
-  Счётчики в памяти: перезапуск их сбрасывает, но снаружи сервер прикрыт
-  ещё и общим лимитом частоты, а на самом маршруте входа — жёстким
-  (см. rateLimit ниже), так что даже со сбросом темп перебора мизерный.
+  Counters live in memory: a restart resets them, but from outside the
+  server is also covered by the general rate limit, and the login route
+  has a strict one of its own (see rateLimit below), so even with resets
+  the guessing tempo is negligible.
 */
 const attempts = new Map<string, { count: number; until: number }>();
 const MAX_ATTEMPTS_LOGIN = 5;
 const MAX_ATTEMPTS_IP = 20;
 const LOCK_MS = 15 * 60_000;
 
-// Протухшие ключи раньше убирались только при повторном обращении к тому же
-// логину/IP — перебор уникальных ключей растил Map безгранично
+// Stale keys used to be removed only on a repeat hit of the same login/IP —
+// sweeping unique keys grew the Map without bound
 setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of attempts) {
@@ -69,30 +71,30 @@ const changeInput = z.object({
 });
 
 export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
-  /** Есть ли вообще пользователи — чтобы фронт знал, что показывать. */
+  /** Whether any users exist at all — so the frontend knows what to show. */
   app.get('/api/auth/state', () => {
-    // В демо ответ фиксированный: основная база пуста (жизнь идёт
-    // в песочницах), но экран первичной настройки показывать нельзя,
-    // а вход один — кнопка «Попробовать демо».
+    // In demo the answer is fixed: the main database is empty (life
+    // happens in sandboxes), but the initial setup screen must not be
+    // shown, and there is one way in — the "Try the demo" button.
     if (env.demoMode) return { initialized: true, google: false, demo: true };
     const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
     return {
       initialized: n > 0,
-      // Есть ли смысл показывать кнопку «Войти через Google»
+      // Whether showing the "Sign in with Google" button makes sense
       google: Boolean(env.googleClientId && env.googleClientSecret && env.publicUrl),
       demo: false,
     };
   });
 
-  // Жёсткий лимит частоты именно на входе, поверх общего: скрипту,
-  // подбирающему пароль, не даём даже стучаться быстро
+  // A strict rate limit specifically on login, on top of the general one:
+  // a password-guessing script doesn't even get to knock fast
   const loginRateLimit = {
     config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
   };
 
   app.post('/api/auth/login', loginRateLimit, async (req, reply) => {
-    // В демо входят только через песочницу: у посетителей нет паролей,
-    // а перебор по чужим учёткам публичному стенду ни к чему
+    // Demo is entered only through a sandbox: visitors have no passwords,
+    // and a public stand has no use for guessing at other people's accounts
     if (env.demoMode) {
       return reply.code(403).send({ error: 'Отключено в демо-режиме' });
     }
@@ -103,7 +105,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     const email = parsed.data.email.trim().toLowerCase();
 
     if (throttled(email, MAX_ATTEMPTS_LOGIN) || throttled(`ip:${req.ip}`, MAX_ATTEMPTS_IP)) {
-      log.warn(`вход заблокирован тормозом: ${email} с ${req.ip}`);
+      log.warn(`login blocked by the brake: ${email} from ${req.ip}`);
       return reply
         .code(429)
         .send({ error: 'Слишком много попыток. Попробуйте через 15 минут' });
@@ -115,30 +117,31 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       | { id: string; password_hash: string; password_login_disabled: number }
       | undefined;
 
-    // Сравнение выполняем даже когда пользователя нет: иначе по времени ответа
-    // видно, какие логины существуют.
+    // The comparison runs even when the user doesn't exist: otherwise
+    // response timing reveals which logins do.
     const hash = user?.password_hash ?? 'scrypt$32768$8$1$AAAAAAAAAAAAAAAAAAAAAA==$AAAA';
     const ok = await verifyPassword(parsed.data.password, hash);
 
-    // Отключённый парольный вход отвечает так же, как неверный пароль:
-    // снаружи не видно, у кого какой режим. Проверка после verifyPassword —
-    // чтобы и по времени ответа режим был неразличим.
+    // Disabled password login answers exactly like a wrong password:
+    // from outside nobody can tell who has which mode. The check comes
+    // after verifyPassword so the mode is indistinguishable by timing too.
     if (user && ok && user.password_login_disabled) {
-      log.warn(`вход по паролю при отключённом пароле: ${email} с ${req.ip}`);
+      log.warn(`password login attempt while password is disabled: ${email} from ${req.ip}`);
       return reply.code(401).send({ error: 'Неверный логин или пароль' });
     }
 
     if (!user || !ok) {
       registerFailure(email);
       registerFailure(`ip:${req.ip}`);
-      log.warn(`неверный вход: ${email} с ${req.ip}`);
+      log.warn(`failed login: ${email} from ${req.ip}`);
       return reply.code(401).send({ error: 'Неверный логин или пароль' });
     }
 
     attempts.delete(email);
-    // След входа с адресом: если появится что расследовать — будет от чего
-    // оттолкнуться. На уровне warn и выше не шумит, виден начиная с info.
-    log.info(`вход: ${email} с ${req.ip}`);
+    // A login trace with the address: if something ever needs
+    // investigating, there is a starting point. Silent at warn and above,
+    // visible from info onward.
+    log.info(`login: ${email} from ${req.ip}`);
     db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?').run(now(), user.id);
 
     setSessionCookie(reply, createSession(user.id, req.headers['user-agent']));
@@ -153,8 +156,8 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.post('/api/auth/logout', async (req, reply) => {
-    // В демо выход хоронит и песочницу: возвращаться в неё некому,
-    // а свежий заход по кнопке получит чистую копию шаблона
+    // In demo, logout buries the sandbox too: nobody is coming back to it,
+    // and a fresh visit via the button gets a clean copy of the template
     if (env.demoMode) {
       const { SANDBOX_COOKIE, destroySandbox } = await import('../lib/sandbox.js');
       const sandboxId = req.cookies[SANDBOX_COOKIE];
@@ -170,10 +173,11 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
   });
 
   /*
-    Вход в демо. Создаёт посетителю личную песочницу (копию шаблонной базы)
-    и сессию администратора в ней — без логина и пароля: спрашивать пароль
-    у одноразовой песочницы не у кого и незачем. Лимит частоты жёсткий:
-    каждая песочница — файл на диске, и щедрость здесь была бы дырой.
+    Demo login. Creates the visitor a personal sandbox (a copy of the
+    template database) and an admin session inside it — no login or
+    password: a throwaway sandbox has nobody to ask a password of and no
+    reason to. The rate limit is strict: every sandbox is a file on disk,
+    and generosity here would be a hole.
   */
   if (env.demoMode) {
     const { SANDBOX_COOKIE, createSandbox } = await import('../lib/sandbox.js');
@@ -195,10 +199,10 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
             sameSite: 'lax',
             secure: env.secureCookies,
             path: '/',
-            // Дольше TTL песочницы: срок жизни определяет сервер, не кука
+            // Longer than the sandbox TTL: the server decides the lifetime, not the cookie
             maxAge: 24 * 60 * 60,
           });
-          log.info(`демо: вход в песочницу с ${req.ip}`);
+          log.info(`demo: sandbox login from ${req.ip}`);
 
           return db
             .prepare(
@@ -212,18 +216,19 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     );
   }
 
-  // Токен уже проверен в authenticate, пользователь лежит в запросе.
+  // The token was already checked in authenticate; the user sits on the request.
   app.get('/api/auth/me', (req) => req.user);
 
   /*
-    Переключатель парольного входа. Два инварианта, оба серверные:
+    The password-login switch. Two invariants, both server-side:
 
-    — отключить пароль можно только при привязанном Google, иначе учётка
-      замуровывается;
-    — администратору отключать пароль нельзя никогда. Его пароль — аварийный
-      вход: если Google недоступен, привязка сломалась или протух секрет,
-      админ входит по паролю и чинит. SSO-only без запасного выхода —
-      классический способ потерять доступ ко всему разом.
+    — the password can be disabled only with Google linked, otherwise the
+      account bricks itself;
+    — the admin may never disable the password. Their password is the
+      emergency entrance: if Google is down, the link broke or the secret
+      expired, the admin logs in by password and fixes things. SSO-only
+      with no back door is the classic way to lose access to everything
+      at once.
   */
   app.post('/api/auth/password-login', (req, reply) => {
     const parsed = z.object({ enabled: z.boolean() }).safeParse(req.body);
@@ -245,12 +250,12 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       parsed.data.enabled ? 0 : 1,
       user.id,
     );
-    log.info(`вход по паролю ${parsed.data.enabled ? 'включён' : 'отключён'}: ${user.email}`);
+    log.info(`password login ${parsed.data.enabled ? 'enabled' : 'disabled'}: ${user.email}`);
     return { ok: true };
   });
 
-  // Отвязка Google. Зеркальный инвариант: нельзя отвязать единственный
-  // оставшийся способ входа.
+  // Google unlink. The mirror invariant: the last remaining way in
+  // cannot be unlinked.
   app.post('/api/auth/google/unlink', (req, reply) => {
     const user = req.user!;
     if (user.password_login_disabled) {
@@ -259,7 +264,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
         .send({ error: 'Сначала включите вход по паролю — иначе входить будет нечем' });
     }
     db.prepare('UPDATE users SET google_sub = NULL WHERE id = ?').run(user.id);
-    log.info(`google отвязан: ${user.email}`);
+    log.info(`google unlinked: ${user.email}`);
     return { ok: true };
   });
 
@@ -294,7 +299,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
         WHERE id = ?`,
     ).run(await hashPassword(parsed.data.new_password), now(), session.id);
 
-    // Смена пароля разлогинивает все устройства, включая текущее
+    // A password change signs out every device, the current one included
     destroyAllSessions(session.id);
     clearSessionCookie(reply);
 

--- a/server/src/routes/budgets.ts
+++ b/server/src/routes/budgets.ts
@@ -15,7 +15,7 @@ function visibleAccountIds(userId: string): Set<string> {
   return new Set(rows.map((r) => r.id));
 }
 
-// ── Регулярные операции ───────────────────────────────────────────────────
+// ── Recurring transactions ──────────────────────────────────────────────────
 
 interface RecurringRow {
   id: string;
@@ -48,12 +48,12 @@ export interface DueItem {
 }
 
 /**
- * Экземпляры правил, которым пора наступить, но которых ещё нет.
+ * Rule instances whose time has come but which don't exist yet.
  *
- * Считается вычитанием: все даты правила до сегодня минус уже созданные
- * операции минус пропущенные вручную. Курсор «следующая дата» не храним —
- * он разъезжается после любой правки правила задним числом, а вычитание
- * всегда даёт один и тот же ответ.
+ * Computed by subtraction: all rule dates up to today minus already
+ * created transactions minus manual skips. No "next date" cursor is
+ * stored — it drifts after any backdated edit of the rule, while
+ * subtraction always gives the same answer.
  */
 export function dueOccurrences(userId: string, horizon = today()): DueItem[] {
   const rules = db
@@ -102,7 +102,7 @@ export function dueOccurrences(userId: string, horizon = today()): DueItem[] {
   return due.sort((a, b) => a.occurred_on.localeCompare(b.occurred_on));
 }
 
-/** Создаёт операцию из правила на указанную дату. Повторный вызов безвреден. */
+/** Creates a transaction from a rule for the given date. Calling again is harmless. */
 function materialize(ruleId: string, date: string, userId: string | null): string | null {
   const rule = db.prepare('SELECT * FROM recurring_transactions WHERE id = ?').get(ruleId) as
     | RecurringRow
@@ -138,8 +138,8 @@ function materialize(ruleId: string, date: string, userId: string | null): strin
 }
 
 /**
- * Создаёт всё, что помечено «создавать самостоятельно».
- * Вызывается при старте сервера и при запросе списка ожидающих.
+ * Creates everything marked "create automatically".
+ * Called at server startup and when the pending list is requested.
  */
 export function runAutoCreate(): number {
   const rules = db
@@ -185,7 +185,7 @@ export function runAutoCreate(): number {
   return created;
 }
 
-// ── Схемы ─────────────────────────────────────────────────────────────────
+// ── Schemas ───────────────────────────────────────────────────────────────
 
 const recurringInput = z.object({
   title: z.string().min(1, 'Укажите название').max(200),
@@ -204,12 +204,12 @@ const recurringInput = z.object({
 });
 
 export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> {
-  // ── Лимиты ──────────────────────────────────────────────────────────────
+  // ── Budgets ─────────────────────────────────────────────────────────────
 
   /**
-   * Лимиты на месяц: постоянный, если на этот месяц нет исключения.
-   * Вместе с потраченным и остатком — считать это на клиенте значило бы
-   * повторять там правило выбора лимита.
+   * Monthly limits: the standing one unless this month has an exception.
+   * Together with spent and remaining — computing this on the client
+   * would mean duplicating the limit-selection rule there.
    */
   app.get('/api/budgets', (req, reply) => {
     const parsed = z.object({ month: z.string().regex(MONTH) }).safeParse(req.query);
@@ -221,10 +221,10 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
     const to = `${month}-31`;
 
     /*
-      Выбираем по одному лимиту на пару «категория + валюта»: исключение
-      на запрошенный месяц, иначе постоянный. Исключения других месяцев
-      в выборку не попадают вовсе — иначе лимит на декабрь отменял бы
-      постоянный лимит во все остальные месяцы.
+      One limit is picked per "category + currency" pair: the exception
+      for the requested month, otherwise the standing one. Other months'
+      exceptions don't enter the selection at all — otherwise a December
+      limit would cancel the standing limit in every other month.
     */
     return db
       .prepare(
@@ -242,8 +242,8 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
                 coalesce((
                   SELECT sum(t.amount) FROM transactions t
                     JOIN accounts a ON a.id = t.account_id
-                   -- Лимит на родителя считает и траты подкатегорий:
-                   -- «Автотраты» — это топливо, парковка и сервис вместе
+                   -- A parent's limit counts subcategory spending too:
+                   -- "Car costs" means fuel, parking and service combined
                    WHERE t.category_id IN (
                            SELECT id FROM categories WHERE id = c.id OR parent_id = c.id
                          )
@@ -299,7 +299,7 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
     return { ok: true };
   });
 
-  // ── Регулярные операции ─────────────────────────────────────────────────
+  // ── Recurring transactions ──────────────────────────────────────────────
 
   app.get('/api/recurring', (req) =>
     db
@@ -412,13 +412,13 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
 
   app.delete('/api/recurring/:id', (req, reply) => {
     const { id: ruleId } = z.object({ id: z.string().uuid() }).parse(req.params);
-    // Созданные операции остаются в истории: они уже случились
+    // Created transactions stay in history: they already happened
     const result = db.prepare('DELETE FROM recurring_transactions WHERE id = ?').run(ruleId);
     if (result.changes === 0) return reply.code(404).send({ error: 'Правило не найдено' });
     return { ok: true };
   });
 
-  /** Что пора подтвердить или что уже создалось само. */
+  /** What is due for confirmation, or has already created itself. */
   app.get('/api/recurring/due', (req) => {
     runAutoCreate();
     return dueOccurrences(req.user?.id ?? '');
@@ -429,8 +429,8 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
     const parsed = z
       .object({
         occurred_on: z.string().regex(DATE),
-        // Фактическая сумма может отличаться от плановой: зарплата с премией,
-        // аренда с изменившимся счётом за воду
+        // The actual amount may differ from the planned one: a salary with
+        // a bonus, rent with a changed water bill
         amount: z.number().int().positive().optional(),
       })
       .safeParse(req.body);

--- a/server/src/routes/calendar.ts
+++ b/server/src/routes/calendar.ts
@@ -7,17 +7,16 @@ const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
 
 /**
- * Время хранится как местное настенное, без перевода в UTC.
+ * Time is stored as local wall-clock time, with no conversion to UTC.
  *
- * Так делает большинство календарей для событий с фиксированным временем:
- * «каждый вторник в 10:00» должно оставаться в 10:00 и после перевода часов.
- * Хранение в UTC заставило бы пересчитывать каждый экземпляр серии через
- * правила летнего времени — источник тонких ошибок на ровном месте.
- * Дом находится в одном часовом поясе, а Белград и Аликанте — это к тому же
- * один и тот же пояс, так что переезд ничего не меняет.
+ * Most calendars do this for fixed-time events: "every Tuesday at 10:00"
+ * must stay at 10:00 after the clocks change. Storing UTC would force
+ * recomputing every instance of a series through DST rules — a source of
+ * subtle bugs out of nowhere. The home lives in one time zone, and
+ * Belgrade and Alicante happen to share it, so the move changes nothing.
  *
- * Событие на весь день:  starts_at = 'ГГГГ-ММ-ДД'
- * Событие со временем:   starts_at = 'ГГГГ-ММ-ДДTЧЧ:ММ'
+ * All-day event:    starts_at = 'YYYY-MM-DD'
+ * Event with time:  starts_at = 'YYYY-MM-DDTHH:MM'
  */
 const eventBase = z.object({
   calendar_id: z.string().uuid(),
@@ -42,8 +41,8 @@ const eventInput = eventBase.refine(endsAfterStart, {
   path: ['ends_at'],
 });
 
-// Частичное изменение проверяет ту же инвариантность, но только когда
-// в запросе пришли обе границы
+// A partial edit checks the same invariant, but only when both bounds
+// arrived in the request
 const eventPatch = eventBase.partial().refine(endsAfterStart, {
   message: 'Конец события раньше начала',
   path: ['ends_at'],
@@ -67,7 +66,7 @@ interface EventRow {
   project_title: string | null;
 }
 
-/** Календарь виден, если он общий или принадлежит спрашивающему. */
+/** A calendar is visible if it is shared or belongs to the asker. */
 const CALENDAR_VISIBLE = '(c.shared = 1 OR c.owner_id = ?)';
 
 function shiftDays(date: string, days: number): string {
@@ -104,9 +103,9 @@ export interface Occurrence {
 }
 
 /**
- * Развёрнутые экземпляры всех видимых событий в диапазоне дат.
- * Используется и календарём, и дашбордом — чтобы «сегодня» считалось
- * ровно так же, как показывается в сетке.
+ * Expanded instances of all visible events within a date range.
+ * Used by both the calendar and the dashboard — so that "today" is
+ * computed exactly as it is shown in the grid.
  */
 export function listOccurrences(userId: string, from: string, to: string): Occurrence[] {
   const events = db
@@ -137,7 +136,7 @@ export function listOccurrences(userId: string, from: string, to: string): Occur
     const anchor = event.starts_at.slice(0, 10);
     const span = daysBetween(anchor, event.ends_at.slice(0, 10));
 
-    // Длинное событие могло начаться до окна — отступаем на его длительность
+    // A long event may have started before the window — step back by its duration
     const searchFrom = shiftDays(from, -Math.max(span, 0));
     const dates = expandOccurrences(anchor, event.recurrence_rule, searchFrom, to);
 
@@ -181,7 +180,7 @@ export function listOccurrences(userId: string, from: string, to: string): Occur
   return result.sort((a, b) => a.starts_at.localeCompare(b.starts_at));
 }
 
-/** События, о которых пора предупредить именно сегодня. */
+/** Events whose reminder is due precisely today. */
 export function remindersFor(userId: string, today: string): Occurrence[] {
   return listOccurrences(userId, today, shiftDays(today, 365)).filter(
     (o) =>
@@ -192,7 +191,7 @@ export function remindersFor(userId: string, today: string): Occurrence[] {
 }
 
 export async function registerCalendarRoutes(app: FastifyInstance): Promise<void> {
-  // ── Календари ───────────────────────────────────────────────────────────
+  // ── Calendars ───────────────────────────────────────────────────────────
 
   app.get('/api/calendars', (req) =>
     db
@@ -247,7 +246,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
       .get(calendarId, req.user?.id ?? '') as { owner_id: string | null } | undefined;
     if (!calendar) return reply.code(404).send({ error: 'Календарь не найден' });
 
-    // Личным календарём распоряжается только владелец
+    // A personal calendar is managed by its owner alone
     if (calendar.owner_id && calendar.owner_id !== req.user?.id) {
       return reply.code(403).send({ error: 'Этот календарь принадлежит другому человеку' });
     }
@@ -284,7 +283,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
     return { ok: true };
   });
 
-  // ── События ─────────────────────────────────────────────────────────────
+  // ── Events ──────────────────────────────────────────────────────────────
 
   app.get('/api/events', (req, reply) => {
     const parsed = z
@@ -299,7 +298,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
     return listOccurrences(req.user?.id ?? '', parsed.data.from, parsed.data.to);
   });
 
-  /** Полное событие серии — правило повтора и прочее, чего нет в экземпляре. */
+  /** The full series event — the recurrence rule and the rest an instance lacks. */
   app.get('/api/events/:id', (req, reply) => {
     const { id: eventId } = z.object({ id: z.string().uuid() }).parse(req.params);
     const event = db
@@ -427,7 +426,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
         }
       }
 
-      // Сдвиг серии обнуляет исключения: старые даты больше ни к чему не относятся
+      // Shifting the series resets exceptions: the old dates no longer refer to anything
       if (d.starts_at !== undefined || d.recurrence_rule !== undefined) {
         db.prepare('DELETE FROM event_exceptions WHERE event_id = ?').run(eventId);
       }
@@ -451,7 +450,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
     return { ok: true };
   });
 
-  /** Отменить один экземпляр серии, не трогая саму серию. */
+  /** Cancel a single instance of a series without touching the series itself. */
   app.delete('/api/events/:id/occurrences/:date', (req, reply) => {
     const { id: eventId, date } = z
       .object({ id: z.string().uuid(), date: z.string().regex(DATE) })

--- a/server/src/routes/google.ts
+++ b/server/src/routes/google.ts
@@ -6,46 +6,49 @@ import { createSession, setSessionCookie } from '../lib/auth.js';
 import { log } from '../lib/log.js';
 
 /*
-  Вход через Google — обычный OIDC authorization code flow с PKCE,
-  руками через два fetch: тяжёлые SDK здесь не нужны.
+  Sign-in with Google — a plain OIDC authorization code flow with PKCE,
+  by hand via two fetches: heavy SDKs are not needed here.
 
-  Правила, которые держит этот модуль:
+  The rules this module upholds:
 
-  — Учётки по Google НЕ создаются. Вход пускает только тех, у кого
-    google_sub уже привязан; любой другой гугл-аккаунт получает отказ.
-    Хаб семейный, состав известен, самозапись не предусмотрена.
+  — Accounts are NOT created via Google. Login admits only those whose
+    google_sub is already linked; any other Google account is refused.
+    The hub is a family one, the roster is known, self-signup is not
+    a thing.
 
-  — Привязка — только явным действием из настроек, из-под живой сессии.
-    Никакой привязки «по совпадению email»: почту в Google можно сменить,
-    а у местных учёток она вида user@hub.local и не гуглится вовсе.
+  — Linking happens only by explicit action from settings, under a live
+    session. No linking "by matching email": the email in Google can be
+    changed, and local accounts have ones like user@hub.local that don't
+    google at all.
 
-  — Идентификация по claim `sub` — постоянному ID гугл-аккаунта.
+  — Identification is by the `sub` claim — the Google account's
+    permanent ID.
 */
 
 const AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const USERINFO_URL = 'https://openidconnect.googleapis.com/v1/userinfo';
 
-/** Сколько живёт начатый, но не завершённый заход через Google. */
+/** How long a started but unfinished Google sign-in lives. */
 const STATE_TTL_MS = 10 * 60_000;
 
 /*
-  Кука привязывает state к браузеру, который начал флоу. Без неё чужой
-  callback-URL, подсунутый жертве, тихо завершал бы флоу атакующего в её
-  браузере (login CSRF). Теперь возврат от Google принимается только в том
-  браузере, где вход начинался.
+  The cookie ties the state to the browser that started the flow. Without
+  it, a foreign callback URL slipped to the victim would quietly complete
+  the attacker's flow in her browser (login CSRF). Now the return from
+  Google is accepted only in the browser where the sign-in began.
 */
 const OAUTH_COOKIE = 'hub_oauth';
 
 interface PendingState {
   verifier: string;
   mode: 'login' | 'link';
-  /** Для привязки — кому привязываем. */
+  /** For linking — who we are linking to. */
   userId?: string;
   expires: number;
 }
 
-// В памяти: процесс один, а незавершённый флоу и должен умирать с рестартом
+// In memory: there is one process, and an unfinished flow should die with a restart anyway
 const pending = new Map<string, PendingState>();
 
 function prunePending(): void {
@@ -63,7 +66,7 @@ function redirectUri(): string {
   return `${env.publicUrl}/api/auth/google/callback`;
 }
 
-/** PKCE: verifier остаётся у нас, challenge уезжает в Google. */
+/** PKCE: the verifier stays with us, the challenge travels to Google. */
 function pkcePair(): { verifier: string; challenge: string } {
   const verifier = randomBytes(32).toString('base64url');
   const challenge = createHash('sha256').update(verifier).digest('base64url');
@@ -78,7 +81,7 @@ function startFlow(reply: FastifyReply, mode: 'login' | 'link', userId?: string)
 
   reply.setCookie(OAUTH_COOKIE, state, {
     httpOnly: true,
-    sameSite: 'lax', // Lax пропускает куку на top-level редиректе от Google
+    sameSite: 'lax', // Lax lets the cookie through on the top-level redirect from Google
     secure: env.secureCookies,
     path: '/api/auth/google',
     maxAge: STATE_TTL_MS / 1000,
@@ -92,14 +95,14 @@ function startFlow(reply: FastifyReply, mode: 'login' | 'link', userId?: string)
   url.searchParams.set('state', state);
   url.searchParams.set('code_challenge', challenge);
   url.searchParams.set('code_challenge_method', 'S256');
-  // Всегда показывать выбор аккаунта: в семье на одном устройстве
-  // может быть несколько гугл-аккаунтов
+  // Always show the account chooser: a family device may hold
+  // several Google accounts
   url.searchParams.set('prompt', 'select_account');
 
   void reply.redirect(url.toString());
 }
 
-/** Обмен кода на токен и получение sub. Ошибки — наружу исключением. */
+/** Exchange the code for a token and fetch the sub. Errors escape as exceptions. */
 async function fetchGoogleSub(code: string, verifier: string): Promise<{ sub: string; email: string | null }> {
   const tokenRes = await fetch(TOKEN_URL, {
     method: 'POST',
@@ -117,7 +120,7 @@ async function fetchGoogleSub(code: string, verifier: string): Promise<{ sub: st
     throw new Error(`Google token endpoint: ${tokenRes.status} ${await tokenRes.text()}`);
   }
   const token = (await tokenRes.json()) as { access_token?: string };
-  if (!token.access_token) throw new Error('Google не вернул access_token');
+  if (!token.access_token) throw new Error('Google returned no access_token');
 
   const infoRes = await fetch(USERINFO_URL, {
     headers: { Authorization: `Bearer ${token.access_token}` },
@@ -126,12 +129,12 @@ async function fetchGoogleSub(code: string, verifier: string): Promise<{ sub: st
     throw new Error(`Google userinfo: ${infoRes.status} ${await infoRes.text()}`);
   }
   const info = (await infoRes.json()) as { sub?: string; email?: string };
-  if (!info.sub) throw new Error('Google не вернул sub');
+  if (!info.sub) throw new Error('Google returned no sub');
   return { sub: info.sub, email: info.email ?? null };
 }
 
 export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> {
-  // Начало входа. Публичный маршрут: сессии ещё нет.
+  // Login start. A public route: there is no session yet.
   app.get('/api/auth/google/start', (req, reply) => {
     if (!configured()) {
       return reply.code(501).send({ error: 'Вход через Google не настроен' });
@@ -139,7 +142,7 @@ export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> 
     return startFlow(reply, 'login');
   });
 
-  // Начало привязки. Закрыт общей аутентификацией: без сессии сюда не дойти.
+  // Linking start. Closed by the general authentication: no session, no entry.
   app.get('/api/auth/google/link', (req, reply) => {
     if (!configured()) {
       return reply.code(501).send({ error: 'Вход через Google не настроен' });
@@ -147,24 +150,24 @@ export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> 
     return startFlow(reply, 'link', req.user?.id);
   });
 
-  // Возврат от Google. Публичный маршрут; свои и чужие state различаем сами.
+  // The return from Google. A public route; we tell our states from foreign ones ourselves.
   app.get('/api/auth/google/callback', async (req, reply) => {
     const q = req.query as Record<string, string | undefined>;
 
-    // Пользователь передумал на экране Google — не ошибка, просто назад
+    // The user changed their mind on the Google screen — not an error, just go back
     if (q.error) {
       return reply.redirect(q.error === 'access_denied' ? '/' : '/?google=error');
     }
 
     prunePending();
     const state = q.state ? pending.get(q.state) : undefined;
-    // state должен совпасть с кукой, поставленной на старте флоу:
-    // возврат принимается только в браузере, который вход начинал
+    // The state must match the cookie set at flow start: the return is
+    // accepted only in the browser that began the sign-in
     if (!state || !q.code || req.cookies[OAUTH_COOKIE] !== q.state) {
-      // Чужой, протухший или повторно использованный state
+      // A foreign, expired or reused state
       return reply.redirect('/?google=error');
     }
-    pending.delete(q.state!); // одноразовый
+    pending.delete(q.state!); // single-use
     reply.clearCookie(OAUTH_COOKIE, { path: '/api/auth/google' });
 
     let sub: string;
@@ -172,7 +175,7 @@ export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> 
     try {
       ({ sub, email } = await fetchGoogleSub(q.code, state.verifier));
     } catch (err) {
-      log.error('обмен кода Google не удался', err);
+      log.error('Google code exchange failed', err);
       return reply.redirect('/?google=error');
     }
 
@@ -183,12 +186,12 @@ export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> 
         .prepare('SELECT id FROM users WHERE google_sub = ? AND id != ?')
         .get(sub, state.userId);
       if (taken) {
-        // Один гугл-аккаунт — одна учётка
+        // One Google account — one user account
         return reply.redirect('/settings?google=taken');
       }
 
       db.prepare('UPDATE users SET google_sub = ? WHERE id = ?').run(sub, state.userId);
-      log.info(`google привязан: пользователь ${state.userId}, ${email ?? 'email скрыт'} с ${req.ip}`);
+      log.info(`google linked: user ${state.userId}, ${email ?? 'email hidden'} from ${req.ip}`);
       return reply.redirect('/settings?google=linked');
     }
 
@@ -198,13 +201,13 @@ export async function registerGoogleRoutes(app: FastifyInstance): Promise<void> 
       .get(sub) as { id: string; email: string } | undefined;
 
     if (!user) {
-      // Валидный гугл-аккаунт, но не наш. Учётку не создаём — отказ.
-      log.warn(`вход google отклонён: ${email ?? sub} не привязан, с ${req.ip}`);
+      // A valid Google account, but not ours. No account is created — refuse.
+      log.warn(`google login refused: ${email ?? sub} is not linked, from ${req.ip}`);
       return reply.redirect('/?google=not_linked');
     }
 
     setSessionCookie(reply, createSession(user.id, req.headers['user-agent']));
-    log.info(`вход google: ${user.email} с ${req.ip}`);
+    log.info(`google login: ${user.email} from ${req.ip}`);
     return reply.redirect('/');
   });
 }

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -4,10 +4,11 @@ import { db, now, today as localToday } from '../db/index.js';
 import { listOccurrences, remindersFor } from './calendar.js';
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
-  // Наружу — только факт жизни. Версия и прочие подробности публичному
-  // интернету ни к чему: чем меньше сканер узнаёт бесплатно, тем лучше.
-  // Запрос к базе — чтобы «жив» означало «жив вместе с базой», а не
-  // «процесс существует»: контейнер с умершим SQLite не должен быть healthy.
+  // Only the fact of life goes outside. The version and other details are
+  // of no use to the public internet: the less a scanner learns for free,
+  // the better. The database query is so "alive" means "alive along with
+  // the database", not "the process exists": a container with a dead
+  // SQLite must not be healthy.
   app.get('/api/health', (_req, reply) => {
     try {
       db.prepare('SELECT 1').get();
@@ -17,7 +18,7 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     }
   });
 
-  // ── Настройки (в т.ч. виджеты дашборда) ────────────────────────────────
+  // ── Settings (dashboard widgets included) ──────────────────────────────
 
   app.get('/api/settings', () => {
     const rows = db.prepare('SELECT key, value FROM settings').all() as {
@@ -28,10 +29,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.patch('/api/settings', (req, reply) => {
-    // Ключи и значения ограничены по форме и длине: раньше запись была
-    // безразмерной, и это был самый дешёвый способ раздуть базу из-под
-    // любой учётки. Настоящим настройкам (подписи табло, валюта) хватает
-    // с большим запасом.
+    // Keys and values are bounded in shape and length: writes used to be
+    // unbounded, and that was the cheapest way to bloat the database from
+    // any account. Real settings (dashboard labels, currency) fit with
+    // plenty of headroom.
     const parsed = z
       .record(
         z.string().max(64).regex(/^[a-zA-Z0-9._-]+$/, 'Некорректный ключ настройки'),
@@ -42,8 +43,8 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     if (!parsed.success) {
       return reply.code(400).send({ error: 'Настройки должны быть парами строк' });
     }
-    // Потолок на общее число ключей — та же защита с другого конца.
-    // Считаются только новые ключи: обновление существующих не растит базу.
+    // A ceiling on the total key count — the same protection from the other
+    // end. Only new keys count: updating existing ones doesn't grow the base.
     const keys = Object.keys(parsed.data);
     if (keys.length === 0) return { ok: true };
     const { n } = db.prepare('SELECT count(*) AS n FROM settings').get() as { n: number };
@@ -66,16 +67,17 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  // ── Общий поиск ─────────────────────────────────────────────────────────
+  // ── Global search ───────────────────────────────────────────────────────
 
   /**
-   * Ищем по всему пространству: заметки, задачи, проекты, события, вложения.
+   * Searches the whole space: notes, tasks, projects, events, attachments.
    *
-   * Заметки, задачи и проекты идут через полнотекстовый индекс FTS5 —
-   * там нужен поиск по телу заметки, а это может быть десяток тысяч знаков.
-   * События и вложения ищутся прямым перебором с ci_contains: их немного,
-   * а поддерживать триггеры индекса для сущности, чья видимость зависит от
-   * настроек календаря, — источник рассинхронизации на ровном месте.
+   * Notes, tasks and projects go through the FTS5 full-text index —
+   * note bodies need searching there, and that can be tens of thousands
+   * of characters. Events and attachments are scanned directly with
+   * ci_contains: there are few of them, and maintaining index triggers
+   * for an entity whose visibility depends on calendar settings is a
+   * desync source out of nowhere.
    */
   app.get('/api/search', (req, reply) => {
     const { q } = z.object({ q: z.string() }).parse(req.query);
@@ -233,10 +235,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     };
   });
 
-  // ── Дашборд ────────────────────────────────────────────────────────────
+  // ── Dashboard ──────────────────────────────────────────────────────────
 
   app.get('/api/dashboard', (req) => {
-    // По местным часам: по UTC «сегодня» после полуночи ещё вчера
+    // By the local clock: in UTC "today" is still yesterday after midnight
     const today = localToday();
 
     const dueToday = db

--- a/server/src/routes/money.ts
+++ b/server/src/routes/money.ts
@@ -17,9 +17,9 @@ function plural(n: number, one: string, few: string, many: string): string {
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
- * Счёт виден, если он общий или принадлежит спрашивающему.
- * Дальше на этом правиле держится вся приватность денег: у операции
- * отдельного признака приватности нет — она наследует его от счёта.
+ * An account is visible if it is shared or belongs to the asker.
+ * All money privacy rests on this rule from here on: a transaction has
+ * no privacy flag of its own — it inherits it from the account.
  */
 const ACCOUNT_VISIBLE = '(a.shared = 1 OR a.owner_id = ?)';
 
@@ -42,9 +42,9 @@ const categoryInput = z.object({
 });
 
 /**
- * Родитель обязан быть существующей категорией того же вида и сам быть
- * верхнего уровня — глубже одного уровня иерархия не растёт.
- * Возвращает текст ошибки или null, если всё в порядке.
+ * The parent must be an existing category of the same kind and itself be
+ * top-level — the hierarchy never grows deeper than one level.
+ * Returns the error text, or null if all is well.
  */
 function parentProblem(parentId: string, kind: string): string | null {
   const parent = db
@@ -114,11 +114,11 @@ function visibleAccountIds(userId: string): Set<string> {
 }
 
 export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
-  // ── Счета ───────────────────────────────────────────────────────────────
+  // ── Accounts ────────────────────────────────────────────────────────────
 
   /**
-   * Остаток считается, а не хранится: начальный плюс движения.
-   * Хранимый баланс разъезжается с историей после любой правки задним числом.
+   * The balance is computed, not stored: opening balance plus movements.
+   * A stored balance drifts from history after any backdated edit.
    */
   app.get('/api/accounts', (req) => {
     const { archived } = z
@@ -161,16 +161,17 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     })[];
 
     /**
-     * Остаток на момент сверки — для расхождения. Сравнивать актуал из банка
-     * с текущим остатком нельзя: каждая операция после сверки сдвигала бы
-     * расхождение на свою сумму, и счёт приходилось бы сверять заново после
-     * каждой траты.
+     * The balance as of reconciliation — for the discrepancy. Comparing the
+     * bank's actual against the current balance won't do: every transaction
+     * after the reconciliation would shift the discrepancy by its amount,
+     * and the account would need re-reconciling after every purchase.
      *
-     * «На момент сверки» — это операции более ранних дат плюс операции дня
-     * сверки, введённые до неё (у дат нет времени, различаем по created_at).
-     * Обе величины считаются, а не хранятся: пропущенная трата, вписанная
-     * задним числом, пересчитает остаток на момент сверки и закроет
-     * расхождение — ровно тот рабочий процесс, ради которого сверка нужна.
+     * "As of reconciliation" means transactions on earlier dates plus
+     * same-day ones entered before it (dates carry no time, we tell them
+     * apart by created_at). Both quantities are computed, not stored:
+     * a missed expense entered retroactively recomputes the balance as of
+     * reconciliation and closes the discrepancy — exactly the workflow
+     * reconciliation exists for.
      */
     const checkedBalance = db.prepare(
       `SELECT
@@ -246,7 +247,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     }
 
     const d = parsed.data;
-    // Смена валюты у счёта с операциями превратила бы историю в кашу
+    // Changing the currency of an account with transactions would turn history into mush
     if (d.currency && d.currency !== account.currency) {
       const used = (
         db
@@ -317,7 +318,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  /** Сверка с банком: фактический остаток и расхождение. */
+  /** Reconciliation against the bank: the actual balance and the discrepancy. */
   app.post('/api/accounts/:id/reconcile', (req, reply) => {
     const { id: accountId } = z.object({ id: z.string().uuid() }).parse(req.params);
     const parsed = z
@@ -334,8 +335,9 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
       .get(accountId, req.user?.id ?? '');
     if (!visible) return reply.code(404).send({ error: 'Счёт не найден' });
 
-    // Повторная сверка в тот же день обновляет предыдущую, а не плодит
-    // двойников: важен фактический остаток на дату, а не история попыток
+    // A repeat reconciliation on the same day updates the previous one
+    // instead of spawning twins: what matters is the actual balance on
+    // the date, not the history of attempts
     db.prepare(
       `INSERT INTO reconciliations (id, account_id, checked_on, actual_balance, note, created_by)
        VALUES (?, ?, ?, ?, ?, ?)
@@ -355,7 +357,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  // ── Категории ───────────────────────────────────────────────────────────
+  // ── Categories ──────────────────────────────────────────────────────────
 
   app.get('/api/categories', (req) => {
     const { kind } = z
@@ -443,8 +445,8 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
       }
     ).n;
     if (used > 0) {
-      // Категорию с историей не удаляем, а прячем: иначе прошлые операции
-      // потеряют разметку и отчёты за прошлые месяцы изменятся
+      // A category with history is hidden, not deleted: otherwise past
+      // transactions lose their labeling and past months' reports change
       db.prepare('UPDATE categories SET archived_at = ? WHERE id = ?').run(now(), categoryId);
       return { archived: true, used };
     }
@@ -452,7 +454,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     return { archived: false, used: 0 };
   });
 
-  // ── Операции ────────────────────────────────────────────────────────────
+  // ── Transactions ────────────────────────────────────────────────────────
 
   app.get('/api/transactions', (req) => {
     const q = z
@@ -469,7 +471,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
 
     const userId = req.user?.id ?? '';
     const where: string[] = [
-      // Операция видна, если видна хотя бы одна её сторона
+      // A transaction is visible if at least one of its sides is
       `(a.shared = 1 OR a.owner_id = ? OR b.shared = 1 OR b.owner_id = ?)`,
     ];
     const args: unknown[] = [userId, userId];
@@ -522,8 +524,9 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
 
     const visible = visibleAccountIds(userId);
 
-    // Перевод на чужой личный счёт виден суммой, но без названия счёта:
-    // скрыть уход денег с общего счёта нельзя, иначе остаток будет неверным
+    // A transfer to someone else's personal account shows its amount but
+    // not the account name: money leaving a shared account can't be
+    // hidden, or the balance would be wrong
     return rows.map((row) => {
       const masked = { ...row };
       if (row['to_account_id'] && !visible.has(row['to_account_id'] as string)) {
@@ -608,8 +611,8 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     for (const key of ['occurred_on', 'amount', 'note', 'place', 'to_amount'] as const) {
       if (d[key] !== undefined) fields.push([key, d[key]]);
     }
-    // Категория проверяется так же, как при создании: иначе правкой можно
-    // повесить доходную категорию на трату, и отчёты по категориям поедут
+    // The category is validated the same as on create: otherwise an edit
+    // could hang an income category on an expense, skewing category reports
     if (d.category_id !== undefined) {
       if (d.category_id) {
         if (tx.kind === 'transfer') {
@@ -657,7 +660,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(404).send({ error: 'Операция не найдена' });
     }
 
-    // Строки уйдут каскадом, файлы чеков надо убрать руками
+    // Rows go away via cascade; receipt files must be removed by hand
     const receipts = db
       .prepare('SELECT storage_path FROM attachments WHERE transaction_id = ?')
       .all(txId) as { storage_path: string }[];
@@ -670,7 +673,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  /** Операция с чеками — для карточки. */
+  /** A transaction's receipts — for the detail card. */
   app.get('/api/transactions/:id/attachments', (req, reply) => {
     const { id: txId } = z.object({ id: z.string().uuid() }).parse(req.params);
     if (!visibleAccountIds(req.user?.id ?? '').has(
@@ -689,9 +692,9 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
       .all(txId);
   });
 
-  // ── Сводка за месяц ─────────────────────────────────────────────────────
+  // ── Monthly summary ─────────────────────────────────────────────────────
 
-  /** Итоги по каждой валюте отдельно: общего итога без курса не бывает. */
+  /** Totals per currency, separately: no grand total without an exchange rate. */
   app.get('/api/money/summary', (req, reply) => {
     const parsed = z
       .object({ from: z.string().regex(DATE), to: z.string().regex(DATE) })

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -20,9 +20,9 @@ interface NoteRow {
 }
 
 /**
- * Приватную заметку видит только владелец.
- * Роль здесь не участвует: администратор — служебная учётка для управления
- * системой, а не суперпользователь над содержимым. См. раздел о ролях в ТЗ.
+ * A private note is visible to its owner only.
+ * Role plays no part here: the admin is a service account for managing
+ * the system, not a superuser over content. See the roles section of the spec.
  */
 const VISIBLE = "(n.visibility = 'shared' OR n.owner_id = ?)";
 
@@ -53,7 +53,7 @@ function loadVisible(noteId: string, userId: string): NoteRow | null {
   return row ?? null;
 }
 
-/** Менять заметку может любой домочадец, кроме чужих приватных. */
+/** Any family member may edit a note, except other people's private ones. */
 function guard(
   noteId: string,
   req: FastifyRequest,
@@ -67,15 +67,15 @@ function guard(
   return note;
 }
 
-// ── Ссылки [[Заголовок]] ──────────────────────────────────────────────────
+// ── [[Title]] links ───────────────────────────────────────────────────────
 
 const WIKI_LINK = /\[\[([^\][|]{1,200})\]\]/g;
 const ESCAPED_WIKI_LINK = /\\\[\\\[([^\][|]{1,200})\\\]\\\]/g;
 
 /**
- * Редакторы markdown любят экранировать квадратные скобки. Приводим ссылки
- * к каноничному виду до того, как текст попадёт в базу: иначе заметка
- * читается глазами нормально, а связь между заметками теряется.
+ * Markdown editors love escaping square brackets. Links are normalized to
+ * canonical form before the text reaches the database: otherwise the note
+ * reads fine to the eye while the connection between notes is lost.
  */
 export function normalizeWikiLinks(body: string): string {
   return body.replace(ESCAPED_WIKI_LINK, '[[$1]]');
@@ -91,9 +91,9 @@ export function extractLinks(body: string): string[] {
 }
 
 /**
- * Перестраивает исходящие ссылки заметки.
- * Ссылка на ещё не созданную заметку сохраняется с пустой целью — когда
- * заметка с таким заголовком появится, связь подхватится автоматически.
+ * Rebuilds a note's outgoing links.
+ * A link to a not-yet-created note is stored with an empty target — when
+ * a note with that title appears, the connection picks up automatically.
  */
 function rebuildLinks(noteId: string, body: string): void {
   db.prepare('DELETE FROM note_links WHERE source_note_id = ?').run(noteId);
@@ -104,7 +104,7 @@ function rebuildLinks(noteId: string, body: string): void {
   for (const title of extractLinks(body)) insert.run(noteId, title, title);
 }
 
-/** Подтягивает висящие ссылки на заметку с таким заголовком. */
+/** Picks up dangling links pointing at a note with this title. */
 function resolveIncoming(noteId: string, title: string): void {
   db.prepare(
     `UPDATE note_links SET target_note_id = ?
@@ -113,18 +113,18 @@ function resolveIncoming(noteId: string, title: string): void {
 }
 
 /**
- * Подстановки в шаблоне. Раскрываются один раз, в момент создания заметки:
- * дальше это обычный текст, который можно править. Живых, пересчитываемых
- * значений здесь сознательно нет — заметка должна означать одно и то же
- * и через год.
+ * Template placeholders. Expanded once, at note creation: after that it
+ * is plain editable text. Live, recomputed values are deliberately absent
+ * here — a note must mean the same thing a year later.
  */
 export function applyPlaceholders(text: string, authorName: string): string {
   const date = new Date();
   const values: Record<string, string> = {
     дата: new Intl.DateTimeFormat('ru-RU', { dateStyle: 'long' }).format(date),
     date: new Intl.DateTimeFormat('ru-RU', { dateStyle: 'long' }).format(date),
-    // По местным часам, как {{дата}} и {{время}}: toISOString() дал бы
-    // дату по Гринвичу, и заметка, созданная в 00:30, помечалась бы вчерашним днём
+    // By the local clock, like the date and time placeholders: toISOString()
+    // would give the Greenwich date, and a note created at 00:30 would be
+    // stamped with yesterday
     изо: today(),
     iso: today(),
     время: new Intl.DateTimeFormat('ru-RU', { timeStyle: 'short' }).format(date),
@@ -139,14 +139,14 @@ export function applyPlaceholders(text: string, authorName: string): string {
   });
 }
 
-// ── История версий ────────────────────────────────────────────────────────
+// ── Version history ───────────────────────────────────────────────────────
 
 const VERSION_GAP_MINUTES = 10;
 
 /**
- * Снимок предыдущего содержимого — но не на каждое сохранение.
- * Автосохранение срабатывает раз в пару секунд, и без этого условия
- * история за один вечер работы превратилась бы в тысячу бесполезных строк.
+ * A snapshot of the previous content — but not on every save.
+ * Autosave fires every couple of seconds, and without this condition one
+ * evening of work would turn the history into a thousand useless rows.
  */
 function snapshotIfNeeded(note: NoteRow, authorId: string): void {
   const last = db
@@ -170,7 +170,7 @@ function snapshotIfNeeded(note: NoteRow, authorId: string): void {
   ).run(id(), note.id, note.title, note.body_md, authorId, now());
 }
 
-// ── Схемы ─────────────────────────────────────────────────────────────────
+// ── Schemas ───────────────────────────────────────────────────────────────
 
 const createInput = z.object({
   title: z.string().max(200).optional(),
@@ -192,7 +192,7 @@ const patchInput = z.object({
 });
 
 export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
-  // ── Папки ───────────────────────────────────────────────────────────────
+  // ── Folders ─────────────────────────────────────────────────────────────
 
   app.get('/api/folders', () =>
     db.prepare('SELECT * FROM folders ORDER BY position, name').all(),
@@ -249,7 +249,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  // ── Список заметок ──────────────────────────────────────────────────────
+  // ── Note list ───────────────────────────────────────────────────────────
 
   app.get('/api/notes', (req) => {
     const q = z
@@ -292,7 +292,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return rows.map((r) => ({ ...r, excerpt: excerptOf(String(r.excerpt ?? '')) }));
   });
 
-  // ── Одна заметка со связями ─────────────────────────────────────────────
+  // ── One note with its connections ───────────────────────────────────────
 
   app.get('/api/notes/:id', (req, reply) => {
     const { id: noteId } = z.object({ id: z.string().uuid() }).parse(req.params);
@@ -335,7 +335,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return { ...note, outgoing, backlinks, attachments };
   });
 
-  // ── Создание ────────────────────────────────────────────────────────────
+  // ── Creation ────────────────────────────────────────────────────────────
 
   app.post('/api/notes', (req, reply) => {
     const parsed = createInput.safeParse(req.body);
@@ -356,8 +356,8 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     let titleFromTemplate: string | null = null;
 
     if (d.template_id) {
-      // Шаблон подчиняется той же видимости, что и обычная заметка:
-      // чужой приватный шаблон нельзя развернуть, даже зная его идентификатор
+      // A template obeys the same visibility as a regular note: someone
+      // else's private template can't be expanded even knowing its id
       const template = db
         .prepare(
           `SELECT title, body_md FROM notes
@@ -375,8 +375,9 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
         | NoteRow
         | undefined;
       if (existing) {
-        // Чужая приватная заметка дня не отдаётся — как и в GET /api/notes/daily.
-        // Вторую на ту же дату не создать (daily_date уникальна), поэтому 409.
+        // Someone else's private daily note is not returned — same as in
+        // GET /api/notes/daily. A second one for the same date can't be
+        // created (daily_date is unique), hence 409.
         if (existing.visibility === 'private' && existing.owner_id !== userId) {
           return reply
             .code(409)
@@ -413,7 +414,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return reply.code(201).send(db.prepare('SELECT * FROM notes WHERE id = ?').get(noteId));
   });
 
-  // ── Изменение ───────────────────────────────────────────────────────────
+  // ── Editing ─────────────────────────────────────────────────────────────
 
   app.patch('/api/notes/:id', (req, reply) => {
     const { id: noteId } = z.object({ id: z.string().uuid() }).parse(req.params);
@@ -427,7 +428,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     const d = parsed.data;
     const userId = req.user?.id ?? '';
 
-    // Сделать заметку приватной может только тот, кто станет её владельцем
+    // Only the person who would become its owner may make a note private
     if (d.visibility === 'private' && note.owner_id && note.owner_id !== userId) {
       return reply.code(403).send({ error: 'Приватной заметку делает её владелец' });
     }
@@ -447,7 +448,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
       if (d.is_template !== undefined) fields.push(['is_template', d.is_template ? 1 : 0]);
       if (d.visibility !== undefined) {
         fields.push(['visibility', d.visibility]);
-        // Приватная заметка обязана иметь владельца, иначе её не увидит никто
+        // A private note must have an owner, or nobody would see it at all
         if (d.visibility === 'private' && !note.owner_id) fields.push(['owner_id', userId]);
       }
 
@@ -473,8 +474,8 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     const note = guard(noteId, req, reply);
     if (!note) return;
 
-    // Строки в базе уйдут каскадом, но файлы на диске нужно убрать руками,
-    // иначе каталог вложений будет расти вечно.
+    // Database rows go away via cascade, but files on disk must be removed
+    // by hand, or the attachments directory grows forever.
     const files = db
       .prepare('SELECT storage_path FROM attachments WHERE note_id = ?')
       .all(noteId) as { storage_path: string }[];
@@ -487,7 +488,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return { ok: true };
   });
 
-  // ── История ─────────────────────────────────────────────────────────────
+  // ── History ─────────────────────────────────────────────────────────────
 
   app.get('/api/notes/:id/versions', (req, reply) => {
     const { id: noteId } = z.object({ id: z.string().uuid() }).parse(req.params);
@@ -533,7 +534,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
 
     const userId = req.user?.id ?? '';
     const run = db.transaction(() => {
-      // Текущее состояние сохраняем всегда: откат тоже должен быть обратим
+      // The current state is always saved: a rollback must be reversible too
       db.prepare(
         `INSERT INTO note_versions (id, note_id, title, body_md, author_id, created_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
@@ -552,7 +553,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     return db.prepare('SELECT * FROM notes WHERE id = ?').get(noteId);
   });
 
-  // ── Заметка дня ─────────────────────────────────────────────────────────
+  // ── Daily note ──────────────────────────────────────────────────────────
 
   app.get('/api/notes/daily/:date', (req, reply) => {
     const { date } = z

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { db, id, now } from '../db/index.js';
 
-/** Русское склонение: 1 задача, 2 задачи, 5 задач. */
+/** Russian declension: 1 задача, 2 задачи, 5 задач. */
 function plural(n: number, one: string, few: string, many: string): string {
   const abs = Math.abs(n) % 100;
   const last = abs % 10;
@@ -127,7 +127,7 @@ export async function registerProjectRoutes(app: FastifyInstance): Promise<void>
     return { ok: true };
   });
 
-  /** Кому можно назначать задачи. Доступно всем, это не админский раздел. */
+  /** Who tasks can be assigned to. Available to everyone; not an admin section. */
   app.get('/api/household', () =>
     db
       .prepare(

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -7,15 +7,15 @@ import { hashPassword } from '../lib/password.js';
 import { log } from '../lib/log.js';
 
 /*
-  Первичная настройка и приглашения — онбординг без чтения логов.
+  Initial setup and invites — onboarding without reading logs.
 
-  Пустая база: хаб при открытии предлагает создать первую учётку —
-  она становится администратором. Никаких паролей в журнале сервера.
+  Empty database: the hub, when opened, offers to create the first
+  account — it becomes the admin. No passwords in the server log.
 
-  Дальше домочадцы добавляются ссылками: администратор создаёт
-  одноразовую ссылку, человек открывает её и сам заполняет имя, логин
-  и пароль. Ссылка живёт неделю, показывается создателю один раз
-  (хранится только хэш) и гаснет после использования.
+  Family members are then added by links: the admin creates a one-time
+  link, the person opens it and fills in their own name, login and
+  password. The link lives a week, is shown to its creator once
+  (only the hash is stored) and goes dark after use.
 */
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60_000;
@@ -35,7 +35,7 @@ interface InviteRow {
   used_at: string | null;
 }
 
-/** Живое приглашение по токену: не использовано и не протухло. */
+/** A live invite by token: not used and not expired. */
 function liveInvite(token: string): InviteRow | null {
   const row = db
     .prepare('SELECT id, role, expires_at, used_at FROM invites WHERE token_hash = ?')
@@ -45,14 +45,14 @@ function liveInvite(token: string): InviteRow | null {
 }
 
 export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
-  // Жёсткий лимит на публичные точки онбординга — как на входе
+  // A strict limit on the public onboarding endpoints — same as on login
   const strictRate = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
 
   /*
-    Первичная настройка. Работает ровно один раз — пока в базе нет ни одного
-    пользователя. Дальше отвечает 403 навсегда: гонку двух одновременных
-    настройщиков решает уникальность момента, проверка и вставка идут
-    в одной транзакции.
+    Initial setup. Works exactly once — while the database has no users
+    at all. Afterwards it answers 403 forever: a race of two simultaneous
+    setups is settled by the uniqueness of the moment, the check and the
+    insert run in one transaction.
   */
   app.post('/api/auth/setup', strictRate, async (req, reply) => {
     const parsed = z
@@ -79,12 +79,12 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(403).send({ error: 'Хаб уже настроен' });
     }
 
-    log.info(`первичная настройка: создан администратор ${parsed.data.email} с ${req.ip}`);
+    log.info(`initial setup: admin ${parsed.data.email} created from ${req.ip}`);
     setSessionCookie(reply, createSession(userId, req.headers['user-agent']));
     return reply.code(201).send({ ok: true });
   });
 
-  // ── Приглашения: административная сторона ─────────────────────────────
+  // ── Invites: the admin side ────────────────────────────────────────────
 
   app.post('/api/invites', (req, reply) => {
     if (req.user?.role !== 'admin') {
@@ -109,7 +109,7 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       new Date(Date.now() + INVITE_TTL_MS).toISOString().replace('T', ' ').slice(0, 19),
     );
 
-    // Токен наружу отдаётся единственный раз — дальше живёт только хэш
+    // The token leaves the server exactly once — from then on only the hash lives
     return reply.code(201).send({ id: inviteId, path: `/join?token=${token}` });
   });
 
@@ -135,14 +135,14 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(403).send({ error: 'Только администратор' });
     }
     const { id: inviteId } = z.object({ id: z.string().uuid() }).parse(req.params);
-    // Использованные не трогаем — это уже история, а не приглашение
+    // Used ones stay untouched — that's history now, not an invite
     db.prepare('DELETE FROM invites WHERE id = ? AND used_at IS NULL').run(inviteId);
     return { ok: true };
   });
 
-  // ── Приглашения: сторона приглашённого (публичная) ────────────────────
+  // ── Invites: the invitee side (public) ─────────────────────────────────
 
-  // Открывший ссылку узнаёт, жива ли она, до заполнения формы
+  // Whoever opens the link learns whether it is alive before filling the form
   app.get('/api/auth/invite', strictRate, (req, reply) => {
     const { token } = z.object({ token: z.string().min(1) }).parse(req.query);
     const invite = liveInvite(token);
@@ -180,8 +180,8 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
     const passwordHash = await hashPassword(parsed.data.password);
     const userId = id();
 
-    // Гонку двух заходов по одной ссылке решает транзакция:
-    // второй увидит used_at и получит отказ
+    // A race of two visits via one link is settled by the transaction:
+    // the second one sees used_at and gets refused
     const joined = db.transaction(() => {
       const fresh = db
         .prepare('SELECT used_at FROM invites WHERE id = ?')
@@ -203,7 +203,7 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(404).send({ error: 'Ссылка не действует: истекла или уже использована' });
     }
 
-    log.info(`вход по приглашению: ${parsed.data.email} (${invite.role}) с ${req.ip}`);
+    log.info(`invite join: ${parsed.data.email} (${invite.role}) from ${req.ip}`);
     setSessionCookie(reply, createSession(userId, req.headers['user-agent']));
     return reply.code(201).send({ ok: true });
   });

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -37,7 +37,7 @@ const createInput = z.object({
 
 const patchInput = createInput.partial().omit({ project_id: true });
 
-/** Глубина поддерева относительно самой задачи: 0 — детей нет. */
+/** Subtree depth relative to the task itself: 0 — no children. */
 function subtreeDepth(taskId: string): number {
   const row = db
     .prepare(
@@ -217,7 +217,7 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(400).send({ error: 'Правило повтора не разобрать' });
     }
 
-    // Смена родителя пересчитывает уровень всего поддерева
+    // A parent change recomputes the level of the whole subtree
     let levelDelta = 0;
     if (d.parent_id !== undefined && d.parent_id !== task.parent_id) {
       let newLevel = 0;
@@ -263,10 +263,10 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
     });
     run();
 
-    // Повторяющаяся задача при закрытии порождает следующую
+    // A recurring task spawns the next one when closed
     let spawned: unknown = null;
     if (d.status === 'done' && task.recurrence_rule && task.due_date) {
-      // Начало серии — исходная задача, от неё и считаем.
+      // The series starts at the original task — that is what we count from.
       const rootId = task.recurrence_parent_id ?? taskId;
       const root = db.prepare('SELECT due_date FROM tasks WHERE id = ?').get(rootId) as
         | { due_date: string | null }
@@ -304,10 +304,10 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
   });
 
   /**
-   * Порядок задаётся списком идентификаторов целиком.
-   * Проще и надёжнее, чем вычислять дробные позиции между соседями:
-   * на домашних объёмах переписать полсотни строк ничего не стоит,
-   * зато позиции не расползаются со временем.
+   * The order is given as the full list of ids.
+   * Simpler and sturdier than computing fractional positions between
+   * neighbors: at household volumes rewriting fifty rows costs nothing,
+   * and positions never smear apart over time.
    */
   app.post('/api/tasks/reorder', (req, reply) => {
     const parsed = z.object({ ids: z.array(z.string().uuid()).max(500) }).safeParse(req.body);

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -5,8 +5,9 @@ import { destroyAllSessions, requireAdmin } from '../lib/auth.js';
 import { generatePassword, hashPassword } from '../lib/password.js';
 
 /**
- * Аватар — первая буква имени, поэтому людей различает цвет.
- * Одинаковый цвет по умолчанию делал бы «Денис» и «Дочка» неотличимыми.
+ * The avatar is the first letter of the name, so color is what tells
+ * people apart. An identical default color would make "Dad" and
+ * "Daughter" indistinguishable.
  */
 const USER_COLORS = ['#1F6E8C', '#C4842B', '#6B8F5E', '#8C4A6B', '#7A5C9E', '#4A6B8C'];
 
@@ -69,7 +70,7 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
       now(),
     );
 
-    // Пароль возвращается ровно один раз — показать и передать человеку.
+    // The password is returned exactly once — to show and hand to the person.
     return reply.code(201).send({
       user: db
         .prepare('SELECT id, email, name, role, color FROM users WHERE id = ?')
@@ -112,13 +113,13 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
     if (!user) return reply.code(404).send({ error: 'Пользователь не найден' });
 
     const password = generatePassword();
-    // Сброс — это и путь восстановления при умершем гугл-аккаунте,
-    // поэтому парольный вход включается обратно
+    // A reset is also the recovery path for a dead Google account,
+    // so password login gets switched back on
     db.prepare(
       `UPDATE users SET password_hash = ?, must_change_password = 1,
               password_login_disabled = 0 WHERE id = ?`,
     ).run(await hashPassword(password), userId);
-    // Сброс пароля выкидывает пользователя со всех устройств
+    // A password reset kicks the user off every device
     destroyAllSessions(userId);
 
     return { password };

--- a/server/vitest.setup.ts
+++ b/server/vitest.setup.ts
@@ -2,6 +2,6 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// env.ts читает DATA_DIR при импорте — подсовываем одноразовый каталог,
-// чтобы тесты никогда не касались настоящей базы в ~/.family-hub
+// env.ts reads DATA_DIR at import time — slip in a throwaway directory
+// so tests never touch the real database in ~/.family-hub
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'family-hub-test-'));

--- a/web/index.html
+++ b/web/index.html
@@ -3,13 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <!-- Приближение к теме приложения: сама тема переключается в рантайме,
-         но цвет хрома браузера задаётся до загрузки скриптов -->
+    <!-- Approximation of the app theme: the theme itself switches at runtime,
+         but the browser chrome color is set before any scripts load -->
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#F5F4F1" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#131C24" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <!-- lang и title перенастраиваются в src/lib/i18n.ts под язык устройства -->
+    <!-- lang and title are reconfigured in src/lib/i18n.ts for the device language -->
     <title>Family Hub</title>
   </head>
   <body>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -73,7 +73,7 @@ const NAV: NavItem[] = [
   },
 ];
 
-/** Разделы, которым место не в основном ряду. */
+/** Sections that don't belong in the main row. */
 const SECONDARY: NavItem[] = [
   {
     to: '/settings',
@@ -151,19 +151,19 @@ function ThemeRow() {
 
 export function AppShell() {
   const { user, logout } = useAuth();
-  // Задача, добавленная из любого места, должна сразу появиться в открытом разделе
+  // A task added from anywhere must show up immediately in the open section
   const [refreshKey, setRefreshKey] = useState(0);
-  // Поиском управляет оболочка: на телефоне его открывает нижняя панель,
-  // а боковой панели там нет вовсе.
+  // Search is owned by the shell: on the phone it's opened from the bottom bar,
+  // and there is no sidebar there at all.
   const [searchOpen, setSearchOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const sidebarNav = [...NAV, ...SECONDARY];
 
   return (
     <div className="min-h-dvh md:flex">
-      {/* Боковая навигация: ноутбук и стенд.
-          Липкая и со своим скроллом: на длинном списке задач страница
-          прокручивается, а панель с разделами остаётся на месте. */}
+      {/* Sidebar navigation: laptop and kiosk.
+          Sticky with its own scroll: on a long task list the page
+          scrolls while the section panel stays put. */}
       <aside className="hidden w-56 shrink-0 flex-col border-r border-line bg-surface px-4 py-6 md:sticky md:top-0 md:flex md:h-dvh md:overflow-y-auto 3xl:w-64">
         {/* The theme toggle lives in the header: next to Sign out a missed
             click cost a whole session — a price out of scale for the button */}
@@ -218,14 +218,14 @@ export function AppShell() {
         </div>
       </aside>
 
-      {/* Контент */}
+      {/* Content */}
       <main className="flex-1 pb-20 md:pb-0">
         <Outlet key={refreshKey} />
       </main>
 
       <QuickAdd onAdded={() => setRefreshKey((k) => k + 1)} />
 
-      {/* Нижняя навигация: телефон */}
+      {/* Bottom navigation: phone */}
       <nav className="fixed inset-x-0 bottom-0 z-10 grid grid-cols-6 border-t border-line bg-surface pb-[env(safe-area-inset-bottom)] md:hidden">
         {NAV.map((item) => (
           <NavLink
@@ -244,7 +244,7 @@ export function AppShell() {
           </NavLink>
         ))}
 
-        {/* Шестым пунктом — всё, что не влезло: поиск, настройки, пользователи */}
+        {/* Sixth item holds everything that didn't fit: search, settings, users */}
         <button
           type="button"
           onClick={() => setMoreOpen((v) => !v)}

--- a/web/src/components/CalendarViews.tsx
+++ b/web/src/components/CalendarViews.tsx
@@ -34,7 +34,7 @@ function groupByDate(occurrences: Occurrence[], tasks: Task[]) {
   };
 
   for (const o of occurrences) {
-    // Многодневное событие показываем в каждом его дне
+    // A multi-day event is shown on each of its days
     let cursor = o.date;
     const last = o.ends_at.slice(0, 10);
     for (let guard = 0; cursor <= last && guard < 400; guard++) {
@@ -48,7 +48,7 @@ function groupByDate(occurrences: Occurrence[], tasks: Task[]) {
   return map;
 }
 
-/** Кружки участников: без них выбор «кто идёт» не виден нигде, кроме карточки. */
+/** Attendee circles: without them the "who's going" choice is invisible outside the card. */
 function Participants({
   people,
   compact,
@@ -74,7 +74,7 @@ function Participants({
   );
 }
 
-/** Одна плашка события. Цвет всегда от календаря, проект — точкой. */
+/** One event chip. Color always comes from the calendar; the project is a dot. */
 function EventChip({
   occurrence,
   onOpen,
@@ -110,7 +110,7 @@ function EventChip({
   );
 }
 
-/** Кнопка добавления в клетке дня: щелчок по самой клетке — не для клавиатуры. */
+/** Add button inside a day cell: clicking the cell itself isn't keyboard-friendly. */
 function AddInDay({ date, onPickDay }: { date: string; onPickDay: (d: string) => void }) {
   return (
     <button
@@ -148,7 +148,7 @@ function TaskChip({ task, compact }: { task: Task; compact?: boolean }) {
   );
 }
 
-// ── Неделя ────────────────────────────────────────────────────────────────
+// ── Week ──────────────────────────────────────────────────────────────────
 
 export function WeekView({ from, today, occurrences, tasks, onPickDay, onOpen }: ViewProps) {
   const days = Array.from({ length: 7 }, (_, i) => addDays(startOfWeek(from), i));
@@ -194,7 +194,7 @@ export function WeekView({ from, today, occurrences, tasks, onPickDay, onOpen }:
   );
 }
 
-// ── Месяц ─────────────────────────────────────────────────────────────────
+// ── Month ─────────────────────────────────────────────────────────────────
 
 export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOpen }: ViewProps) {
   const grouped = groupByDate(occurrences, tasks);
@@ -283,7 +283,7 @@ export function MonthView({ from, to, today, occurrences, tasks, onPickDay, onOp
   );
 }
 
-// ── День и лента ──────────────────────────────────────────────────────────
+// ── Day and agenda ────────────────────────────────────────────────────────
 
 export function AgendaView({ from, to, today, occurrences, tasks, onPickDay, onOpen }: ViewProps) {
   const grouped = groupByDate(occurrences, tasks);

--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -11,11 +11,11 @@ import {
 import { dialogKeys, onEnter } from '../lib/keys';
 
 /**
- * Свои диалоги вместо window.prompt и window.confirm.
+ * Our own dialogs instead of window.prompt and window.confirm.
  *
- * Нативные окна нельзя оформить, они выпадают из интерфейса, а на планшете
- * ведут себя непредсказуемо — на стенде это особенно заметно. Плюс их
- * невозможно проверить автоматически: браузер закрывает их сам.
+ * Native popups can't be styled, they fall outside the interface, and on
+ * a tablet they behave unpredictably — especially noticeable on the kiosk.
+ * Plus they can't be tested automatically: the browser closes them itself.
  */
 
 export function Modal({
@@ -30,7 +30,7 @@ export function Modal({
   children?: ReactNode;
   footer: ReactNode;
   onClose: () => void;
-  /** Главное действие диалога — выполняется по Enter из любого места окна. */
+  /** The dialog's primary action — runs on Enter from anywhere in the window. */
   onSubmit?: () => void;
   width?: string;
 }) {
@@ -70,7 +70,7 @@ export const dialogGhost = 'px-2 py-2 text-sm text-muted hover:text-ink';
 export const dialogDanger =
   'rounded-lg border border-urgent px-4 py-2 text-sm font-medium text-urgent hover:bg-urgent/10';
 
-// ── Контекст ──────────────────────────────────────────────────────────────
+// ── Context ───────────────────────────────────────────────────────────────
 
 interface PromptOptions {
   title: string;
@@ -120,7 +120,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (pending?.kind === 'prompt') {
-      // Значение выделяем целиком: поле почти всегда переписывают, а не дополняют
+      // Select the whole value: the field is almost always rewritten, not appended to
       setTimeout(() => inputRef.current?.select(), 0);
     }
   }, [pending]);

--- a/web/src/components/DonutChart.tsx
+++ b/web/src/components/DonutChart.tsx
@@ -1,10 +1,10 @@
 /**
- * Круговая диаграмма долей на чистом SVG.
+ * Donut chart of shares in pure SVG.
  *
- * Библиотеку графиков ради одного круга не тащим: CSP запрещает внешние
- * скрипты, а самим сегментам хватает трюка со stroke-dasharray — каждый
- * сегмент это кольцо, у которого прорисована только его доля окружности,
- * повёрнутая на сумму предыдущих долей.
+ * No chart library for the sake of one circle: CSP forbids external
+ * scripts, and the segments only need the stroke-dasharray trick — each
+ * segment is a ring with only its share of the circumference drawn,
+ * rotated by the sum of the preceding shares.
  */
 
 export interface DonutSegment {
@@ -15,7 +15,7 @@ export interface DonutSegment {
 
 interface Props {
   segments: DonutSegment[];
-  /** Подпись в центре — обычно отформатированный итог. */
+  /** Center label — usually the formatted total. */
   centerLabel?: string;
   size?: number;
 }
@@ -28,9 +28,9 @@ export function DonutChart({ segments, centerLabel, size = 132 }: Props) {
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
 
-  // Начало — сверху (12 часов): SVG рисует дуги с трёх часов.
-  // Смещения считаются заранее и без мутаций: аккумулятор, изменяемый
-  // внутри JSX-map, ломает предпосылки React о чистоте рендера.
+  // Start at the top (12 o'clock): SVG draws arcs from 3 o'clock.
+  // Offsets are computed up front and without mutation: an accumulator
+  // mutated inside a JSX map breaks React's assumptions about render purity.
   const fractions = segments.map((s) => s.value / total);
   const starts = fractions.map(
     (_, i) => -0.25 + fractions.slice(0, i).reduce((sum, f) => sum + f, 0),

--- a/web/src/components/Editor.tsx
+++ b/web/src/components/Editor.tsx
@@ -12,17 +12,17 @@ import { Markdown } from 'tiptap-markdown';
 import { WikiLink } from './WikiLink';
 
 /**
- * Сериализатор markdown экранирует квадратные скобки, и [[Ссылка]]
- * превращается в \[\[Ссылка\]\]. При обратном разборе экранирование
- * снимается, поэтому в редакторе всё выглядит правильно — а на диск при
- * этом ложится текст, в котором связь между заметками уже не распознать.
- * Разэкранируем ровно этот случай, не трогая остальную разметку.
+ * The markdown serializer escapes square brackets, turning [[Link]]
+ * into \[\[Link\]\]. Parsing back removes the escaping, so everything
+ * looks fine in the editor — while what lands on disk is text where
+ * the connection between notes can no longer be recognized.
+ * We unescape exactly this case, leaving the rest of the markup alone.
  */
 function unescapeWikiLinks(markdown: string): string {
   return markdown.replace(/\\\[\\\[([^\][|]{1,200})\\\]\\\]/g, '[[$1]]');
 }
 
-// tiptap-markdown кладёт сериализатор в storage, но своих типов не приносит
+// tiptap-markdown puts the serializer in storage but ships no types of its own
 declare module '@tiptap/core' {
   interface Storage {
     markdown: { getMarkdown: () => string };
@@ -37,14 +37,14 @@ export interface UploadedFile {
 }
 
 interface Props {
-  /** Меняется только при переключении заметки, не при каждом нажатии клавиши. */
+  /** Changes only when switching notes, not on every keystroke. */
   noteId: string;
   /**
-   * Счётчик внешних замен содержимого — например, откат к версии.
-   * Редактор держит документ у себя и об изменении initialMarkdown не узнаёт,
-   * поэтому его нужно пересоздать явно. Без этого откат выглядел успешным
-   * на сервере, но в редакторе оставался прежний текст — и следующее
-   * автосохранение возвращало его обратно, отменяя откат.
+   * Counter of external content replacements — e.g. reverting to a version.
+   * The editor owns the document and never learns that initialMarkdown
+   * changed, so it must be recreated explicitly. Without this a revert
+   * looked successful on the server while the editor kept the old text —
+   * and the next autosave wrote it back, undoing the revert.
    */
   revision?: number;
   initialMarkdown: string;
@@ -61,9 +61,9 @@ export function Editor({ noteId, revision = 0, initialMarkdown, onChange, onNavi
   const [dropping, setDropping] = useState(false);
   const [uploading, setUploading] = useState(false);
   const uploadRef = useRef(onUpload);
-  // Обновление ref — после рендера, не во время: запись в ref в теле
-  // компонента ломает предпосылки React о чистоте рендера. Обработчикам
-  // TipTap ref нужен только по событиям, эффект успевает раньше.
+  // Update the ref after render, not during it: writing to a ref in the
+  // component body breaks React's assumptions about render purity. TipTap
+  // handlers only need the ref on events, and the effect runs before those.
   useEffect(() => {
     uploadRef.current = onUpload;
   }, [onUpload]);
@@ -79,9 +79,9 @@ export function Editor({ noteId, revision = 0, initialMarkdown, onChange, onNavi
         TableKit.configure({ table: { resizable: false } }),
         Highlight,
         Placeholder.configure({ placeholder: t('Начните писать. [[Ссылка]] связывает заметки') }),
-        // Ленивая загрузка: раскодированная фотография занимает мегабайты
-        // памяти вкладки независимо от веса файла. В длинной заметке с
-        // фотографиями пусть декодируются те, что на экране, а не все сразу.
+        // Lazy loading: a decoded photo takes megabytes of tab memory
+        // regardless of file size. In a long note full of photos, let
+        // the ones on screen decode rather than all of them at once.
         Image.configure({
           inline: false,
           HTMLAttributes: { loading: 'lazy', decoding: 'async' },
@@ -93,8 +93,8 @@ export function Editor({ noteId, revision = 0, initialMarkdown, onChange, onNavi
       editorProps: {
         attributes: { class: 'note-content' },
 
-        // Перетаскивание файлов в текст. Картинки встают на место броска,
-        // остальные файлы просто прикрепляются к заметке.
+        // Drag-and-drop of files into the text. Images land at the drop
+        // point, other files simply get attached to the note.
         handleDrop(view, event, _slice, moved) {
           const files = Array.from(event.dataTransfer?.files ?? []);
           if (moved || files.length === 0) return false;
@@ -116,8 +116,8 @@ export function Editor({ noteId, revision = 0, initialMarkdown, onChange, onNavi
         onChange(unescapeWikiLinks(editor.storage.markdown.getMarkdown()));
       },
     },
-    // Пересоздаём редактор при смене заметки: так не нужно синхронизировать
-    // содержимое вручную и невозможно случайно записать текст не в ту заметку.
+    // Recreate the editor when the note changes: no manual content sync
+    // needed, and it's impossible to accidentally write text into the wrong note.
     [noteId, revision],
   );
 

--- a/web/src/components/EntityDialog.tsx
+++ b/web/src/components/EntityDialog.tsx
@@ -12,9 +12,9 @@ import { onEnter } from '../lib/keys';
 import { PALETTE, addToPalette, loadCustomPalette } from '../lib/palette';
 
 /**
- * Проекты, папки и календари — разные сущности, но правятся одинаково:
- * название, цвет, иногда один переключатель, удаление и архив.
- * Один диалог на всех вместо трёх почти одинаковых.
+ * Projects, folders and calendars are different entities but are edited
+ * the same way: name, color, sometimes one toggle, delete and archive.
+ * One dialog for all of them instead of three nearly identical ones.
  */
 
 export { PALETTE } from '../lib/palette';
@@ -28,10 +28,10 @@ export interface EntityDraft {
 interface Props {
   title: string;
   initial: EntityDraft;
-  /** Подпись переключателя. Если не задана — переключателя нет. */
+  /** Toggle label. If absent, there is no toggle. */
   flagLabel?: string;
   flagHint?: string;
-  /** Текст кнопки архива. Если не задан — архива нет. */
+  /** Archive button text. If absent, there is no archive. */
   archiveLabel?: string;
   deletable?: boolean;
   deleteHint?: string;
@@ -39,7 +39,7 @@ interface Props {
   onArchive?: () => Promise<void> | void;
   onDelete?: () => Promise<void> | void;
   onClose: () => void;
-  /** Дополнительные поля, специфичные для сущности. */
+  /** Extra fields specific to the entity. */
   children?: ReactNode;
 }
 

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -12,7 +12,7 @@ const field =
 const label = 'mb-1.5 block text-sm font-medium text-ink';
 
 interface Props {
-  /** Существующий экземпляр либо дата для нового события. */
+  /** An existing occurrence or a date for a new event. */
   occurrence: Occurrence | null;
   defaultDate: string;
   calendars: Calendar[];
@@ -44,7 +44,7 @@ export function EventDialog({
     end_date: occurrence?.ends_at.slice(0, 10) ?? defaultDate,
     start_time: occurrence ? timeOf(occurrence.starts_at) || '10:00' : '10:00',
     end_time: occurrence ? timeOf(occurrence.ends_at) || '11:00' : '11:00',
-    // Подтягивается ниже: в экземпляре серии правила повтора нет
+    // Fetched below: a series occurrence carries no recurrence rule
     recurrence_rule: '',
     project_id: occurrence?.project_id ?? '',
     remind_days_before:
@@ -57,7 +57,7 @@ export function EventDialog({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  // Правило повтора и год рождения приходят только с полным событием
+  // The recurrence rule and birth year only come with the full event
   useEffect(() => {
     if (!occurrence) return;
     void api
@@ -74,8 +74,8 @@ export function EventDialog({
       .catch(() => {});
   }, [occurrence]);
 
-  // Без списка зависимостей: подписка обновляется на каждый рендер,
-  // и save всегда видит актуальный черновик
+  // No dependency list: the subscription is refreshed on every render,
+  // so save always sees the current draft
   useEffect(() => {
     const onKey = dialogKeys(() => {
       if (!busy) void save();
@@ -120,7 +120,7 @@ export function EventDialog({
     }
   }
 
-  /** У повторяющегося события удаление — это два разных действия. */
+  /** For a recurring event, deletion is two distinct actions. */
   async function removeOne() {
     if (!occurrence) return;
     await api.delete(`/events/${occurrence.event_id}/occurrences/${occurrence.date}`);

--- a/web/src/components/GlobalSearch.tsx
+++ b/web/src/components/GlobalSearch.tsx
@@ -10,7 +10,7 @@ interface Result {
   id: string;
   title: string;
   subtitle: string;
-  /** У задач — для перевода подписи «Входящие» по известному id. */
+  /** For tasks — to translate the "Inbox" label by its well-known id. */
   project_id?: string;
   excerpt: string;
   color: string | null;
@@ -27,9 +27,9 @@ const KIND_LABEL: Record<Result['kind'], string> = {
 };
 
 /*
-  Подписи приходят с сервера по-русски. Пользовательские названия (проект,
-  папка) переводить нельзя, а служебные константы — нужно. Переводим только
-  известный конечный список; названия проектов задач решает projectTitle по id.
+  Subtitles come from the server in Russian. User-given names (project,
+  folder) must not be translated, while built-in constants must be. We only
+  translate a known finite list; task project names are handled by projectTitle by id.
 */
 const SERVER_SUBTITLES = new Set(['Приватная', 'Без папки', 'Проект']);
 
@@ -48,9 +48,9 @@ export function GlobalSearch({
   const navigate = useNavigate();
   const [openLocal, setOpenLocal] = useState(false);
   const open = openProp ?? openLocal;
-  // useCallback обязателен: setOpen участвует в зависимостях эффекта с
-  // window-обработчиком — нестабильная идентичность пересоздавала бы
-  // подписку на каждый рендер (те самые грабли нестабильных хуков)
+  // useCallback is mandatory: setOpen is a dependency of the effect with
+  // the window handler — an unstable identity would recreate the
+  // subscription on every render (the classic unstable-hooks trap)
   const setOpen = useCallback(
     (value: boolean) => {
       setOpenLocal(value);
@@ -64,7 +64,7 @@ export function GlobalSearch({
   const [cursor, setCursor] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Cmd+K уже занят быстрым добавлением, поэтому поиск на Cmd+Shift+F.
+  // Cmd+K is already taken by quick add, so search lives on Cmd+Shift+F.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'f') {
@@ -81,7 +81,7 @@ export function GlobalSearch({
     if (open) setTimeout(() => inputRef.current?.focus(), 0);
   }, [open]);
 
-  // Поиск с задержкой: иначе каждый символ уходит в базу
+  // Debounced search: otherwise every keystroke hits the database
   useEffect(() => {
     if (!open) return;
     const trimmed = query.trim();

--- a/web/src/components/MoveBoard.tsx
+++ b/web/src/components/MoveBoard.tsx
@@ -9,8 +9,8 @@ interface Props {
 }
 
 /**
- * Табло переезда — единственный громкий элемент интерфейса.
- * Всё остальное вокруг намеренно тихое.
+ * The move board is the one loud element in the interface.
+ * Everything around it is deliberately quiet.
  */
 export function MoveBoard({ settings, onChange }: Props) {
   const targetDate = settings['move.target_date'] ?? '';
@@ -47,7 +47,7 @@ export function MoveBoard({ settings, onChange }: Props) {
   return (
     <section className="overflow-hidden rounded-card bg-[#131c24] text-[#e8eae5] shadow-sm">
       <div className="grid divide-y divide-white/10 sm:grid-cols-[1.1fr_1fr] sm:divide-x sm:divide-y-0">
-        {/* Отсчёт */}
+        {/* Countdown */}
         <div className="px-6 py-5">
           <p className="eyebrow text-white/45!">{settings['move.label'] ?? t('Переезд')}</p>
           {days === null ? (
@@ -71,7 +71,7 @@ export function MoveBoard({ settings, onChange }: Props) {
           )}
         </div>
 
-        {/* Накопления */}
+        {/* Savings */}
         <div className="px-6 py-5">
           <p className="eyebrow text-white/45!">{settings['savings.label'] ?? t('Накоплено')}</p>
 
@@ -81,8 +81,8 @@ export function MoveBoard({ settings, onChange }: Props) {
                 <input
                   autoFocus
                   inputMode="decimal"
-                  // Сумму почти всегда вводят заново, а не дописывают к старой.
-                  // Без выделения «4500» плюс набранная семёрка давали 45007.
+                  // The amount is almost always retyped, not appended to.
+                  // Without select-all, "4500" plus a typed 7 became 45007.
                   onFocus={(e) => e.currentTarget.select()}
                   value={draft}
                   onChange={(e) => setDraft(e.target.value)}

--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -1,17 +1,17 @@
 import type { ReactNode } from 'react';
 
 /**
- * narrow — формы и настройки, шире делать нечего.
- * default — растёт ступенями до 1920px: колонки множатся, строки не удлиняются.
- * full — занимает всё, что дают. Для доски задач, где колонок четыре.
+ * narrow — forms and settings; nothing to gain from going wider.
+ * default — grows up to 1920px: columns multiply, lines don't stretch.
+ * full — takes everything it's given. For the task board with its four columns.
  */
 type Width = 'narrow' | 'default' | 'full';
 
 const WIDTH: Record<Width, string> = {
   narrow: 'max-w-3xl',
-  // Ширина растёт непрерывно до 1920px, а не ступенями по точкам останова.
-  // Ступени создают ровно ту же проблему, от которой мы уходим: между
-  // соседними порогами область снова перестаёт расти и по краям копится пустота.
+  // Width grows continuously up to 1920px, not in breakpoint steps.
+  // Steps recreate exactly the problem we're escaping: between adjacent
+  // thresholds the area stops growing again and emptiness piles up at the edges.
   default: 'max-w-[120rem]',
   full: 'max-w-none',
 };
@@ -46,7 +46,7 @@ export function Page({
   );
 }
 
-/** Пустой экран — это приглашение к действию, а не извинение. */
+/** An empty screen is an invitation to act, not an apology. */
 export function Empty({ children }: { children: ReactNode }) {
   return (
     <div className="rounded-card border border-dashed border-line px-6 py-10 text-center text-sm text-muted">

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -23,7 +23,7 @@ const ROLE_LABEL: Record<ManagedUser['role'], string> = {
   kid: t('Ребёнок'),
 };
 
-/** Пароль показывается ровно один раз — дальше его знает только владелец. */
+/** The password is shown exactly once — after that only the owner knows it. */
 function PasswordOnce({ password, onClose }: { password: string; onClose: () => void }) {
   return (
     <div className="mb-5 rounded-card border border-accent bg-accent-soft p-4">
@@ -53,9 +53,9 @@ interface Invite {
 }
 
 /**
- * Приглашения по ссылке — основной путь добавить домочадца:
- * человек сам заполняет имя, логин и пароль, диктовать ничего не нужно.
- * Ссылка одноразовая, живёт неделю и показывается один раз.
+ * Invite links are the primary way to add a household member:
+ * the person fills in their own name, login and password — nothing to dictate.
+ * The link is single-use, lives a week and is shown once.
  */
 function InvitesBlock() {
   const [invites, setInvites] = useState<Invite[] | null>(null);
@@ -88,7 +88,7 @@ function InvitesBlock() {
       await navigator.clipboard.writeText(link);
       setCopied(true);
     } catch {
-      // Буфер недоступен (не-HTTPS или запрет) — ссылка на экране, скопируют руками
+      // Clipboard unavailable (non-HTTPS or denied) — the link is on screen, they'll copy it by hand
     }
   }
 

--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -6,9 +6,9 @@ import { TaskDetail } from './TaskDetail';
 import { INBOX_ID, projectTitle } from '../lib/tasks';
 
 /**
- * Быстрое добавление по Cmd/Ctrl+K из любого места.
- * Задача без выбранного проекта уходит во «Входящие» — разбирать потом,
- * важнее не потерять мысль в момент, когда она пришла.
+ * Quick add via Cmd/Ctrl+K from anywhere.
+ * A task with no project selected goes to Inbox — triage later;
+ * what matters is not losing the thought the moment it arrives.
  */
 export function QuickAdd({ onAdded }: { onAdded: () => void }) {
   const [open, setOpen] = useState(false);
@@ -19,8 +19,8 @@ export function QuickAdd({ onAdded }: { onAdded: () => void }) {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [members, setMembers] = useState<HouseholdMember[]>([]);
-  // Созданная задача сразу открывается на редактирование:
-  // срок, исполнителя и приоритет удобнее проставить по горячим следам.
+  // A created task opens for editing right away:
+  // due date, assignee and priority are easiest to set while it's fresh.
   const [created, setCreated] = useState<Task | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -32,7 +32,7 @@ export function QuickAdd({ onAdded }: { onAdded: () => void }) {
       }
       if (e.key === 'Escape') setOpen(false);
     };
-    // Открытие извне — с экрана быстрых действий на телефоне
+    // External open — from the quick actions screen on the phone
     const openIt = () => setOpen(true);
     window.addEventListener('keydown', onKey);
     window.addEventListener('hub:quick-add', openIt);

--- a/web/src/components/RecurringPanel.tsx
+++ b/web/src/components/RecurringPanel.tsx
@@ -58,7 +58,7 @@ export interface Rule {
   created_count: number;
 }
 
-/** Панель ожидающих подтверждения — она же на странице операций. */
+/** Panel of items awaiting confirmation — also shown on the transactions page. */
 export function DuePanel({
   due,
   onChanged,

--- a/web/src/components/TaskBoard.tsx
+++ b/web/src/components/TaskBoard.tsx
@@ -27,10 +27,10 @@ interface Props {
 
 export function TaskBoard({ tasks, onChanged, onOpen }: Props) {
   const [dragging, setDragging] = useState<Task | null>(null);
-  // После броска карточки браузер всё равно отдаёт click по ней —
-  // без этого флага перетаскивание заканчивалось бы открытием задачи
+  // After a card is dropped the browser still fires a click on it —
+  // without this flag a drag would end with the task opening
   const justDragged = useRef(false);
-  // Локальная копия, чтобы карточка вставала на место сразу, не дожидаясь сервера
+  // Local copy so the card snaps into place immediately, without waiting for the server
   const [optimistic, setOptimistic] = useState<Task[] | null>(null);
   const current = optimistic ?? tasks;
 
@@ -43,7 +43,7 @@ export function TaskBoard({ tasks, onChanged, onOpen }: Props) {
     return map;
   }, [current]);
 
-  // Планшет: задержка не даёт спутать перетаскивание с прокруткой
+  // Tablet: the delay keeps a drag from being confused with a scroll
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 180, tolerance: 6 } }),
@@ -54,8 +54,8 @@ export function TaskBoard({ tasks, onChanged, onOpen }: Props) {
     setDragging(current.find((t) => t.id === event.active.id) ?? null);
   }
 
-  // click приходит синхронно после pointerup, то есть до этого таймера —
-  // флаг доживает ровно до конца текущего цикла событий
+  // click arrives synchronously after pointerup, i.e. before this timer —
+  // the flag lives exactly until the end of the current event cycle
   function dropDragFlag() {
     setTimeout(() => {
       justDragged.current = false;
@@ -71,7 +71,7 @@ export function TaskBoard({ tasks, onChanged, onOpen }: Props) {
     const task = current.find((t) => t.id === active.id);
     if (!task) return;
 
-    // Бросок на колонку даёт её идентификатор, бросок на карточку — соседа
+    // Dropping on a column yields its id, dropping on a card yields a sibling
     const overTask = current.find((t) => t.id === over.id);
     const target = (overTask?.status ?? over.id) as Status;
     if (!BOARD_COLUMNS.includes(target)) return;
@@ -167,9 +167,9 @@ function SortableCard({ task, onOpen }: { task: Task; onOpen: (task: Task) => vo
     id: task.id,
   });
 
-  // Клик открывает карточку, перетаскивание — перетаскивает: сенсор
-  // с порогом в 6px начинает drag только после заметного движения,
-  // поэтому обычный клик до него не дотягивает и остаётся кликом
+  // Click opens the card, dragging drags: a sensor with a 6px threshold
+  // starts the drag only after noticeable movement, so an ordinary click
+  // never reaches it and stays a click
   return (
     <div
       ref={setNodeRef}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -38,8 +38,8 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
   const [busy, setBusy] = useState(false);
   const [spawnedDate, setSpawnedDate] = useState<string | null>(null);
 
-  // Без списка зависимостей: подписка обновляется на каждый рендер,
-  // и save всегда видит актуальный черновик
+  // No dependency list: the subscription is refreshed on every render,
+  // so save always sees the current draft
   useEffect(() => {
     const onKey = dialogKeys(() => {
       if (!busy) void save();

--- a/web/src/components/TransactionDialog.tsx
+++ b/web/src/components/TransactionDialog.tsx
@@ -63,8 +63,8 @@ export function TransactionDialog({
   >([]);
   const [uploading, setUploading] = useState(false);
 
-  // Чеки подтягиваем только у существующей операции: к несохранённой
-  // прикладывать нечего
+  // Receipts are fetched only for an existing transaction: there is
+  // nothing to attach to an unsaved one
   useEffect(() => {
     if (!transaction) return;
     void api
@@ -77,7 +77,7 @@ export function TransactionDialog({
     if (!transaction || files.length === 0) return;
     setUploading(true);
     try {
-      // Снимок чека весит несколько мегабайт, а нужны с него сумма и дата
+      // A receipt photo weighs several megabytes, yet all we need from it is the amount and date
       const shrunk = await shrinkAll(files);
       const form = new FormData();
       for (const file of shrunk) form.append('file', file);
@@ -106,8 +106,8 @@ export function TransactionDialog({
 
   const account = accounts.find((a) => a.id === draft.account_id);
   const toAccount = accounts.find((a) => a.id === draft.to_account_id);
-  // Валюты не связаны: у перевода между разными валютами вторая сумма
-  // вводится руками, потому что курса в системе нет
+  // Currencies are unlinked: for a transfer between different currencies
+  // the second amount is entered by hand, because the system has no exchange rate
   const needsSecondAmount =
     kind === 'transfer' && account && toAccount && account.currency !== toAccount.currency;
 

--- a/web/src/components/WikiLink.ts
+++ b/web/src/components/WikiLink.ts
@@ -9,12 +9,13 @@ export interface WikiLinkOptions {
 }
 
 /**
- * Подсветка ссылок вида [[Заголовок]].
+ * Highlighting of [[Title]]-style links.
  *
- * Реализовано декорациями, а не собственным узлом схемы: текст остаётся
- * обычным текстом, поэтому markdown сериализуется без специальной обработки,
- * а заметка читается как есть даже в блокноте. Цена — ссылка не «объект»,
- * её можно испортить правкой руками, но для личных заметок это скорее плюс.
+ * Implemented with decorations rather than a custom schema node: the text
+ * stays plain text, so markdown serializes with no special handling and
+ * the note reads as-is even in a plain text editor. The price: a link is
+ * not an "object" and can be broken by hand-editing — but for personal
+ * notes that's arguably a plus.
  */
 export const WikiLink = Extension.create<WikiLinkOptions>({
   name: 'wikiLink',
@@ -50,7 +51,7 @@ export const WikiLink = Extension.create<WikiLinkOptions>({
           handleClick(_view, _pos, event) {
             const target = event.target as HTMLElement | null;
             const title = target?.closest<HTMLElement>('.wiki-link')?.dataset['title'];
-            // Переход только по Cmd/Ctrl — иначе нельзя было бы поставить курсор
+            // Navigate only with Cmd/Ctrl — otherwise placing the cursor would be impossible
             if (title && (event.metaKey || event.ctrlKey)) {
               onNavigate(title);
               return true;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,7 +31,7 @@ export const api = {
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 };
 
-// ── Типы, разделяемые с сервером ──────────────────────────────────────────
+// ── Types shared with the server ──────────────────────────────────────────
 
 export type TaskStatus = 'backlog' | 'todo' | 'in_progress' | 'done' | 'cancelled';
 export type TaskPriority = 'low' | 'normal' | 'high' | 'urgent';
@@ -75,7 +75,7 @@ export interface HouseholdMember {
   color: string;
 }
 
-/** Ответ на изменение задачи: сама задача и порождённый повтор, если он был. */
+/** Response to a task mutation: the task itself plus the spawned recurrence, if any. */
 export interface TaskMutation {
   task: Task;
   spawned: Task | null;

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -17,7 +17,7 @@ interface AuthState {
   loading: boolean;
   mustChangePassword: boolean;
   login: (email: string, password: string) => Promise<void>;
-  /** Вход в демо: сервер создаёт песочницу и сессию, пароля нет. */
+  /** Demo login: the server creates a sandbox and a session, no password involved. */
   loginDemo: () => Promise<void>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -80,7 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 export function useAuth(): AuthState {
   const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error('useAuth вызван вне AuthProvider');
+  if (!ctx) throw new Error('useAuth called outside AuthProvider');
   return ctx;
 }
 

--- a/web/src/lib/calendar.ts
+++ b/web/src/lib/calendar.ts
@@ -1,13 +1,13 @@
 import { t } from './i18n';
 
-/** Календарь по умолчанию — единственный с заранее известным id (миграция 006). */
+/** The default calendar — the only one with an id known in advance (migration 006). */
 export const SHARED_CALENDAR_ID = '00000000-0000-4000-8000-000000000201';
 
 /**
- * Имя календаря для показа. «Общий» — данные, а не интерфейс: он засеян
- * миграцией в базу по-русски, и словарь t() его не видит. Календарь один
- * и известен по фиксированному id — переводим на месте, как projectTitle
- * для «Входящих» в tasks.ts.
+ * Calendar name for display. «Общий» is data, not UI: a migration seeds it
+ * into the DB in Russian, so the t() dictionary never sees it. There is one
+ * such calendar with a fixed id — translate in place, same as projectTitle
+ * does for the Inbox in tasks.ts.
  */
 export function calendarName(id: string, name: string): string {
   return id === SHARED_CALENDAR_ID && name === 'Общий' ? t('Общий') : name;
@@ -29,7 +29,7 @@ export interface Participant {
   color: string;
 }
 
-/** Один экземпляр события: у повторяющейся серии их много. */
+/** One instance of an event: a recurring series has many. */
 export interface Occurrence {
   id: string;
   event_id: string;
@@ -69,9 +69,9 @@ export const REMIND_OPTIONS: { value: string; label: string }[] = [
 ];
 
 /**
- * Настройки вида хранятся на устройстве, а не в базе.
- * На стенде всегда неделя, на телефоне удобнее лента — и это разные
- * предпочтения одного и того же человека, а не одно общее.
+ * View settings live on the device, not in the DB.
+ * The kiosk always shows the week, the phone is better with the agenda —
+ * these are different preferences of the same person, not one shared one.
  */
 export function loadLocal<T>(key: string, fallback: T): T {
   try {
@@ -86,6 +86,6 @@ export function saveLocal(key: string, value: unknown): void {
   try {
     localStorage.setItem(`hub.calendar.${key}`, JSON.stringify(value));
   } catch {
-    // Приватный режим браузера может запрещать запись — не повод падать
+    // Private browsing may forbid writes — no reason to crash
   }
 }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,10 +1,10 @@
 import { intlLocale, tPlural } from './i18n';
 
 /*
-  Начало недели — настройка устройства, как язык: читается синхронно
-  при загрузке модуля, смена перезагружает страницу. Вся сетка календаря
-  считает дни через weekdayIndex/startOfWeek, поэтому параметризуются
-  только они — остальное подстраивается само.
+  Week start is a device setting, like language: read synchronously at
+  module load, changing it reloads the page. The whole calendar grid
+  computes days through weekdayIndex/startOfWeek, so only those two are
+  parameterized — everything else adjusts on its own.
 */
 export type WeekStart = 'mon' | 'sun';
 
@@ -22,17 +22,17 @@ export function setWeekStart(next: WeekStart): void {
   try {
     localStorage.setItem('hub-week-start', next);
   } catch {
-    // Нет localStorage — настройка просто не запомнится
+    // No localStorage — the setting just won't stick
   }
   window.location.reload();
 }
 
-/** Сдвиг дня недели относительно начала недели: 0 — первый день сетки. */
+/** Weekday shift relative to the week start: 0 is the grid's first day. */
 const START_SHIFT = weekStart === 'mon' ? 6 : 0;
 
 /**
- * «14 ноября» / «14 November» — без года, если год текущий.
- * Intl сам знает русский родительный падеж, ручные массивы месяцев не нужны.
+ * «14 ноября» / «14 November» — year omitted when it is the current one.
+ * Intl knows the Russian genitive itself, no hand-rolled month arrays.
  */
 export function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -45,8 +45,9 @@ export function formatDate(iso: string): string {
 }
 
 /**
- * Множественное число. Формы задаются русской тройкой (день/дня/дней) —
- * для английского она же служит ключом словаря пар (см. i18n.en.ts).
+ * Pluralization. Forms are given as the Russian triple (день/дня/дней) —
+ * for English the same triple serves as the key into the pair dictionary
+ * (see i18n.en.ts).
  */
 export function plural(n: number, one: string, few: string, many: string): string {
   return tPlural(n, [one, few, many]);
@@ -69,30 +70,30 @@ export function formatEur(value: number): string {
   }).format(value);
 }
 
-// ── Даты для календаря ────────────────────────────────────────────────────
+// ── Calendar dates ────────────────────────────────────────────────────────
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-/** Названия месяцев в именительном — для заголовков календаря. */
+/** Month names in the nominative case — for calendar headers. */
 export const MONTHS_NOM = Array.from({ length: 12 }, (_, m) =>
   capitalize(
     new Intl.DateTimeFormat(intlLocale, { month: 'long' }).format(new Date(Date.UTC(2026, m, 1))),
   ),
 );
 
-/** Короткие дни недели, с настроенного первого дня. */
+/** Short weekday names, starting from the configured first day. */
 export const WEEKDAYS_SHORT = Array.from({ length: 7 }, (_, i) =>
   capitalize(
     new Intl.DateTimeFormat(intlLocale, { weekday: 'short', timeZone: 'UTC' })
-      // 5 января 2026 — понедельник, 4-е — воскресенье
+      // January 5, 2026 is a Monday, the 4th a Sunday
       .format(new Date(Date.UTC(2026, 0, (weekStart === 'mon' ? 5 : 4) + i)))
       .replace('.', ''),
   ),
 );
 
-/** Все операции с датами — в UTC, чтобы переход на летнее время не сдвигал сетку. */
+/** All date arithmetic in UTC so a DST switch never shifts the grid. */
 export function toDate(iso: string): Date {
   return new Date(`${iso.slice(0, 10)}T00:00:00Z`);
 }
@@ -117,7 +118,7 @@ export function addMonths(iso: string, months: number): string {
   return toISO(d);
 }
 
-/** Первый день недели — по настройке устройства. */
+/** First day of the week — per the device setting. */
 export function startOfWeek(iso: string): string {
   const d = toDate(iso);
   const shift = (d.getUTCDay() + START_SHIFT) % 7;
@@ -141,7 +142,7 @@ export function weekdayIndex(iso: string): number {
   return (toDate(iso).getUTCDay() + START_SHIFT) % 7;
 }
 
-/** Суббота и воскресенье — независимо от того, с чего начинается сетка. */
+/** Saturday and Sunday — regardless of where the grid starts. */
 export function isWeekend(iso: string): boolean {
   const day = toDate(iso).getUTCDay();
   return day === 0 || day === 6;
@@ -153,7 +154,7 @@ export function monthTitle(iso: string): string {
   return `${month} ${d.getUTCFullYear()}`;
 }
 
-/** «3 — 9 августа» или «29 сентября — 5 октября». */
+/** «3 — 9 August» or «29 September — 5 October». */
 export function rangeTitle(from: string, to: string): string {
   const a = toDate(from);
   const b = toDate(to);
@@ -161,15 +162,16 @@ export function rangeTitle(from: string, to: string): string {
   return `${left} — ${formatDate(to)}`;
 }
 
-/** Из '2026-09-15T10:30' достаём '10:30'. */
+/** From '2026-09-15T10:30' extract '10:30'. */
 export function timeOf(value: string): string {
   return value.length > 10 ? value.slice(11, 16) : '';
 }
 
 /**
- * Метка времени из базы в местное время.
- * Сервер пишет ISO в UTC без обозначения зоны, поэтому зону дописываем
- * вручную — иначе браузер считает строку местным временем и час теряется.
+ * DB timestamp rendered in local time.
+ * The server writes ISO in UTC without a zone marker, so the zone is
+ * appended by hand — otherwise the browser reads the string as local
+ * time and an hour goes missing.
  */
 export function formatStamp(stored: string): string {
   const iso = stored.includes('T') ? stored : stored.replace(' ', 'T');

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1,22 +1,22 @@
 import { en, enPlurals } from './i18n.en';
 
 /*
-  Интернационализация. Подход: русские строки — ключи словаря.
+  Internationalization. Approach: Russian strings are the dictionary keys.
 
-  В коде остаётся t('Сохранить'); английский словарь (i18n.en.ts) отдаёт
-  перевод, русский язык — тождество. Что это даёт:
+  Code keeps t('Сохранить'); the English dictionary (i18n.en.ts) supplies
+  the translation, Russian is the identity. What this buys:
 
-  — русская локаль полна по построению, словарь для неё не нужен;
-  — пропущенный в en-словаре ключ виден (покажется по-русски),
-    но ничего не ломает;
-  — ошибки сервера переводятся той же t() в одной точке (lib/api.ts):
-    сервер шлёт русский текст, клиент показывает на языке интерфейса.
+  — the Russian locale is complete by construction, no dictionary needed;
+  — a key missing from the en dictionary is visible (shows up in Russian)
+    but breaks nothing;
+  — server errors are translated by the same t() in one place (lib/api.ts):
+    the server sends Russian text, the client shows it in the UI language.
 
-  Язык — настройка устройства (localStorage), а не учётки: телефон жены
-  и общий стенд могут говорить на разных языках. По умолчанию английский.
-  Смена языка перезагружает страницу: это одноразовое действие,
-  и перезагрузка избавляет от реактивной обвязки — t() остаётся
-  чистой функцией, пригодной и вне React.
+  Language is a device setting (localStorage), not an account one: the
+  wife's phone and a shared kiosk may speak different languages. Default is
+  English. Switching languages reloads the page: it is a one-off action,
+  and the reload removes the need for reactive plumbing — t() stays a pure
+  function, usable outside React too.
 */
 
 export type Lang = 'en' | 'ru';
@@ -34,10 +34,10 @@ function readLang(): Lang {
 
 export const lang: Lang = readLang();
 
-// Атрибуты документа — под выбранный язык. index.html статически заявляет
-// английский (язык по умолчанию), здесь он уточняется по факту: заголовок
-// вкладки и lang для читалок должны совпадать с языком интерфейса.
-// Проверка на document — модуль импортируется и в Node (тесты).
+// Document attributes follow the chosen language. index.html statically
+// declares English (the default); here it is corrected to the actual one:
+// the tab title and lang for screen readers must match the UI language.
+// The document check is because the module is also imported in Node (tests).
 if (typeof document !== 'undefined') {
   document.documentElement.lang = lang;
   document.title = lang === 'ru' ? 'Дом' : 'Family Hub';
@@ -47,12 +47,12 @@ export function setLang(next: Lang): void {
   try {
     localStorage.setItem(STORAGE_KEY, next);
   } catch {
-    // Приватный режим без localStorage — язык просто не запомнится
+    // Private mode without localStorage — the language just won't stick
   }
   window.location.reload();
 }
 
-/** Перевод строки. Подстановки — {name} из params. */
+/** Translate a string. Substitutions: {name} from params. */
 export function t(key: string, params?: Record<string, string | number>): string {
   let out = lang === 'ru' ? key : (en[key] ?? key);
   if (params) {
@@ -64,8 +64,8 @@ export function t(key: string, params?: Record<string, string | number>): string
 }
 
 /**
- * Множественное число. Формы задаются русской тройкой (день/дня/дней) —
- * она же ключ для английской пары в enPlurals.
+ * Pluralization. Forms are given as the Russian triple (день/дня/дней) —
+ * which doubles as the key for the English pair in enPlurals.
  */
 export function tPlural(n: number, forms: [string, string, string]): string {
   if (lang === 'ru') {
@@ -80,5 +80,5 @@ export function tPlural(n: number, forms: [string, string, string]): string {
   return n === 1 ? pair[0] : pair[1];
 }
 
-/** Локаль для Intl-форматтеров дат и чисел. */
+/** Locale for Intl date and number formatters. */
 export const intlLocale = lang === 'ru' ? 'ru-RU' : 'en-GB';

--- a/web/src/lib/image.ts
+++ b/web/src/lib/image.ts
@@ -1,10 +1,11 @@
 /**
- * Уменьшение изображения перед отправкой.
+ * Downscale an image before upload.
  *
- * Снимок чека с телефона весит 3–5 МБ, а читать с него нужно только сумму
- * и дату. Без уменьшения бюджет вложений в 2 ГБ кончится на пятистах чеках,
- * причём большая часть места уйдёт на детали, которые никто не разглядывает.
- * Не-картинки и мелкие файлы отдаются как есть.
+ * A receipt photo from a phone weighs 3–5 MB, yet all you read off it is
+ * the amount and the date. Without downscaling the 2 GB attachment budget
+ * runs out after five hundred receipts, with most of the space spent on
+ * detail nobody ever inspects. Non-images and small files pass through
+ * untouched.
  */
 const MAX_SIDE = 1600;
 const QUALITY = 0.8;
@@ -12,7 +13,7 @@ const SKIP_BELOW = 300 * 1024;
 
 export async function shrinkImage(file: File): Promise<File> {
   if (!file.type.startsWith('image/')) return file;
-  // SVG — вектор, растрировать его бессмысленно
+  // SVG is a vector format — rasterizing it makes no sense
   if (file.type === 'image/svg+xml') return file;
   if (file.size < SKIP_BELOW) return file;
 
@@ -38,7 +39,7 @@ export async function shrinkImage(file: File): Promise<File> {
     const name = file.name.replace(/\.[^.]+$/, '') + '.jpg';
     return new File([blob], name, { type: 'image/jpeg', lastModified: file.lastModified });
   } catch {
-    // Если браузер не смог разобрать картинку — отправляем оригинал
+    // Browser failed to decode the image — upload the original
     return file;
   }
 }

--- a/web/src/lib/keys.ts
+++ b/web/src/lib/keys.ts
@@ -1,15 +1,15 @@
 import type { KeyboardEvent } from 'react';
 
 /**
- * Enter отправляет форму.
+ * Enter submits the form.
  *
- * Полагаться только на неявную отправку формы браузером оказалось ненадёжно:
- * поведение отличается между полями, браузерами и экранной клавиатурой.
- * Дешевле обработать явно везде, где человек может нажать Enter.
+ * Relying on the browser's implicit form submission proved unreliable:
+ * behavior differs across fields, browsers and the on-screen keyboard.
+ * Cheaper to handle it explicitly wherever a person might press Enter.
  *
- * Ввод иероглифов и других языков с составным вводом не ломаем: во время
- * набора через IME браузер выставляет isComposing, и Enter там означает
- * «подтвердить символ», а не «отправить».
+ * CJK and other composed input stays intact: while typing through an IME
+ * the browser sets isComposing, and Enter there means "confirm the
+ * character", not "submit".
  */
 export function onEnter<T extends HTMLElement>(action: () => void) {
   return (e: KeyboardEvent<T>) => {
@@ -20,14 +20,14 @@ export function onEnter<T extends HTMLElement>(action: () => void) {
 }
 
 /**
- * Клавиши диалога, слушаются на уровне окна: Enter выполняет главное
- * действие, Escape закрывает — где бы ни находился фокус, а не только
- * в текстовом поле с собственным обработчиком.
+ * Dialog keys, listened for at the window level: Enter runs the primary
+ * action, Escape closes — wherever the focus is, not just in a text field
+ * with its own handler.
  *
- * Enter пропускается там, где у него уже есть работа: в textarea и
- * редакторе он вводит перенос строки, на кнопке и ссылке — нажимает их.
- * Полевой обработчик onEnter срабатывает раньше и ставит defaultPrevented,
- * поэтому отправка не задваивается.
+ * Enter is skipped where it already has a job: in a textarea and the
+ * editor it inserts a line break, on a button or link it presses them.
+ * The field-level onEnter handler fires first and sets defaultPrevented,
+ * so submission never doubles.
  */
 export function dialogKeys(submit: () => void, close: () => void) {
   return (e: globalThis.KeyboardEvent) => {

--- a/web/src/lib/latest.ts
+++ b/web/src/lib/latest.ts
@@ -1,28 +1,28 @@
 import { useCallback, useRef } from 'react';
 
 /**
- * Защита от устаревших ответов.
+ * Guard against stale responses.
  *
- * Когда фильтр или диапазон меняются быстрее, чем отвечает сервер, ответы
- * приходят не в том порядке, в каком уходили запросы. Последний пришедший
- * перетирает состояние — и на экране оказываются данные не того диапазона.
- * Ловится это только в живом браузере: на сервере всё отвечает мгновенно.
+ * When the filter or range changes faster than the server responds,
+ * replies arrive out of request order. The last one in overwrites state —
+ * and the screen ends up showing data for the wrong range. This only
+ * reproduces in a live browser: locally everything responds instantly.
  *
- * Использование:
+ * Usage:
  *   const isLatest = useLatest();
  *   const load = useCallback(async () => {
  *     const fresh = isLatest();
  *     const data = await api.get(...);
- *     if (!fresh()) return;   // пока ждали, запросили другое
+ *     if (!fresh()) return;   // something else was requested meanwhile
  *     setState(data);
  *   }, [...]);
  *
- * Возвращаемая функция обязана быть стабильной (useCallback без
- * зависимостей): она лежит в зависимостях load на каждой странице,
- * а load — в зависимостях эффекта загрузки. Новая функция на каждый
- * рендер замыкала это в кольцо «запрос → setState → рендер → новый
- * load → эффект → запрос»: страницы бесконечно перезагружали данные,
- * прожигая память вкладки и лимиты запросов на сервере.
+ * The returned function must be stable (useCallback with no deps): it
+ * sits in load's dependencies on every page, and load sits in the loading
+ * effect's dependencies. A new function on every render closed this into
+ * a loop of "request → setState → render → new load → effect → request":
+ * pages reloaded data endlessly, burning tab memory and the server's
+ * rate limits.
  */
 export function useLatest(): () => () => boolean {
   const seq = useRef(0);

--- a/web/src/lib/money.test.ts
+++ b/web/src/lib/money.test.ts
@@ -9,7 +9,7 @@ import {
 } from './money';
 
 describe('parseAmount', () => {
-  it('целые и дробные, оба разделителя', () => {
+  it('integers and decimals, both separators', () => {
     expect(parseAmount('1234')).toBe(123400);
     expect(parseAmount('1234.56')).toBe(123456);
     expect(parseAmount('1234,56')).toBe(123456);
@@ -17,49 +17,49 @@ describe('parseAmount', () => {
     expect(parseAmount('0')).toBe(0);
   });
 
-  it('группировка тысяч: десятичный разделитель — тот, что правее', () => {
+  it('thousands grouping: the decimal separator is the rightmost one', () => {
     expect(parseAmount('1,234.56')).toBe(123456);
     expect(parseAmount('1.234,56')).toBe(123456);
     expect(parseAmount('1 234.56')).toBe(123456);
     expect(parseAmount('1 234,56')).toBe(123456);
   });
 
-  it('одиночный разделитель с тремя знаками — двусмысленность, отказ', () => {
-    // «1,500» — то ли полторы тысячи, то ли полтора: лучше честный отказ,
-    // чем молчаливая ошибка в тысячу раз. Поле ввода такое не порождает
-    // (formatAmountInput не группирует), а вставку из буфера с группировкой
-    // спасает вариант с обоими разделителями выше (там разделитель тысяч
-    // определяется однозначно).
+  it('single separator with three digits is ambiguous — reject', () => {
+    // «1,500» — fifteen hundred or one and a half: an honest rejection
+    // beats a silent thousand-fold error. Input fields never produce this
+    // (formatAmountInput doesn't group), and pasting grouped text from the
+    // clipboard is saved by the both-separators case above (there the
+    // thousands separator is unambiguous).
     expect(parseAmount('1,500')).toBeNull();
     expect(parseAmount('1.500')).toBeNull();
   });
 
-  it('мусор и отрицательные — null', () => {
+  it('garbage and negatives — null', () => {
     expect(parseAmount('')).toBeNull();
     expect(parseAmount('abc')).toBeNull();
-    expect(parseAmount('12.345')).toBeNull(); // три знака после точки — не сумма
+    expect(parseAmount('12.345')).toBeNull(); // three digits after the dot is not an amount
     expect(parseAmount('-5')).toBeNull();
     expect(parseAmount('1..2')).toBeNull();
   });
 
-  it('копейки не теряются на округлении', () => {
-    // 19.99 * 100 = 1998.9999… в плавающей точке — Math.round обязателен
+  it('cents survive rounding', () => {
+    // 19.99 * 100 = 1998.9999… in floating point — Math.round is mandatory
     expect(parseAmount('19.99')).toBe(1999);
     expect(parseAmount('0.07')).toBe(7);
   });
 });
 
 describe('formatAmountInput → parseAmount: round-trip', () => {
-  // Поле ввода обязано показывать то, что разбор гарантированно примет
-  // обратно — реальный баг: локализованное «1,500» разбиралось как 1.5
+  // The input field must show what the parser is guaranteed to accept
+  // back — real bug: localized «1,500» parsed as 1.5
   it.each([0, 1, 99, 100, 123456, 150000, 999999999, 1999, 7])(
-    'минорные %i выживают round-trip',
+    'minor units %i survive the round-trip',
     (minor) => {
       expect(parseAmount(formatAmountInput(minor))).toBe(minor);
     },
   );
 
-  it('формат без локали и группировки', () => {
+  it('formats without locale or grouping', () => {
     expect(formatAmountInput(150000)).toBe('1500');
     expect(formatAmountInput(123456)).toBe('1234.56');
   });
@@ -95,7 +95,7 @@ describe('orderCategories', () => {
     parent_id: parent,
   });
 
-  it('дети идут сразу за родителем с глубиной 1', () => {
+  it('children follow their parent immediately at depth 1', () => {
     const ordered = orderCategories([cat('fuel', 'car'), cat('car'), cat('food')]);
     expect(ordered.map((o) => [o.category.id, o.depth])).toEqual([
       ['car', 0],
@@ -104,13 +104,13 @@ describe('orderCategories', () => {
     ]);
   });
 
-  it('подкатегория со скрытым родителем поднимается на верхний уровень', () => {
-    // Родителя нет в пуле (в архиве) — ребёнок не должен исчезнуть
+  it('a subcategory with a hidden parent is promoted to the top level', () => {
+    // The parent is not in the pool (archived) — the child must not vanish
     const ordered = orderCategories([cat('fuel', 'car-archived')]);
     expect(ordered).toEqual([{ category: cat('fuel', 'car-archived'), depth: 0 }]);
   });
 
-  it('фильтр по kind не ломает связку родитель-ребёнок', () => {
+  it('filtering by kind keeps the parent-child pairing intact', () => {
     const ordered = orderCategories(
       [cat('car'), cat('fuel', 'car'), cat('salary', null, 'income')],
       'expense',

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -18,7 +18,7 @@ export interface Account {
   tx_count: number;
   last_actual: number | null;
   last_checked_on: string | null;
-  /** Остаток на момент последней сверки — с ним и сравнивается актуал. */
+  /** Balance as of the last reconciliation — what the actual is compared against. */
   checked_balance: number | null;
 }
 
@@ -27,14 +27,14 @@ export interface Category {
   name: string;
   kind: 'expense' | 'income';
   color: string;
-  /** Родительская категория. Глубина иерархии — один уровень. */
+  /** Parent category. Hierarchy is exactly one level deep. */
   parent_id: string | null;
 }
 
 /**
- * Категории в порядке показа: родитель, сразу за ним его подкатегории.
- * Подкатегория, чей родитель скрыт (в архиве), поднимается на верхний
- * уровень — иначе она бы исчезла из всех списков.
+ * Categories in display order: parent, then its subcategories right after.
+ * A subcategory whose parent is hidden (archived) is promoted to the top
+ * level — otherwise it would vanish from every list.
  */
 export function orderCategories(
   categories: Category[],
@@ -116,19 +116,19 @@ export const TX_KIND_LABEL: Record<TxKind, string> = {
 };
 
 /**
- * Валюты, которые заводятся в один клик. Любой другой трёхбуквенный код
- * ISO 4217 вводится руками — сервер принимает любой, Intl отформатирует.
+ * One-click currencies. Any other three-letter ISO 4217 code is typed in
+ * by hand — the server accepts anything, Intl handles the formatting.
  */
 export const COMMON_CURRENCIES = ['EUR', 'RSD', 'USD', 'GBP', 'CHF', 'PLN', 'CZK', 'SEK', 'HUF'];
 
 /**
- * Суммы везде целые, в минорных единицах: 1234.56 → 123456.
- * Числа с плавающей точкой в деньгах дают ошибку округления, которая
- * копится в суммах и в итоге расходится с банком.
+ * Amounts are integers everywhere, in minor units: 1234.56 → 123456.
+ * Floating point in money produces rounding error that accumulates in
+ * totals and eventually disagrees with the bank.
  */
 export function formatMoney(minor: number, currency: string): string {
-  // Копейки показываем только когда они есть: в динарах их обычно нет,
-  // и «2 345,00 RSD» вместо «2 345 RSD» лишний шум
+  // Show cents only when present: dinars usually have none, and
+  // «2 345,00 RSD» instead of «2 345 RSD» is just noise
   const fraction = minor % 100 === 0 ? 0 : 2;
   try {
     return new Intl.NumberFormat(intlLocale, {
@@ -138,7 +138,7 @@ export function formatMoney(minor: number, currency: string): string {
       maximumFractionDigits: 2,
     }).format(minor / 100);
   } catch {
-    // Неизвестный код валюты Intl не примет — показываем как есть
+    // Intl rejects unknown currency codes — show it as is
     return `${(minor / 100).toLocaleString(intlLocale, {
       minimumFractionDigits: fraction,
       maximumFractionDigits: 2,
@@ -146,7 +146,7 @@ export function formatMoney(minor: number, currency: string): string {
   }
 }
 
-/** Без знака валюты — для компактных мест, где сумму только читают. */
+/** Without the currency sign — for compact spots where the amount is read-only. */
 export function formatAmount(minor: number): string {
   const fraction = minor % 100 === 0 ? 0 : 2;
   return (minor / 100).toLocaleString(intlLocale, {
@@ -156,13 +156,13 @@ export function formatAmount(minor: number): string {
 }
 
 /**
- * Формат для полей ввода: без локали и группировки, точка как разделитель.
+ * Format for input fields: no locale, no grouping, dot as the separator.
  *
- * Локализованный formatAmount сюда не годится: английская локаль ставит
- * запятую тысяч («1,500»), которую parseAmount принимал за десятичную
- * точку и отклонял строку — при редактировании операции сумму приходилось
- * вводить заново, даже если она не менялась. Поле должно показывать то,
- * что разбор гарантированно примет обратно.
+ * The localized formatAmount won't do here: the English locale inserts a
+ * thousands comma («1,500»), which parseAmount took for a decimal point
+ * and rejected the string — editing a transaction meant retyping the
+ * amount even when it hadn't changed. The field must show what the parser
+ * is guaranteed to accept back.
  */
 export function formatAmountInput(minor: number): string {
   const value = minor / 100;
@@ -170,15 +170,15 @@ export function formatAmountInput(minor: number): string {
 }
 
 /**
- * Разбор введённой суммы в минорные единицы.
- * Принимает «1234,56», «1 234.56», «1,234.56», «1.234,56», «1234».
- * Возвращает null, если не число.
+ * Parse an entered amount into minor units.
+ * Accepts «1234,56», «1 234.56», «1,234.56», «1.234,56», «1234».
+ * Returns null if not a number.
  */
 export function parseAmount(input: string): number | null {
   let cleaned = input.replace(/[\s\u00a0]/g, '');
 
-  // Если есть оба разделителя, десятичный — тот, что правее,
-  // второй группирует тысячи: «1,234.56» и «1.234,56» равнозначны.
+  // When both separators are present, the decimal one is the rightmost,
+  // the other groups thousands: «1,234.56» and «1.234,56» are equivalent.
   const lastComma = cleaned.lastIndexOf(',');
   const lastDot = cleaned.lastIndexOf('.');
   if (lastComma !== -1 && lastDot !== -1) {
@@ -203,7 +203,7 @@ export function monthBounds(anchor: string): { from: string; to: string } {
   return { from, to: last.toISOString().slice(0, 10) };
 }
 
-/** Счета по валютам: общего итога без курса не бывает. */
+/** Accounts grouped by currency: no grand total without an exchange rate. */
 export function groupByCurrency(accounts: Account[]): { currency: string; total: number; items: Account[] }[] {
   const map = new Map<string, Account[]>();
   for (const a of accounts) {

--- a/web/src/lib/tasks.ts
+++ b/web/src/lib/tasks.ts
@@ -12,7 +12,7 @@ export const STATUS_LABEL: Record<Status, string> = {
   cancelled: t('Отменено'),
 };
 
-/** Колонки доски. «Отменено» на доске не показываем — это не этап, а исход. */
+/** Board columns. «Cancelled» is not shown on the board — it is an outcome, not a stage. */
 export const BOARD_COLUMNS: Status[] = ['backlog', 'todo', 'in_progress', 'done'];
 
 export const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
@@ -37,13 +37,13 @@ export const RECURRENCE_OPTIONS: { value: string; label: string }[] = [
   { value: 'FREQ=YEARLY', label: t('Каждый год') },
 ];
 
-/** Проект по умолчанию — единственный, чей id известен заранее (миграция 004). */
+/** The default project — the only one whose id is known in advance (migration 004). */
 export const INBOX_ID = '00000000-0000-4000-8000-000000000001';
 
 /**
- * Название проекта для показа. «Входящие» — данные, а не интерфейс:
- * они засеяны миграцией в базу по-русски, и словарь t() их не видит.
- * Проект один и известен по фиксированному id — переводим на месте.
+ * Project title for display. «Входящие» (Inbox) is data, not UI: a
+ * migration seeds it into the DB in Russian, so the t() dictionary never
+ * sees it. One such project with a fixed id — translate in place.
  */
 export function projectTitle(id: string | null | undefined, title: string): string {
   return id === INBOX_ID ? t('Входящие') : title;
@@ -54,9 +54,10 @@ export interface TaskNode extends Task {
 }
 
 /**
- * Плоский список превращаем в дерево, сохраняя порядок из ответа сервера.
- * Задачи, чей родитель отфильтрован, поднимаются на верхний уровень —
- * иначе они бы просто исчезли из выдачи, и человек решил бы, что их нет.
+ * Turn the flat list into a tree, keeping the server response order.
+ * Tasks whose parent got filtered out are promoted to the top level —
+ * otherwise they would silently vanish, and a person would assume they
+ * do not exist.
  */
 export function buildTree(tasks: Task[]): TaskNode[] {
   const nodes = new Map<string, TaskNode>();

--- a/web/src/pages/Calendar.tsx
+++ b/web/src/pages/Calendar.tsx
@@ -32,14 +32,14 @@ const chip = 'rounded-full border px-3 py-1.5 text-sm transition-colors';
 const chipOn = 'border-accent bg-accent-soft text-accent';
 const chipOff = 'border-line text-muted hover:text-ink';
 
-/** Границы запроса для выбранного вида. */
+/** Request bounds for the selected view. */
 function rangeFor(view: CalendarView, anchor: string): { from: string; to: string } {
   if (view === 'week') {
     const from = startOfWeek(anchor);
     return { from, to: addDays(from, 6) };
   }
   if (view === 'month') {
-    // Сетка месяца показывает и хвосты соседних месяцев
+    // The month grid also shows the tails of adjacent months
     return { from: startOfWeek(startOfMonth(anchor)), to: addDays(startOfWeek(endOfMonth(anchor)), 6) };
   }
   return { from: anchor, to: addDays(anchor, 45) };
@@ -82,7 +82,7 @@ export function Calendar() {
           ? api.get<Task[]>(`/tasks?due_after=${from}&due_before=${to}&include_done=true`)
           : Promise.resolve([]),
       ]);
-      // Пока ждали, диапазон мог смениться — тогда этот ответ уже не нужен
+      // The range may have changed while waiting — then this response is stale
       if (!fresh()) return;
       setOccurrences(events);
       setTasks(dueTasks);
@@ -103,7 +103,7 @@ export function Calendar() {
     void load();
   }, [load]);
 
-  // Переход из общего поиска: /calendar?date=<ГГГГ-ММ-ДД>
+  // Arriving from global search: /calendar?date=<YYYY-MM-DD>
   useEffect(() => {
     const date = params.get('date');
     if (!date) return;
@@ -160,7 +160,7 @@ export function Calendar() {
         </div>
       }
     >
-      {/* Навигация */}
+      {/* Navigation */}
       <div className="mb-4 flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-1">
           <button
@@ -199,7 +199,7 @@ export function Calendar() {
         </button>
       </div>
 
-      {/* Слои */}
+      {/* Layers */}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         {calendars.map((c) => {
           const on = !hidden.includes(c.id);

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -15,9 +15,9 @@ const PRIORITY_LABEL: Record<Task['priority'], string> = {
 };
 
 /*
-  Каждая строка дашборда ведёт туда, где с ней можно что-то сделать.
-  Задача открывает свою карточку, событие — календарь на нужной дате,
-  заметка — саму заметку. Показывать список без перехода — тупик.
+  Every dashboard row leads to where something can be done about it.
+  A task opens its card, an event the calendar at the right date, a note
+  the note itself. Showing a list with nowhere to go is a dead end.
 */
 function TaskRow({ task, overdue }: { task: Task; overdue?: boolean }) {
   return (
@@ -86,10 +86,10 @@ function EventRow({ occurrence }: { occurrence: Occurrence }) {
 }
 
 /**
- * Быстрые действия — только на телефоне. Главная на телефоне открывается,
- * чтобы что-то записать на ходу: задачу, трату, заметку. Три крупные
- * кнопки решают это в одно касание, на широких экранах их роль выполняют
- * Cmd+K и кнопки разделов.
+ * Quick actions — phone only. On the phone the home screen is opened to
+ * jot something down on the go: a task, an expense, a note. Three big
+ * buttons solve that in one tap; on wide screens Cmd+K and the section
+ * buttons play that role.
  */
 function QuickActions() {
   const navigate = useNavigate();
@@ -170,7 +170,7 @@ export function Dashboard() {
         .catch((e: Error) => alive && setError(e.message));
 
     void load();
-    // Стенд висит открытым сутками — обновляем сам, без перезагрузки страницы.
+    // The kiosk stays open for days — refresh ourselves, no page reload.
     const timer = setInterval(load, 60_000);
     return () => {
       alive = false;

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -35,7 +35,7 @@ const inputClass =
 const buttonClass =
   'w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50';
 
-/** Сообщения после возврата от Google — код приезжает в ?google= */
+/** Messages after returning from Google — the code arrives in ?google= */
 const GOOGLE_MESSAGES: Record<string, string> = {
   not_linked:
     t('Этот Google-аккаунт не привязан ни к одной учётке. Войдите по паролю и привяжите его в настройках.'),
@@ -50,7 +50,7 @@ export function Login() {
   const [busy, setBusy] = useState(false);
   const [googleAvailable, setGoogleAvailable] = useState(false);
   const [demo, setDemo] = useState(false);
-  // null — ещё выясняем; false — пустая база, показываем первичную настройку
+  // null — still finding out; false — empty DB, show the first-run setup
   const [initialized, setInitialized] = useState<boolean | null>(null);
 
   useEffect(() => {
@@ -62,7 +62,7 @@ export function Login() {
         setDemo(Boolean(s.demo));
       })
       .catch(() => setInitialized(true));
-    // Итог захода через Google приходит редиректом с кодом в адресе
+    // The outcome of a Google sign-in arrives as a redirect with a code in the URL
     const code = new URLSearchParams(window.location.search).get('google');
     if (code && GOOGLE_MESSAGES[code]) {
       setError(GOOGLE_MESSAGES[code]);
@@ -83,7 +83,7 @@ export function Login() {
     }
   }
 
-  // Пришли по пригласительной ссылке — форма регистрации вместо входа
+  // Arrived via an invite link — registration form instead of login
   if (window.location.pathname === '/join') {
     return <Join />;
   }
@@ -102,7 +102,7 @@ export function Login() {
   if (initialized === null) return null;
   if (!initialized) return <Setup />;
 
-  // Демо: пароля нет, сервер выдаёт каждому личную песочницу по кнопке
+  // Demo: no password, the server hands everyone a personal sandbox at the press of a button
   if (demo) {
     return (
       <Frame title={t('Демо')} hint={t('Семейный хаб')}>
@@ -193,8 +193,8 @@ export function Login() {
 }
 
 /**
- * Первичная настройка: база пуста, создаётся первая учётка — администратор.
- * Пароли в журналах сервера больше не печатаются.
+ * First-run setup: the DB is empty, the first account being created is
+ * the admin. Passwords are no longer printed in the server logs.
  */
 function Setup() {
   const [name, setName] = useState('');
@@ -250,10 +250,10 @@ function Setup() {
   );
 }
 
-/** Вход по пригласительной ссылке: /join?token=... */
+/** Signup via an invite link: /join?token=... */
 function Join() {
   const token = new URLSearchParams(window.location.search).get('token') ?? '';
-  // null — проверяем ссылку; дальше либо форма, либо объяснение
+  // null — validating the link; then either the form or an explanation
   const [valid, setValid] = useState<boolean | null>(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');

--- a/web/src/pages/Money.tsx
+++ b/web/src/pages/Money.tsx
@@ -47,7 +47,7 @@ export function Money() {
   const [due, setDue] = useState<DueItem[]>([]);
   const [tab, setTab] = useState<'operations' | 'budgets' | 'recurring'>('operations');
 
-  // Быстрый ввод: сумма и категория, всё остальное по умолчанию
+  // Quick entry: amount and category, everything else defaulted
   const [quickAmount, setQuickAmount] = useState('');
   const [quickCategory, setQuickCategory] = useState('');
   const [quickAccount, setQuickAccount] = useState('');
@@ -61,10 +61,10 @@ export function Money() {
   const [creatingCategoryKind, setCreatingCategoryKind] = useState<'expense' | 'income' | null>(
     null,
   );
-  // Родитель в диалоге категории. Своё состояние, потому что EntityDialog
-  // общий и про иерархию категорий ничего не знает.
+  // Parent in the category dialog. Separate state because EntityDialog is
+  // generic and knows nothing about the category hierarchy.
   const [categoryParent, setCategoryParent] = useState('');
-  // Раскрытые родители в сводке «По категориям»
+  // Expanded parents in the "By category" summary
   const [expandedCats, setExpandedCats] = useState<Set<string>>(new Set());
 
   const { from, to } = useMemo(() => monthBounds(anchor), [anchor]);
@@ -77,7 +77,7 @@ export function Money() {
         api.get<Category[]>('/categories'),
         api.get<Transaction[]>(`/transactions?from=${from}&to=${to}&limit=200`),
         api.get<Summary>(`/money/summary?from=${from}&to=${to}`),
-        // Этот запрос заодно догоняет то, что помечено «создавать самостоятельно»
+        // This request also catches up whatever is marked "create automatically"
         api.get<DueItem[]>('/recurring/due'),
         api.get<Record<string, string>>('/settings'),
       ]);
@@ -89,7 +89,7 @@ export function Money() {
       setDue(dueItems);
       setError(null);
       setQuickAccount((prev) => prev || acc.find((a) => a.shared === 1)?.id || acc[0]?.id || '');
-      // Валюта нового счёта: настройка хаба, иначе валюта первого счёта
+      // New account currency: the hub setting, else the first account's currency
       const preferred = settings['money.default_currency']?.trim().toUpperCase();
       setNewCurrency((prev) =>
         prev !== 'EUR' ? prev : preferred || acc[0]?.currency || 'EUR',
@@ -104,7 +104,7 @@ export function Money() {
     void load();
   }, [load]);
 
-  // Переход с экрана быстрых действий: /money?add=1 сразу открывает форму
+  // Arriving from the quick-actions screen: /money?add=1 opens the form right away
   const [params, setParams] = useSearchParams();
   useEffect(() => {
     if (!params.get('add')) return;
@@ -166,9 +166,9 @@ export function Money() {
   const expenseTotals = (summary?.byCurrency ?? []).filter((r) => r.kind === 'expense');
   const incomeTotals = (summary?.byCurrency ?? []).filter((r) => r.kind === 'income');
 
-  // Траты по категориям, сгруппированные по валютам: у каждой валюты
-  // свой круг — доли между валютами без курса не имеют смысла.
-  // Подкатегории сворачиваются в родителя; его строка раскрывается по клику.
+  // Expenses by category, grouped by currency: each currency gets its own
+  // donut — shares across currencies mean nothing without a rate.
+  // Subcategories roll up into their parent; its row expands on click.
   const expenseByCurrency = useMemo(() => {
     const rows = (summary?.byCategory ?? []).filter((r) => r.kind === 'expense');
     type Row = (typeof rows)[number];
@@ -189,8 +189,9 @@ export function Money() {
       const bucket = byCurrency.get(r.currency) ?? new Map<string, Rolled>();
       byCurrency.set(r.currency, bucket);
 
-      // Строка сворачивается в родителя, только если тот виден (не в архиве) —
-      // иначе подкатегория показывается сама, как категория верхнего уровня
+      // A row rolls up into its parent only if the parent is visible (not
+      // archived) — otherwise the subcategory shows on its own, as a
+      // top-level category
       const parent = r.parent_id ? byId.get(r.parent_id) : undefined;
       const key = parent?.id ?? r.category_id ?? 'none';
       const entry = bucket.get(key) ?? {
@@ -204,8 +205,8 @@ export function Money() {
       };
       entry.total += r.total;
       entry.count += r.count;
-      // Траты самого родителя в раскрытом списке не строка, а остаток —
-      // отдельной дочерней записи для них не нужно
+      // The parent's own spending in the expanded list is the remainder,
+      // not a row — no separate child entry needed for it
       if (parent) entry.children.push(r);
       bucket.set(key, entry);
     }
@@ -266,7 +267,7 @@ export function Money() {
         </div>
       ) : (
         <div className="space-y-6">
-          {/* Остатки по валютам */}
+          {/* Balances by currency */}
           <div className="space-y-4">
             {groups.map((group) => (
               <section key={group.currency}>
@@ -279,8 +280,9 @@ export function Money() {
 
                 <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                   {group.items.map((a) => {
-                    // Расхождение — на момент сверки, а не против текущего
-                    // остатка: операции после сверки его не сдвигают
+                    // The discrepancy is as of the reconciliation, not
+                    // against the current balance: transactions after the
+                    // check do not move it
                     const diff =
                       a.last_actual === null || a.checked_balance === null
                         ? null
@@ -353,7 +355,7 @@ export function Money() {
             ))}
           </div>
 
-          {/* Быстрый ввод траты */}
+          {/* Quick expense entry */}
           <section className="rounded-card border border-line bg-surface p-4">
             <h2 className="eyebrow mb-3">{t('Записать трату')}</h2>
             <div className="flex flex-wrap items-end gap-3">
@@ -426,7 +428,7 @@ export function Money() {
 
           <DuePanel due={due} onChanged={() => void load()} />
 
-          {/* Месяц */}
+          {/* Month */}
           <section>
             <div className="mb-3 flex flex-wrap items-center gap-3">
               <div className="flex items-center gap-1">
@@ -500,7 +502,7 @@ export function Money() {
 
             {tab === 'operations' && (
             <div className="grid gap-4 lg:grid-cols-[1fr_20rem]">
-              {/* Операции */}
+              {/* Transactions */}
               <div>
                 {byDate.length === 0 ? (
                   <Empty>{t('За этот месяц операций нет.')}</Empty>
@@ -562,7 +564,7 @@ export function Money() {
                 )}
               </div>
 
-              {/* Итоги */}
+              {/* Totals */}
               <aside className="space-y-4">
                 <section className="rounded-card border border-line bg-surface p-4">
                   <h3 className="eyebrow mb-2.5">{t('Итоги месяца')}</h3>
@@ -680,7 +682,7 @@ export function Money() {
                                           </span>
                                         </li>
                                       ))}
-                                      {/* Остаток — траты, записанные на самого родителя */}
+                                      {/* Remainder — spending recorded on the parent itself */}
                                       {(() => {
                                         const childSum = r.children.reduce(
                                           (sum, c) => sum + c.total,
@@ -765,7 +767,7 @@ export function Money() {
         </div>
       )}
 
-      {/* ── Диалоги ─────────────────────────────────────────────────────── */}
+      {/* ── Dialogs ─────────────────────────────────────────────────────── */}
 
       {(creatingTx || editingTx) && accounts && accounts.length > 0 && (
         <TransactionDialog
@@ -894,15 +896,15 @@ export function Money() {
             await load();
           }}
           onDelete={async () => {
-            // Категория с историей не удаляется, а прячется — иначе прошлые
-            // отчёты потеряли бы разметку
+            // A category with history is hidden, not deleted — otherwise
+            // past reports would lose their labeling
             await api.delete(`/categories/${editingCategory.id}`);
             await load();
           }}
           onClose={() => setEditingCategory(null)}
         >
-          {/* Категория с подкатегориями сама не может стать подкатегорией —
-              сервер это отклонит, поэтому селект просто не показываем */}
+          {/* A category with subcategories cannot itself become one —
+              the server would reject it, so the select simply isn't shown */}
           {!categories.some((c) => c.parent_id === editingCategory.id) && (
             <CategoryParentField
               categories={categories}
@@ -918,7 +920,7 @@ export function Money() {
   );
 }
 
-/** Селект родительской категории для диалогов создания и правки. */
+/** Parent-category select for the create and edit dialogs. */
 function CategoryParentField({
   categories,
   kind,
@@ -932,7 +934,7 @@ function CategoryParentField({
   value: string;
   onChange: (id: string) => void;
 }) {
-  // Родителем может быть только категория верхнего уровня того же вида
+  // Only a top-level category of the same kind can be a parent
   const options = categories.filter(
     (c) => c.kind === kind && !c.parent_id && c.id !== excludeId,
   );

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -92,16 +92,16 @@ export function Notes() {
   const [revision, setRevision] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  // Незаписанные правки хранятся вместе с идентификатором заметки.
-  // Иначе при быстром переключении отложенное сохранение уезжает в ту
-  // заметку, что открыта сейчас, и переписывает её чужим текстом.
+  // Unsaved edits are stored together with the note id.
+  // Otherwise on a quick switch the debounced save lands on whichever
+  // note is open now, overwriting it with someone else's text.
   const pending = useRef<{ noteId: string; patch: { title?: string; body_md?: string } } | null>(
     null,
   );
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const noteRef = useRef<Note | null>(null);
   noteRef.current = note;
-  // flush объявлен ниже openNote, поэтому обращаемся через ссылку
+  // flush is declared below openNote, so it is reached through a ref
   const flushRef = useRef<() => Promise<void>>(async () => {});
 
   const inTemplates = folderId === 'templates';
@@ -112,8 +112,9 @@ export function Notes() {
     else if (folderId) params.set('folder_id', folderId);
     if (query.trim()) params.set('q', query.trim());
 
-    // Поиск отправляет запрос на каждое нажатие; без этой проверки ответ
-    // на «до» может прийти после ответа на «докум» и перетереть выдачу
+    // Search fires a request on every keystroke; without this check the
+    // response for «до» can arrive after the one for «докум» and clobber
+    // the results
     const fresh = isLatest();
     const rows = await api.get<NoteStub[]>(`/notes?${params}`);
     if (!fresh()) return;
@@ -135,7 +136,7 @@ export function Notes() {
 
 
   const openNote = useCallback(async (noteId: string) => {
-    // Уходя с заметки, дописываем то, что не успело сохраниться
+    // Leaving a note, write out whatever has not been saved yet
     if (pending.current) {
       if (timer.current) clearTimeout(timer.current);
       await flushRef.current();
@@ -149,8 +150,8 @@ export function Notes() {
       setError(err instanceof Error ? err.message : t('Не удалось открыть заметку'));
     }
   }, []);
-  // Переход из общего поиска: /notes?open=<id>.
-  // С экрана быстрых действий: /notes?new=1 — сразу новая заметка.
+  // Arriving from global search: /notes?open=<id>.
+  // From the quick-actions screen: /notes?new=1 — a new note right away.
   useEffect(() => {
     const target = params.get('open');
     const wantNew = params.get('new');
@@ -158,11 +159,11 @@ export function Notes() {
     if (target) void openNote(target);
     else void createNote();
     setParams({}, { replace: true });
-    // createNote объявлена ниже как function declaration и потому доступна
+    // createNote is a function declaration below and therefore in scope
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params, openNote, setParams]);
 
-  // ── Автосохранение ──────────────────────────────────────────────────────
+  // ── Autosave ────────────────────────────────────────────────────────────
 
   const flush = useCallback(async () => {
     const entry = pending.current;
@@ -174,10 +175,11 @@ export function Notes() {
       setSaveState('saved');
       void loadNotes();
 
-      // Ссылки пересчитываются на сервере при каждом сохранении, поэтому
-      // панель связей надо обновить — иначе она показывает состояние на
-      // момент открытия заметки. Тело и заголовок при этом не трогаем:
-      // человек продолжает печатать, и перезапись сбросила бы курсор.
+      // Links are recomputed on the server on every save, so the
+      // connections panel must be refreshed — otherwise it shows the
+      // state as of when the note was opened. Body and title stay
+      // untouched: the person keeps typing, and overwriting them would
+      // reset the cursor.
       const fresh = await api.get<Note>(`/notes/${entry.noteId}`);
       setNote((prev) =>
         prev && prev.id === fresh.id
@@ -197,7 +199,7 @@ export function Notes() {
       const current = noteRef.current;
       if (!current) return;
 
-      // Накопленное для другой заметки записываем немедленно
+      // Anything accumulated for a different note is written immediately
       if (pending.current && pending.current.noteId !== current.id) void flush();
 
       pending.current = {
@@ -214,7 +216,7 @@ export function Notes() {
     [flush],
   );
 
-  // Недописанное не должно теряться при закрытии вкладки или уходе со страницы
+  // Unfinished text must not be lost when the tab closes or the page is left
   useEffect(() => {
     const onLeave = () => {
       if (pending.current) void flush();
@@ -226,12 +228,13 @@ export function Notes() {
     };
   }, [flush]);
 
-  // ── Действия ────────────────────────────────────────────────────────────
+  // ── Actions ─────────────────────────────────────────────────────────────
 
   async function createNote(templateId?: string) {
     const created = await api.post<Note>('/notes', {
-      // Заголовок при создании из шаблона не передаём: сервер возьмёт его
-      // из шаблона и раскроет подстановки. Явный title их перебил бы.
+      // No title is sent when creating from a template: the server takes
+      // it from the template and expands the substitutions. An explicit
+      // title would override them.
       ...(templateId ? {} : { title: inTemplates ? t('Новый шаблон') : t('Без названия') }),
       folder_id:
         folderId && folderId !== 'none' && folderId !== 'templates' ? folderId : null,
@@ -243,7 +246,7 @@ export function Notes() {
     await openNote(created.id);
   }
 
-  /** Превратить заметку в шаблон и обратно. */
+  /** Turn a note into a template and back. */
   async function toggleTemplate() {
     if (!note) return;
     const next = !note.is_template;
@@ -259,8 +262,8 @@ export function Notes() {
       const daily = await api.get<Note>(`/notes/daily/${date}`);
       await openNote(daily.id);
     } catch {
-      // Шаблон дня ищется по названию в данных, а не по языку интерфейса:
-      // 'Day' у свежих баз, 'День' у живших до перевода
+      // The daily template is looked up by its title in the data, not by
+      // the UI language: 'Day' on fresh DBs, 'День' on pre-translation ones
       const template = templates.find((tpl) => tpl.title === 'Day' || tpl.title === 'День');
       const created = await api.post<Note>('/notes', {
         daily_date: date,
@@ -302,7 +305,7 @@ export function Notes() {
     await loadNotes();
   }
 
-  /** Переход по [[ссылке]]: если заметки нет — предлагаем создать. */
+  /** Following a [[link]]: if the note does not exist, offer to create it. */
   const navigateByTitle = useCallback(
     async (title: string) => {
       const found = await api.get<NoteStub[]>(`/notes?q=${encodeURIComponent(title)}`);
@@ -325,7 +328,7 @@ export function Notes() {
     [openNote, loadNotes, dialogs],
   );
 
-  /** Отправка файлов, прикреплённых к текущей заметке. */
+  /** Upload files attached to the current note. */
   const uploadFiles = useCallback(
     async (files: File[]): Promise<UploadedFile[]> => {
       const current = noteRef.current;
@@ -382,8 +385,8 @@ export function Notes() {
       confirmLabel: t('Вернуть'),
     });
     if (!ok) return;
-    // Отложенное сохранение содержит текст ДО отката — его нужно выбросить,
-    // иначе оно вернёт отменённую правку назад
+    // The pending save holds the text from BEFORE the rollback — it must
+    // be discarded, or it would bring the undone edit right back
     pending.current = null;
     if (timer.current) clearTimeout(timer.current);
 
@@ -549,10 +552,11 @@ export function Notes() {
         </div>
 
         {note ? (
-          /* Ширину ограничиваем на уровне всей колонки, а не текста внутри
-             карточки: иначе панель инструментов начинается у левого края,
-             а строка — где-то посередине, и это читается как поломка.
-             52rem дают около 95 знаков в строке — верх читаемого. */
+          /* Width is capped on the whole column, not on the text inside
+             the card: otherwise the toolbar starts at the left edge while
+             the text line sits somewhere in the middle, which reads as
+             breakage. 52rem gives about 95 characters per line — the
+             upper bound of readable. */
           <div className="w-full max-w-[52rem]">
             <div className="mb-3 flex flex-wrap items-center gap-3">
               <button

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -80,7 +80,7 @@ function PaletteSection() {
   );
 }
 
-/** Сообщения после возврата от Google на привязке — код в ?google= */
+/** Messages after returning from Google during linking — the code is in ?google= */
 const LINK_MESSAGES: Record<string, string> = {
   linked: t('Google привязан. Теперь можно входить кнопкой на экране входа.'),
   taken: t('Этот Google-аккаунт уже привязан к другой учётке.'),
@@ -88,9 +88,9 @@ const LINK_MESSAGES: Record<string, string> = {
 };
 
 /**
- * Способы входа. Правила серверные, здесь только их отражение:
- * пароль отключается лишь при привязанном Google и не у администратора,
- * отвязать Google нельзя, пока пароль отключён.
+ * Sign-in methods. The rules are server-side, this is only their mirror:
+ * the password can be disabled only with Google linked and never for the
+ * admin; Google cannot be unlinked while the password is disabled.
  */
 function SignInSection() {
   const { user, refresh } = useAuth();

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -69,8 +69,8 @@ export function Tasks() {
     void loadTasks();
   }, [loadTasks]);
 
-  // В архиве «все проекты» бессмысленны: без выбора проекта выдача
-  // задач не отфильтрована и показывает дела из активных проектов.
+  // In the archive "all projects" is meaningless: with no project chosen
+  // the task list is unfiltered and shows items from active projects.
   useEffect(() => {
     if (!showArchived) return;
     if (projectId && projects.some((p) => p.id === projectId)) return;
@@ -95,7 +95,7 @@ export function Tasks() {
     [projects],
   );
 
-  // Переход из общего поиска: /tasks?open=<id> либо /tasks?project=<id>
+  // Arriving from global search: /tasks?open=<id> or /tasks?project=<id>
   useEffect(() => {
     const project = params.get('project');
     const target = params.get('open');
@@ -131,7 +131,7 @@ export function Tasks() {
     <Page
       title={t('Задачи')}
       eyebrow={t('Проекты и дела')}
-      // Доске колонки нужнее, чем поля по краям
+      // The board needs its columns more than it needs side margins
       width={view === 'board' ? 'full' : 'default'}
       action={
         <div className="flex gap-1 rounded-lg border border-line p-0.5">
@@ -150,7 +150,7 @@ export function Tasks() {
         </div>
       }
     >
-      {/* Проекты */}
+      {/* Projects */}
       <div className="mb-5 flex flex-wrap items-center gap-2">
         {!showArchived && (
           <button
@@ -163,7 +163,7 @@ export function Tasks() {
             }`}
           >
             {t('Все проекты')}
-            {/* Тот же счётчик открытых задач, что у каждого проекта */}
+            {/* The same open-task counter every project has */}
             {totalOpen > 0 && <span className="font-mono text-xs">{totalOpen}</span>}
           </button>
         )}
@@ -190,8 +190,8 @@ export function Tasks() {
               {p.open_tasks > 0 && <span className="font-mono text-xs">{p.open_tasks}</span>}
             </button>
 
-            {/* Настройка проекта доступна только у выбранного: иначе строка
-                чипов превращается в частокол шестерёнок */}
+            {/* Project settings only on the selected one: otherwise the
+                chip row turns into a picket fence of gears */}
             {projectId === p.id && p.id !== INBOX_ID && (
               <button
                 type="button"
@@ -232,7 +232,7 @@ export function Tasks() {
         </button>
       </div>
 
-      {/* Фильтры */}
+      {/* Filters */}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <select value={assignee} onChange={(e) => setAssignee(e.target.value)} className={control}>
           <option value="">{t('Все исполнители')}</option>
@@ -362,8 +362,8 @@ export function Tasks() {
           }}
           onArchive={async () => {
             await api.post(`/projects/${editingProject.id}/archive`, {});
-            // Проект уехал в другой список — уходим туда же, иначе экран
-            // показывает выбранным то, чего в нём больше нет
+            // The project moved to the other list — follow it, or the
+            // screen keeps showing a selection that is no longer there
             setShowArchived(!editingProject.archived_at);
             setProjectId('');
             await loadProjects();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
-/* Шрифты подключаются локально пакетами fontsource — приложение
-   не должно ходить в интернет за Google Fonts, оно живёт в офлайне. */
+/* Fonts are bundled locally via fontsource packages — the app must not
+   reach out to Google Fonts, it lives offline. */
 @import '@fontsource-variable/unbounded';
 @import '@fontsource-variable/golos-text';
 @import '@fontsource-variable/jetbrains-mono';
@@ -9,11 +9,11 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /*
-  Палитра: Адриатика и сухая испанская земля.
-  azulejo — сине-бирюзовый изразец, основной акцент.
-  ochre  — прогретая охра, только для срочного и просроченного.
-  olive  — приглушённая олива, только для выполненного.
-  Три цвета состояния, больше нет: интерфейс не должен пестрить.
+  Palette: the Adriatic and dry Spanish earth.
+  azulejo — blue-turquoise tile, the primary accent.
+  ochre  — sun-warmed ochre, only for urgent and overdue.
+  olive  — muted olive, only for completed.
+  Three state colors, no more: the UI must not turn motley.
 */
 :root {
   --c-surface: #f6f7f4;
@@ -59,9 +59,9 @@
 
   --radius-card: 0.75rem;
 
-  /* Стандартная шкала Tailwind заканчивается на 1536px, а 34-дюймовый
-     монитор — это 3440px. Без этих ступеней рабочая область на нём
-     перестаёт расти и превращается в узкую колонку посреди пустоты. */
+  /* Tailwind's standard scale ends at 1536px, while a 34-inch monitor
+     is 3440px. Without these steps the working area stops growing there
+     and becomes a narrow column in the middle of emptiness. */
   --breakpoint-3xl: 120rem;
   --breakpoint-4xl: 160rem;
 }
@@ -95,7 +95,7 @@ select {
     font-family: var(--font-sans);
     font-synthesis-weight: none;
     text-rendering: optimizeLegibility;
-    /* Стенд на iPad: тянуть страницу за край незачем */
+    /* iPad kiosk: no reason to rubber-band the page past its edge */
     overscroll-behavior: none;
   }
 
@@ -106,8 +106,8 @@ select {
   }
 
 
-  /* Метки разделов: моноширинный, разрядка, верхний регистр.
-     Служебный слой типографики, отделённый от контента. */
+  /* Section labels: monospace, letter-spaced, uppercase.
+     A utility typography layer, kept apart from the content. */
   .eyebrow {
     font-family: var(--font-mono);
     font-size: 0.6875rem;
@@ -127,10 +127,10 @@ select {
   }
 }
 
-/* ── Редактор заметок ─────────────────────────────────────────────────────
-   Типографика тела заметки задана вручную, без плагина typography:
-   набор узлов здесь конечный и известный, а лишняя зависимость в офлайновом
-   приложении дороже двух десятков строк CSS. */
+/* ── Note editor ──────────────────────────────────────────────────────────
+   The note body typography is written by hand, without the typography
+   plugin: the node set here is finite and known, and an extra dependency
+   in an offline app costs more than two dozen lines of CSS. */
 
 .note-content {
   padding: 1.25rem 1.5rem;
@@ -203,7 +203,7 @@ select {
   text-underline-offset: 2px;
 }
 
-/* Чеклисты */
+/* Checklists */
 .note-content ul[data-type='taskList'] {
   list-style: none;
   padding-left: 0;
@@ -220,7 +220,7 @@ select {
   accent-color: var(--c-done);
 }
 
-/* Таблицы */
+/* Tables */
 .note-content table {
   border-collapse: collapse;
   width: 100%;
@@ -237,7 +237,7 @@ select {
   font-weight: 600;
 }
 
-/* Подсказка в пустой заметке */
+/* Placeholder in an empty note */
 .note-content p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;
@@ -246,7 +246,7 @@ select {
   color: var(--c-text-muted);
 }
 
-/* Ссылка на другую заметку */
+/* Link to another note */
 .wiki-link {
   color: var(--c-accent);
   background: var(--c-accent-soft);
@@ -255,7 +255,7 @@ select {
   cursor: pointer;
 }
 
-/* Картинки внутри заметки */
+/* Images inside a note */
 .note-content img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
Stage A of the English-first epic (#5 and #6 are stages B and C). Mechanical, zero behavior change: ~70 files of comments, server log messages, script output, SQL migration comments, the home Caddyfile and the `npm run dev` labels — all English now, same why-not-what voice.

**Deliberately untouched** (verified byte-identical to master):
- API error strings and zod messages — the client translates them by exact match; they flip in stage B (#5)
- i18n dictionaries and every `t()`/plural key — the Russian string is the key by design
- seeded data in migrations (`Общий`, `Входящие`, `DEFAULT 'Без названия'`, the `'День'` template lookup) — stage C (#6)
- Cyrillic test fixtures and in-comment examples that are the point (trigram morphology, declension)

Verification: typecheck, lint, 37 tests green; demo-mode boot smoke with English migration logs and a working sandbox; a diff-level assertion that no `error:` string changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)