### PR TITLE
chore: baseline monitoring — log caps, backup dead-man switch, error alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,11 @@ TZ=UTC
 # pushing backups; unencrypted archives are never pushed.
 #AGE_RECIPIENT=age1...
 
+# Dead-man switch for the nightly backup (optional): a healthchecks.io-style
+# ping URL. The backup script hits it on success and <url>/fail on failure,
+# so a backup that silently stops running raises an alarm.
+#BACKUP_PING_URL=https://hc-ping.com/your-uuid
+
 # Google sign-in (optional). Both values come from Google Cloud Console
 # (OAuth client, Web application). Empty values disable the feature.
 #GOOGLE_CLIENT_ID=1234567890-abc.apps.googleusercontent.com

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -13,12 +13,21 @@
 # itself — no reset cron needed. Passwords, membership and file uploads
 # stay blocked (see docs/deploy-vps.md, "Public demo").
 
+# YAML anchors do not cross files, so the log cap is repeated here
+# (see docker-compose.prod.yml for the reasoning).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   app-demo:
     image: family-hub:prod
     build: .
     container_name: family-hub-demo
     restart: unless-stopped
+    logging: *logging
     environment:
       NODE_ENV: production
       DATA_DIR: /data

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,14 @@
 # Launch: docker compose -f docker-compose.prod.yml up -d --build
 # Full step-by-step guide: docs/deploy-vps.md
 
+# Docker's json-file driver keeps logs forever by default — on a small
+# VPS they would quietly eat the disk. Every service caps its own logs.
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   app:
     # The image is built in GitHub Actions and arrives ready-made
@@ -12,6 +20,7 @@ services:
     build: .
     container_name: family-hub
     restart: unless-stopped
+    logging: *logging
     environment:
       NODE_ENV: production
       DATA_DIR: /data
@@ -23,6 +32,8 @@ services:
       TRUST_PROXY: "true"
       # For the nightly backup inside the container (see docs/deploy-vps.md)
       AGE_RECIPIENT: ${AGE_RECIPIENT:-}
+      # Dead-man switch for that backup (see docs/deploy-vps.md, "Monitoring")
+      BACKUP_PING_URL: ${BACKUP_PING_URL:-}
       # Google sign-in (see docs/deploy-vps.md). Empty values disable the feature.
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
@@ -39,6 +50,7 @@ services:
     image: caddy:2-alpine
     container_name: family-hub-caddy
     restart: unless-stopped
+    logging: *logging
     depends_on:
       - app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,17 @@
+# Docker's json-file driver keeps logs forever by default — cap them so
+# a home server that runs for months does not slowly fill its disk.
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   app:
     build: .
     container_name: family-hub
     restart: unless-stopped
+    logging: *logging
     environment:
       NODE_ENV: production
       DATA_DIR: /data
@@ -25,6 +34,7 @@ services:
     image: caddy:2-alpine
     container_name: family-hub-caddy
     restart: unless-stopped
+    logging: *logging
     profiles:
       - https
     depends_on:

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -208,7 +208,56 @@ Every couple of months, pull a random archive and verify that it
 decrypts and opens: a backup that has never been restored is a backup
 only nominally.
 
-## 7. Google sign-in (optional)
+## 7. Monitoring
+
+Three small things cover the failure modes that actually happen: the hub
+went down and nobody noticed, the backup silently stopped running, and
+errors piled up in a log nobody reads. None of them require running any
+monitoring software on the VPS itself.
+
+**Uptime.** `/api/health` answers 200 only when the app is up *and* the
+database responds. Point any free uptime service (UptimeRobot,
+Better Stack, …) at it:
+
+```
+https://hub.example.com/api/health
+https://demo.example.com/api/health   # if you run the public demo
+```
+
+**A dead-man switch for the backup.** An alert firing on a failed backup
+is not enough: the worst failure is the cron job not running at all —
+nothing fails, nothing alerts. A dead-man switch inverts the logic: the
+backup script pings a URL after every run, and the service alarms when
+the ping *stops coming*. Create a check at [healthchecks.io](https://healthchecks.io)
+(free tier is plenty) with a daily schedule, put the ping URL into `.env`:
+
+```
+BACKUP_PING_URL=https://hc-ping.com/your-uuid
+```
+
+then `docker compose -f docker-compose.prod.yml up -d` so the container
+picks it up. On success the script pings the URL, on failure `<url>/fail` —
+you learn about both a broken backup and a backup that quietly stopped.
+
+**Error alerts.** The app logs real errors as `ERROR` lines, but nobody
+reads container logs on a schedule. `scripts/alert-errors.sh` does: it
+greps the last hour of logs and pushes anything found to an
+[ntfy](https://ntfy.sh) topic — a push notification straight to your
+phone, no account needed (pick a long unguessable topic name: anyone who
+knows it can read the alerts). Cron on the host:
+
+```bash
+crontab -e
+# add the line:
+5 * * * * ALERT_URL=https://ntfy.sh/<secret-topic> /srv/family-hub/app/scripts/alert-errors.sh
+```
+
+Container logs are capped by the compose files (10 MB × 3 files per
+service), so they never eat the disk. On an install that predates the
+cap, `docker compose -f docker-compose.prod.yml up -d` recreates the
+containers and applies it.
+
+## 8. Google sign-in (optional)
 
 Once, in the [Google Cloud Console](https://console.cloud.google.com/):
 
@@ -241,7 +290,7 @@ Then each person on their own: sign in with the password → Settings →
 administrator's password cannot be disabled — that is deliberate, see
 [features.md](features.md), "Signing in".
 
-## 8. Public demo (optional)
+## 9. Public demo (optional)
 
 A sandbox at its own subdomain, running next to production on the same
 VPS. Every visitor gets their own throwaway copy of a seeded sample
@@ -282,7 +331,7 @@ The auto-deploy below picks the demo up automatically: it checks the
 server's `.env` for `DEMO_DOMAIN` and, when set, restarts both stacks —
 the image is shared, so shipping a new image updates both.
 
-## 9. Auto-deploy from GitHub
+## 10. Auto-deploy from GitHub
 
 Once configured, every push to `master` deploys itself
 (`.github/workflows/deploy.yml`): Actions checks types, **builds the
@@ -338,7 +387,7 @@ path still works as a fallback.
 The deploy never touches `.env` on the server: it is excluded from
 rsync, secrets keep living only on the machine.
 
-## 10. Updates
+## 11. Updates
 
 The code updates itself on a push to `master` (section above). By hand —
 only if Actions is unavailable:

--- a/scripts/alert-errors.sh
+++ b/scripts/alert-errors.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Hourly error alert for the VPS host: scan the last hour of hub container
+# logs for ERROR lines and push them to an ntfy topic (or any endpoint that
+# accepts a plain-text POST). Silence means no errors — the script sends
+# nothing when the hour was clean.
+#
+# Cron on the host (see docs/deploy-vps.md, "Monitoring"):
+#   5 * * * * ALERT_URL=https://ntfy.sh/<secret-topic> /srv/family-hub/app/scripts/alert-errors.sh
+set -euo pipefail
+
+ALERT_URL="${ALERT_URL:?Set ALERT_URL, e.g. https://ntfy.sh/your-secret-topic}"
+SINCE="${SINCE:-1h}"
+CONTAINERS="${CONTAINERS:-family-hub family-hub-demo}"
+
+for container in $CONTAINERS; do
+  # The demo overlay is optional — skip containers that do not exist
+  docker inspect "$container" >/dev/null 2>&1 || continue
+
+  # App log lines look like "12:34:56 ERROR ..." — anchor on that shape
+  # so the word ERROR inside user data never triggers a false alarm.
+  errors=$(docker logs --since "$SINCE" "$container" 2>&1 |
+    grep -E '^[0-9]{2}:[0-9]{2}:[0-9]{2} ERROR' | tail -20 || true)
+  [ -z "$errors" ] && continue
+
+  curl -fsS -m 10 \
+    -H "Title: $container: errors in the last $SINCE" \
+    -H "Priority: high" \
+    --data-raw "$errors" \
+    "$ALERT_URL" >/dev/null
+done

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,6 +9,18 @@ REPO_DIR="${BACKUP_REPO_DIR:-$HOME/family-hub-backup}"
 AGE_RECIPIENT="${AGE_RECIPIENT:-}"
 STAMP=$(date +%Y-%m-%d)
 
+# Dead-man switch (optional): ping a healthchecks.io-style URL on every
+# outcome, so a backup that silently stops running raises an alarm — the
+# one failure mode a nightly cron hides best. The app container ships no
+# curl; node is always there.
+PING_URL="${BACKUP_PING_URL:-}"
+report() {
+  [ -z "$PING_URL" ] && return 0
+  node -e "fetch(process.argv[1], { signal: AbortSignal.timeout(10000) }).catch(() => {})" \
+    "$PING_URL$1" 2>/dev/null || true
+}
+trap 'status=$?; if [ "$status" -eq 0 ]; then report ""; else report "/fail"; fi' EXIT
+
 mkdir -p "$BACKUP_DIR"
 
 # 1. Consistent database snapshot (safe while the app is running)


### PR DESCRIPTION
## What

- **Log rotation**: every service in all three compose files caps container logs at 10 MB × 3 files. Until now the json-file driver kept logs forever — with `LOG_LEVEL=info` in prod that is a slow disk leak on a 1 GB VPS. Existing installs pick the cap up on the next `docker compose up -d` (containers get recreated once).
- **Backup dead-man switch**: `scripts/backup.sh` pings `BACKUP_PING_URL` (healthchecks.io-style) on success and `<url>/fail` on failure. The worst backup failure mode — cron silently not running — produces no error to alert on; only a missing ping catches it. Ping goes through `node -e "fetch(...)"` since the app image has no curl. Env var plumbed through prod compose and documented in `.env.example`.
- **Error alerts**: new host-side `scripts/alert-errors.sh` for cron — greps the last hour of `family-hub` / `family-hub-demo` logs for `ERROR` lines (anchored to the app's log line shape, so ERROR inside user data can't false-alarm) and pushes them to an ntfy topic.
- **Docs**: new "Monitoring" section in deploy-vps.md (uptime checks on `/api/health`, dead-man setup, alert cron, log cap note); later sections renumbered.

## Not in this PR

Account-side setup (UptimeRobot checks, healthchecks.io check, ntfy topic) — one-time manual steps, follow the new docs section.

Demo usage statistics land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)