### PR TITLE
feat: expected completion date for tasks

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -37,6 +37,8 @@ Setting up Google sign-in on a server: [deploy-vps.md](deploy-vps.md), "Google s
 
 Three nesting levels: story → task → subtask. The server refuses anything deeper, deliberately — otherwise the tree turns into a dump.
 
+A task carries two dates. **Due date** is when it should be done; **expected finish** is when it is realistically going to be done. When the expected finish is set, it takes over everywhere a date matters: overdue is counted from it, and the dashboard and calendar place the task on that day. The scenario it exists for: a coffee machine goes in for a week-long repair — the task is in progress and on plan, not "overdue" for seven days straight. In lists the stand-in date is marked with an arrow (`→ 21 August`). The expected finish belongs to one specific occurrence, so a recurring task's next occurrence never inherits it.
+
 Recurrence uses a subset of RRULE: `FREQ=MONTHLY;INTERVAL=1` and the like. The next date is computed **from the series anchor**, not from the previous occurrence. Otherwise "every 31st" would slip to the 28th forever after February.
 
 Task order is accepted as a full list of IDs (`POST /api/tasks/reorder`) rather than fractional positions between neighbours. At household scale rewriting fifty rows costs nothing, and positions never degrade over time.

--- a/server/src/db/migrations/014_expected_date.sql
+++ b/server/src/db/migrations/014_expected_date.sql
@@ -1,0 +1,12 @@
+-- Tasks: expected completion date (#7).
+--
+-- due_date answers "when should this be done"; expected_date answers
+-- "when do we actually expect it to finish". A task handed over for a
+-- week-long repair is not overdue while the repair runs to plan — when
+-- expected_date is set, overdue (and the dashboard buckets) count from
+-- COALESCE(expected_date, due_date) instead of due_date alone.
+--
+-- Per-instance by design: a spawned recurring occurrence never inherits
+-- it. No index — dashboard queries filter on the COALESCE expression,
+-- and at family scale a table scan of tasks is free.
+ALTER TABLE tasks ADD COLUMN expected_date TEXT;

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -92,6 +92,13 @@ export async function seedDemo(): Promise<void> {
       id(), trip, day(12), sam, sam,
       id(), trip, alex,
     );
+    // Showcases the expected-finish date (#7): the due date is past, but
+    // the repair is known to take a week — the task is not overdue
+    db.prepare(
+      `INSERT INTO tasks (id, project_id, level, title, status, priority, due_date, expected_date,
+                          assignee_id, position, created_by)
+       VALUES (?, ?, 0, 'Coffee machine in repair', 'in_progress', 'normal', ?, ?, ?, 7, ?)`,
+    ).run(id(), home, day(-3), day(4), alex, alex);
     // Nesting: "buy paint" goes under the repaint story
     db.prepare(
       `UPDATE tasks SET parent_id = ?, level = 1 WHERE title IN ('Pick the colour together', 'Buy paint and tape')`,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -241,11 +241,18 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     // By the local clock: in UTC "today" is still yesterday after midnight
     const today = localToday();
 
+    /*
+      All three buckets go by the effective date: when an expected
+      completion is set (#7), it replaces the due date — work that is in
+      progress with a known finish day is not "overdue", it is simply
+      scheduled for that day.
+    */
     const dueToday = db
       .prepare(
         `SELECT t.*, p.title AS project_title, p.color AS project_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
-          WHERE t.due_date = ? AND t.status NOT IN ('done','cancelled')
+          WHERE coalesce(t.expected_date, t.due_date) = ?
+            AND t.status NOT IN ('done','cancelled')
           ORDER BY t.priority DESC`,
       )
       .all(today);
@@ -254,8 +261,9 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       .prepare(
         `SELECT t.*, p.title AS project_title, p.color AS project_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
-          WHERE t.due_date < ? AND t.status NOT IN ('done','cancelled')
-          ORDER BY t.due_date`,
+          WHERE coalesce(t.expected_date, t.due_date) < ?
+            AND t.status NOT IN ('done','cancelled')
+          ORDER BY coalesce(t.expected_date, t.due_date)`,
       )
       .all(today);
 
@@ -263,9 +271,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
       .prepare(
         `SELECT t.*, p.title AS project_title, p.color AS project_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
-          WHERE t.due_date > ? AND t.due_date <= date(?, '+7 days')
+          WHERE coalesce(t.expected_date, t.due_date) > ?
+            AND coalesce(t.expected_date, t.due_date) <= date(?, '+7 days')
             AND t.status NOT IN ('done','cancelled')
-          ORDER BY t.due_date`,
+          ORDER BY coalesce(t.expected_date, t.due_date)`,
       )
       .all(today, today);
 

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -31,6 +31,7 @@ const createInput = z.object({
   status: z.enum(STATUSES).optional(),
   priority: z.enum(PRIORITIES).optional(),
   due_date: z.string().regex(DATE, 'Date must be YYYY-MM-DD').nullable().optional(),
+  expected_date: z.string().regex(DATE, 'Date must be YYYY-MM-DD').nullable().optional(),
   assignee_id: z.string().uuid().nullable().optional(),
   recurrence_rule: z.string().max(100).nullable().optional(),
 });
@@ -117,12 +118,14 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
       where.push('t.priority = ?');
       args.push(q.priority);
     }
+    // Date windows (the calendar fetch) go by the effective date: when an
+    // expected completion is set, that is the day the task actually lives on
     if (q.due_before) {
-      where.push('t.due_date IS NOT NULL AND t.due_date <= ?');
+      where.push('coalesce(t.expected_date, t.due_date) <= ?');
       args.push(q.due_before);
     }
     if (q.due_after) {
-      where.push('t.due_date IS NOT NULL AND t.due_date >= ?');
+      where.push('coalesce(t.expected_date, t.due_date) >= ?');
       args.push(q.due_after);
     }
     if (q.search) {
@@ -181,8 +184,8 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
     const taskId = id();
     db.prepare(
       `INSERT INTO tasks (id, project_id, parent_id, level, title, description, status, priority,
-                          due_date, assignee_id, recurrence_rule, position, created_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                          due_date, expected_date, assignee_id, recurrence_rule, position, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                (SELECT coalesce(max(position), 0) + 1 FROM tasks WHERE project_id = ?), ?)`,
     ).run(
       taskId,
@@ -194,6 +197,7 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
       d.status ?? 'todo',
       d.priority ?? 'normal',
       d.due_date ?? null,
+      d.expected_date ?? null,
       d.assignee_id ?? null,
       d.recurrence_rule ?? null,
       d.project_id,
@@ -275,6 +279,8 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
       const next = occurrenceAfter(anchor, task.due_date, task.recurrence_rule);
       if (next) {
         const nextId = id();
+        // expected_date is deliberately not copied: it describes how one
+        // specific occurrence is going in reality, not the series pattern
         db.prepare(
           `INSERT INTO tasks (id, project_id, parent_id, level, title, description, status,
                               priority, due_date, assignee_id, recurrence_rule,

--- a/web/src/components/CalendarViews.tsx
+++ b/web/src/components/CalendarViews.tsx
@@ -43,7 +43,10 @@ function groupByDate(occurrences: Occurrence[], tasks: Task[]) {
     }
   }
   for (const t of tasks) {
-    if (t.due_date) bucket(t.due_date).tasks.push(t);
+    // The effective day: an expected completion (when set) is the day
+    // the task is actually going to happen — same rule as the dashboard
+    const day = t.expected_date ?? t.due_date;
+    if (day) bucket(day).tasks.push(t);
   }
   return map;
 }

--- a/web/src/components/TaskBoard.tsx
+++ b/web/src/components/TaskBoard.tsx
@@ -17,7 +17,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-
 import { CSS } from '@dnd-kit/utilities';
 import { api, type Task } from '../lib/api';
 import { formatDate } from '../lib/format';
-import { BOARD_COLUMNS, PRIORITY_LABEL, STATUS_LABEL, isOverdue, today, type Status } from '../lib/tasks';
+import { BOARD_COLUMNS, PRIORITY_LABEL, STATUS_LABEL, effectiveDate, isOverdue, today, type Status } from '../lib/tasks';
 
 interface Props {
   tasks: Task[];
@@ -222,9 +222,10 @@ function Card({ task, overlay }: { task: Task; overlay?: boolean }) {
             {PRIORITY_LABEL[task.priority]}
           </span>
         )}
-        {task.due_date && (
+        {effectiveDate(task) && (
           <span className={`font-mono text-xs ${overdue ? 'text-urgent' : 'text-muted'}`}>
-            {formatDate(task.due_date)}
+            {task.expected_date ? '→ ' : ''}
+            {formatDate(effectiveDate(task)!)}
           </span>
         )}
         {task.assignee_name && (

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -32,6 +32,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
     status: task.status,
     priority: task.priority,
     due_date: task.due_date ?? '',
+    expected_date: task.expected_date ?? '',
     assignee_id: task.assignee_id ?? '',
     recurrence_rule: task.recurrence_rule ?? '',
   });
@@ -59,6 +60,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
         status: draft.status,
         priority: draft.priority,
         due_date: draft.due_date || null,
+        expected_date: draft.expected_date || null,
         assignee_id: draft.assignee_id || null,
         recurrence_rule: draft.recurrence_rule || null,
       });
@@ -182,6 +184,21 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
                 onChange={(e) => setDraft({ ...draft, due_date: e.target.value })}
                 className={field}
               />
+            </label>
+
+            <label className="block">
+              <span className={label}>{t('Expected finish')}</span>
+              <input
+                type="date"
+                value={draft.expected_date}
+                onChange={(e) => setDraft({ ...draft, expected_date: e.target.value })}
+                className={field}
+              />
+              {draft.expected_date && (
+                <span className="mt-1 block text-xs text-muted">
+                  {t('Overdue counts from this date')}
+                </span>
+              )}
             </label>
 
             <label className="block">

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -2,7 +2,7 @@ import { t } from '../lib/i18n';
 import { useState } from 'react';
 import { api, type Task, type TaskMutation } from '../lib/api';
 import { formatDate } from '../lib/format';
-import { PRIORITY_LABEL, isClosed, isOverdue, today, type TaskNode } from '../lib/tasks';
+import { PRIORITY_LABEL, effectiveDate, isClosed, isOverdue, today, type TaskNode } from '../lib/tasks';
 import { Empty } from './Page';
 
 interface Props {
@@ -150,9 +150,11 @@ function TaskItem({
           </>
         )}
 
-        {node.due_date && (
+        {effectiveDate(node) && (
           <span className={`font-mono text-xs ${overdue ? 'text-urgent' : 'text-muted'}`}>
-            {formatDate(node.due_date)}
+            {/* The arrow marks an expected date standing in for the due date */}
+            {node.expected_date ? '→ ' : ''}
+            {formatDate(effectiveDate(node)!)}
           </span>
         )}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,7 @@ export interface Task {
   status: TaskStatus;
   priority: TaskPriority;
   due_date: string | null;
+  expected_date: string | null;
   assignee_id: string | null;
   recurrence_rule: string | null;
   position: number;

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -197,6 +197,8 @@ export const ru: Record<string, string> = {
   'Drag files into the text or paste from the clipboard': 'Файлы можно перетащить в текст или вставить из буфера',
   'Drop a task here': 'Перетащите задачу сюда',
   'Due date': 'Срок',
+  'Expected finish': 'Ожидаемое завершение',
+  'Overdue counts from this date': 'Просрочка считается от этой даты',
   'Edit': 'Изменить',
   'Edit the saved amount': 'Изменить накопленную сумму',
   'Empty': 'Пусто',

--- a/web/src/lib/tasks.test.ts
+++ b/web/src/lib/tasks.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from './api';
+import { effectiveDate, isOverdue } from './tasks';
+
+function task(partial: Partial<Task>): Task {
+  return {
+    id: 't1',
+    project_id: 'p1',
+    parent_id: null,
+    level: 0,
+    title: 'x',
+    description: null,
+    status: 'todo',
+    priority: 'normal',
+    due_date: null,
+    expected_date: null,
+    assignee_id: null,
+    recurrence_rule: null,
+    position: 1,
+    ...partial,
+  } as Task;
+}
+
+const TODAY = '2026-08-14';
+
+describe('effectiveDate', () => {
+  it('prefers the expected finish over the due date', () => {
+    expect(effectiveDate(task({ due_date: '2026-08-10', expected_date: '2026-08-20' }))).toBe(
+      '2026-08-20',
+    );
+    expect(effectiveDate(task({ due_date: '2026-08-10' }))).toBe('2026-08-10');
+    expect(effectiveDate(task({}))).toBeNull();
+  });
+});
+
+describe('isOverdue', () => {
+  it('in-progress work with a future expected finish is not overdue (the coffee machine)', () => {
+    expect(
+      isOverdue(
+        task({ status: 'in_progress', due_date: '2026-08-11', expected_date: '2026-08-18' }),
+        TODAY,
+      ),
+    ).toBe(false);
+  });
+
+  it('a past expected finish makes the task overdue even with a future due date', () => {
+    expect(isOverdue(task({ due_date: '2026-08-20', expected_date: '2026-08-12' }), TODAY)).toBe(
+      true,
+    );
+  });
+
+  it('falls back to the due date when no expected finish is set', () => {
+    expect(isOverdue(task({ due_date: '2026-08-12' }), TODAY)).toBe(true);
+    expect(isOverdue(task({ due_date: '2026-08-14' }), TODAY)).toBe(false);
+  });
+
+  it('closed tasks are never overdue', () => {
+    expect(isOverdue(task({ status: 'done', due_date: '2026-08-01' }), TODAY)).toBe(false);
+    expect(
+      isOverdue(task({ status: 'cancelled', expected_date: '2026-08-01' }), TODAY),
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/tasks.ts
+++ b/web/src/lib/tasks.ts
@@ -73,8 +73,20 @@ export function buildTree(tasks: Task[]): TaskNode[] {
   return roots;
 }
 
+/**
+ * The date a task actually lives on. due_date says when it should be
+ * done; expected_date says when it is realistically going to be done
+ * (a repair known to take a week). When set, the expected date drives
+ * overdue and every date-keyed view — in-progress work with a known
+ * finish day is not "overdue", it is scheduled for that day.
+ */
+export function effectiveDate(task: Task): string | null {
+  return task.expected_date ?? task.due_date;
+}
+
 export function isOverdue(task: Task, today: string): boolean {
-  return Boolean(task.due_date && task.due_date < today && !isClosed(task));
+  const date = effectiveDate(task);
+  return Boolean(date && date < today && !isClosed(task));
 }
 
 export function isClosed(task: Task): boolean {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { api, type Dashboard as DashboardData, type Task } from '../lib/api';
 import type { Occurrence } from '../lib/calendar';
 import { formatDate, timeOf } from '../lib/format';
+import { effectiveDate } from '../lib/tasks';
 import { MoveBoard } from '../components/MoveBoard';
 import { Page } from '../components/Page';
 
@@ -36,8 +37,8 @@ function TaskRow({ task, overdue }: { task: Task; overdue?: boolean }) {
           {PRIORITY_LABEL.urgent}
         </span>
       )}
-        {overdue && task.due_date && (
-          <span className="font-mono text-xs text-urgent">{formatDate(task.due_date)}</span>
+        {overdue && effectiveDate(task) && (
+          <span className="font-mono text-xs text-urgent">{formatDate(effectiveDate(task)!)}</span>
         )}
       </Link>
     </li>


### PR DESCRIPTION
Closes #7.

## The semantics

`due_date` = when it should be done. `expected_date` = when it is realistically going to be done. When the expected date is set, the task's **effective date** becomes `COALESCE(expected_date, due_date)` everywhere a date matters. The coffee machine handed over for a week-long repair stops being "overdue" for seven days and becomes a task scheduled for its expected day.

## Design decisions (the issue asked for them)

- **Overdue** counts from the effective date — client `isOverdue` (new `effectiveDate` helper in `web/src/lib/tasks.ts`).
- **Dashboard** (for today / overdue / next 7 days): all three buckets select and sort by the effective date. On-plan work leaves the red zone and appears in the week on its expected day.
- **Calendar**: tasks are placed on their effective day; the `due_before`/`due_after` window filters match.
- **Recurrence**: no interaction by design. Task occurrences are materialized rows, and `expected_date` describes how *one specific occurrence* is going — the spawn-on-close INSERT deliberately does not copy it (commented in `tasks.ts`).
- **Display**: lists and the board mark a stand-in date with an arrow (`→ 18 August`), so a replaced due date is visible at a glance. Quick-add stays quick — the field lives only in the task panel.

## Implementation

- Migration `014_expected_date.sql` (one nullable column; no index — dashboard filters on the COALESCE expression and the table is family-scale).
- `createInput` gains the field; `patchInput` derives automatically; explicit INSERT columns updated.
- Demo seed gets a showcase task (due 3 days ago, expected in 4) so the semantics are visible without reading docs.
- `docs/features.md` — a paragraph in Tasks; ru dictionary entries for the two new labels.
- New `web/src/lib/tasks.test.ts`: effectiveDate preference, the coffee-machine case, past-expected-overrides-future-due, fallback, closed-never-overdue.

## Verification

`typecheck` / `lint` / `test` green (migration exercised by the migrations test on `:memory:`). Live in the dev preview: seeded task renders `→ 18 August` muted (not red) in the list; the dashboard shows **no Overdue panel** and places it in Next 7 days on the 18th; the task panel shows Due date and Expected finish side by side with the "Overdue counts from this date" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)