### PR TITLE
fix: UI polish — settings centering, dark-theme controls, whitespace inputs

### DIFF
--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import { dialogKeys, onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 
 /**
  * Our own dialogs instead of window.prompt and window.confirm.
@@ -164,6 +165,7 @@ export function DialogProvider({ children }: { children: ReactNode }) {
               value={value}
               placeholder={pending.options.placeholder}
               onChange={(e) => setValue(e.target.value)}
+              onBlur={clearBlankOnBlur(() => setValue(''))}
               onKeyDown={onEnter(() => close(value.trim() || null))}
               className={dialogField}
             />

--- a/web/src/components/EntityDialog.tsx
+++ b/web/src/components/EntityDialog.tsx
@@ -9,6 +9,7 @@ import {
   dialogPrimary,
 } from './Dialog';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { PALETTE, addToPalette, loadCustomPalette } from '../lib/palette';
 
 /**
@@ -140,6 +141,7 @@ export function EntityDialog({
             autoFocus
             value={draft.name}
             onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            onBlur={clearBlankOnBlur(() => setDraft({ ...draft, name: '' }))}
             onKeyDown={onEnter(() => void run(() => onSave({ ...draft, name: draft.name.trim() })))}
             className={dialogField}
           />

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -4,6 +4,7 @@ import { api, type HouseholdMember, type Project } from '../lib/api';
 import { REMIND_OPTIONS, calendarName, type Calendar, type Occurrence } from '../lib/calendar';
 import { RECURRENCE_OPTIONS } from '../lib/tasks';
 import { dialogKeys, onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { timeOf } from '../lib/format';
 import { useDialogs } from './Dialog';
 
@@ -163,6 +164,7 @@ export function EventDialog({
               autoFocus
               value={draft.title}
               onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, title: '' }))}
               onKeyDown={onEnter(() => void save())}
               className={field}
             />
@@ -190,6 +192,7 @@ export function EventDialog({
               <input
                 value={draft.location}
                 onChange={(e) => setDraft({ ...draft, location: e.target.value })}
+                onBlur={clearBlankOnBlur(() => setDraft({ ...draft, location: '' }))}
                 className={field}
               />
             </label>
@@ -357,6 +360,7 @@ export function EventDialog({
               rows={3}
               value={draft.description}
               onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, description: '' }))}
               className={`${field} resize-y`}
             />
           </label>

--- a/web/src/components/GlobalSearch.tsx
+++ b/web/src/components/GlobalSearch.tsx
@@ -1,4 +1,5 @@
 import { t } from '../lib/i18n';
+import { clearBlankOnBlur } from '../lib/forms';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../lib/api';
@@ -139,6 +140,7 @@ export function GlobalSearch({
               value={query}
               placeholder={t('Искать по задачам, заметкам, событиям и файлам')}
               onChange={(e) => setQuery(e.target.value)}
+              onBlur={clearBlankOnBlur(() => setQuery(''))}
               onKeyDown={(e) => {
                 if (!results?.length) return;
                 if (e.key === 'ArrowDown') {

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../lib/api';
 import { Empty } from './Page';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { EntityDialog } from './EntityDialog';
 import { useDialogs } from './Dialog';
 
@@ -212,6 +213,7 @@ export function PeopleSection() {
             placeholder={t('Имя')}
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
+            onBlur={clearBlankOnBlur(() => setForm({ ...form, name: '' }))}
             onKeyDown={onEnter(() => void create())}
             className="rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent"
           />
@@ -220,6 +222,7 @@ export function PeopleSection() {
             autoCapitalize="none"
             value={form.email}
             onChange={(e) => setForm({ ...form, email: e.target.value })}
+            onBlur={clearBlankOnBlur(() => setForm({ ...form, email: '' }))}
             onKeyDown={onEnter(() => void create())}
             className="rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent"
           />

--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -2,6 +2,7 @@ import { t } from '../lib/i18n';
 import { useEffect, useRef, useState } from 'react';
 import { api, type HouseholdMember, type Project, type Task } from '../lib/api';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { TaskDetail } from './TaskDetail';
 import { INBOX_ID, projectTitle } from '../lib/tasks';
 
@@ -99,6 +100,7 @@ export function QuickAdd({ onAdded }: { onAdded: () => void }) {
               value={title}
               placeholder={t('Что нужно сделать')}
               onChange={(e) => setTitle(e.target.value)}
+              onBlur={clearBlankOnBlur(() => setTitle(''))}
               onKeyDown={onEnter(() => void submit())}
               className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-sm text-ink outline-none focus:border-accent"
             />

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -10,6 +10,7 @@ import {
   LEVEL_LABEL,
 } from '../lib/tasks';
 import { dialogKeys, onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { useDialogs } from './Dialog';
 
 const field =
@@ -123,6 +124,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
             <input
               value={draft.title}
               onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, title: '' }))}
               onKeyDown={onEnter(() => void save())}
               className={field}
             />
@@ -134,6 +136,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
               rows={4}
               value={draft.description}
               onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, description: '' }))}
               className={`${field} resize-y`}
             />
           </label>

--- a/web/src/components/TransactionDialog.tsx
+++ b/web/src/components/TransactionDialog.tsx
@@ -10,6 +10,7 @@ import {
   dialogPrimary,
 } from './Dialog';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { shrinkAll } from '../lib/image';
 import {
   TX_KIND_LABEL,
@@ -334,6 +335,7 @@ export function TransactionDialog({
             <input
               value={draft.place}
               onChange={(e) => setDraft({ ...draft, place: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, place: '' }))}
               className={dialogField}
             />
           </label>
@@ -342,6 +344,7 @@ export function TransactionDialog({
             <input
               value={draft.note}
               onChange={(e) => setDraft({ ...draft, note: e.target.value })}
+              onBlur={clearBlankOnBlur(() => setDraft({ ...draft, note: '' }))}
               onKeyDown={onEnter(() => void save())}
               className={dialogField}
             />

--- a/web/src/lib/forms.ts
+++ b/web/src/lib/forms.ts
@@ -1,0 +1,18 @@
+import type { FocusEvent } from 'react';
+
+/**
+ * onBlur for text fields: a whitespace-only value looks empty to the
+ * person but does not behave as empty — the placeholder never comes
+ * back, and some forms would even save the spaces. Clearing on blur
+ * makes "looks empty" and "is empty" the same thing. Real text
+ * (anything with a non-space character) is left untouched.
+ */
+export function clearBlankOnBlur(clear: () => void) {
+  return (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    if (e.target.value === '' || e.target.value.trim() !== '') return;
+    // Uncontrolled fields (the note title) keep their value in the DOM,
+    // where a state update alone would not reach
+    e.target.value = '';
+    clear();
+  };
+}

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { formatStamp } from '../lib/format';
 import { useLatest } from '../lib/latest';
 import { today } from '../lib/tasks';
@@ -499,6 +500,7 @@ export function Notes() {
             value={query}
             placeholder={t('Поиск по заметкам')}
             onChange={(e) => setQuery(e.target.value)}
+            onBlur={clearBlankOnBlur(() => setQuery(''))}
             className="mb-3 w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
           />
 
@@ -571,6 +573,7 @@ export function Notes() {
                 key={note.id}
                 defaultValue={note.title}
                 onChange={(e) => queueSave({ title: e.target.value })}
+                onBlur={clearBlankOnBlur(() => queueSave({ title: '' }))}
                 onKeyDown={onEnter(() => void flush())}
                 className="min-w-0 flex-1 rounded-lg border border-transparent bg-transparent px-2 py-1.5 font-display text-lg font-semibold text-ink outline-none focus:border-line"
               />

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -255,8 +255,9 @@ export function Settings() {
       {/* Two columns on wide screens: a single narrow ribbon left the right
           half empty and forced scrolling. Below lg — one column of the old
           max-w-md width (without the cap the forms stretched across the
-          whole max-w-4xl on tablets), same section order. */}
-      <div className="grid max-w-md items-start gap-5 lg:max-w-4xl lg:grid-cols-2">
+          whole max-w-4xl on tablets), same section order. mx-auto because
+          a capped block hugs the left edge while every other page centers. */}
+      <div className="mx-auto grid max-w-md items-start gap-5 lg:max-w-4xl lg:grid-cols-2">
       <div className="space-y-5 rounded-card border border-line bg-surface p-5">
         {FIELDS.map((f) => (
           <label key={f.key} className="block">

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -7,6 +7,7 @@ import { plural } from '../lib/format';
 import { useLatest } from '../lib/latest';
 import { Empty, Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
+import { clearBlankOnBlur } from '../lib/forms';
 import { TaskList } from '../components/TaskList';
 import { TaskBoard } from '../components/TaskBoard';
 import { TaskDetail } from '../components/TaskDetail';
@@ -275,6 +276,7 @@ export function Tasks() {
             value={newTitle}
             placeholder={projectId ? t('Новая задача в этом проекте') : t('Новая задача')}
             onChange={(e) => setNewTitle(e.target.value)}
+            onBlur={clearBlankOnBlur(() => setNewTitle(''))}
             onKeyDown={onEnter(() => void addTask())}
             className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent sm:w-auto sm:flex-1"
           />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -16,6 +16,11 @@
   Three state colors, no more: the UI must not turn motley.
 */
 :root {
+  /* Tells the browser which scheme native controls should render in:
+     without it, unchecked checkboxes (accent-color tints only the
+     checked state), select popups and scrollbars stay light on the
+     dark theme and pierce the surfaces. */
+  color-scheme: light;
   --c-surface: #f6f7f4;
   --c-surface-2: #eaece8;
   --c-surface-3: #dfe2dc;
@@ -29,6 +34,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --c-surface: #18232c;
   --c-surface-2: #101820;
   --c-surface-3: #22303a;


### PR DESCRIPTION
Three small fixes, one commit each.

## Settings centering (closes #17)
The settings grid caps its own width but had no `mx-auto`, so it hugged the container's left edge on wide screens. One class. Checked at 1440px — centered in both the two-column (`lg`) and single-column modes.

## Dark-theme native controls (closes #19)
`color-scheme: light` on `:root`, `color-scheme: dark` on `.dark` — the standards-compliant way to make the UA render native form controls in the theme's scheme. Unchecked checkboxes now paint dark (accent-color only ever tinted the checked state); select popups and scrollbars follow too. Verified in both themes: dark checkboxes no longer pierce, light theme unchanged.

## Whitespace-only inputs (closes #20)
New shared helper `clearBlankOnBlur` in `web/src/lib/forms.ts`: on blur, a value with no non-space character is cleared so the placeholder returns; real text is never touched. Applied to quick-add fields, dialog name/title/place/note fields, descriptions, search boxes, the prompt dialog and the note title (uncontrolled input — the helper also resets the DOM value, which a state update alone would not reach). Amount fields deliberately skipped: they own their blur formatting semantics (`formatAmountInput` round-trip).

## Verification
`npm run typecheck` / `lint` / `test` green. Live-checked in the dev preview: spaces in quick-add and note title clear on blur and the original title round-trips; `  real text  ` survives blur untouched; computed `color-scheme` is `dark` on the dark root and checkboxes render dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)