### PR TITLE
fix: mobile rows collapsed to a sliver next to wrapping controls

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
 import { useAuth } from '../lib/auth';
 import { QuickAdd } from './QuickAdd';
-import { GlobalSearch } from './GlobalSearch';
+import { GlobalSearch, SearchTrigger } from './GlobalSearch';
 
 interface NavItem {
   to: string;
@@ -205,7 +205,7 @@ export function AppShell() {
         </div>
 
         <div className="mb-4">
-          <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
+          <SearchTrigger onOpen={() => setSearchOpen(true)} />
         </div>
 
         <nav className="flex flex-1 flex-col gap-1">
@@ -250,6 +250,10 @@ export function AppShell() {
       </main>
 
       <QuickAdd onAdded={() => setRefreshKey((k) => k + 1)} />
+
+      {/* The search modal lives at the shell root: inside the sidebar it
+          inherited the sidebar's display:none on phones and never showed */}
+      <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
 
       {/* Bottom navigation: phone */}
       <nav className="fixed inset-x-0 bottom-0 z-10 grid grid-cols-6 border-t border-line bg-surface pb-[env(safe-area-inset-bottom)] md:hidden">

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -170,7 +170,7 @@ export function EventDialog({
             />
           </label>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-3 *:min-w-0">
             <label className="block">
               <span className={label}>{t('Calendar')}</span>
               <select
@@ -208,7 +208,7 @@ export function EventDialog({
             {t('All day')}
           </label>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-3 *:min-w-0">
             <label className="block">
               <span className={label}>{t('Start')}</span>
               <input
@@ -260,7 +260,7 @@ export function EventDialog({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-3 *:min-w-0">
             <label className="block">
               <span className={label}>{t('Recurrence')}</span>
               <select

--- a/web/src/components/GlobalSearch.tsx
+++ b/web/src/components/GlobalSearch.tsx
@@ -39,6 +39,28 @@ function subtitleOf(r: Result): string {
   return SERVER_SUBTITLES.has(r.subtitle) ? t(r.subtitle) : r.subtitle;
 }
 
+/**
+ * The sidebar trigger, separated from the modal. The modal must be
+ * mounted at the shell root: it used to live inside the sidebar, and on
+ * phones the sidebar is display:none — which hides even a fixed-position
+ * child, so search silently did nothing outside the desktop layout.
+ */
+export function SearchTrigger({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center gap-2 rounded-lg border border-line px-3 py-2 text-left text-sm text-muted transition-colors hover:text-ink"
+    >
+      <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.6">
+        <circle cx="11" cy="11" r="6.5" />
+        <path d="m16 16 4 4" strokeLinecap="round" />
+      </svg>
+      {t('Search')}
+    </button>
+  );
+}
+
 export function GlobalSearch({
   open: openProp,
   onOpenChange,
@@ -113,18 +135,6 @@ export function GlobalSearch({
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="flex w-full items-center gap-2 rounded-lg border border-line px-3 py-2 text-left text-sm text-muted transition-colors hover:text-ink"
-      >
-        <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.6">
-          <circle cx="11" cy="11" r="6.5" />
-          <path d="m16 16 4 4" strokeLinecap="round" />
-        </svg>
-        {t('Search')}
-      </button>
-
       {open && (
         <div className="fixed inset-0 z-50 flex items-start justify-center px-5 pt-20">
           <button

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -249,17 +249,22 @@ export function PeopleSection() {
               key={u.id}
               className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-line px-4 py-3.5 last:border-0"
             >
-              <span
-                className="size-2.5 shrink-0 rounded-full"
-                style={{ backgroundColor: u.color }}
-                aria-hidden
-              />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-ink">
-                  {u.name}
-                  {u.disabled_at && <span className="ml-2 text-xs text-muted">{t('disabled')}</span>}
-                </p>
-                <p className="truncate font-mono text-xs text-muted">{u.email}</p>
+              {/* Full row on phones: with flex-1 alone the name column
+                  shrank to a couple of characters before the actions
+                  wrapped ("S…" instead of "Sam") */}
+              <div className="flex w-full min-w-0 items-center gap-x-4 sm:w-auto sm:flex-1">
+                <span
+                  className="size-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: u.color }}
+                  aria-hidden
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-ink">
+                    {u.name}
+                    {u.disabled_at && <span className="ml-2 text-xs text-muted">{t('disabled')}</span>}
+                  </p>
+                  <p className="truncate font-mono text-xs text-muted">{u.email}</p>
+                </div>
               </div>
               <span className="text-xs text-muted">{ROLE_LABEL[u.role]}</span>
               <button

--- a/web/src/components/QuickAdd.tsx
+++ b/web/src/components/QuickAdd.tsx
@@ -105,7 +105,7 @@ export function QuickAdd({ onAdded }: { onAdded: () => void }) {
               className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2.5 text-sm text-ink outline-none focus:border-accent"
             />
 
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="mt-3 grid gap-3 *:min-w-0 sm:grid-cols-2">
               <select
                 value={projectId}
                 onChange={(e) => setProjectId(e.target.value)}

--- a/web/src/components/RecurringPanel.tsx
+++ b/web/src/components/RecurringPanel.tsx
@@ -97,7 +97,10 @@ export function DuePanel({
               key={key}
               className="flex flex-wrap items-center gap-3 rounded-lg bg-surface px-3 py-2.5"
             >
-              <span className="min-w-0 flex-1">
+              {/* Full row on phones: flex-1 with min-w-0 shrinks to a
+                  few-pixel column before flex-wrap ever kicks in, and the
+                  meta line collapsed to one word per line */}
+              <span className="w-full min-w-0 sm:w-auto sm:flex-1">
                 <span className="block truncate text-sm text-ink">{item.title}</span>
                 <span className="block text-xs text-muted">
                   {formatDate(item.occurred_on)} · {item.account_name}
@@ -186,7 +189,8 @@ export function RecurringPanel({
                 r.active ? '' : 'opacity-50'
               }`}
             >
-              <span className="min-w-0 flex-1">
+              {/* Same full-row-on-phones treatment as the confirm list above */}
+              <span className="w-full min-w-0 sm:w-auto sm:flex-1">
                 <span className="block truncate text-sm font-medium text-ink">
                   {r.title}
                   <span className="ml-2 text-xs font-normal text-muted">

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -143,7 +143,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
             />
           </label>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 gap-3 *:min-w-0">
             <label className="block">
               <span className={label}>{t('Status')}</span>
               <select

--- a/web/src/components/TransactionDialog.tsx
+++ b/web/src/components/TransactionDialog.tsx
@@ -212,7 +212,7 @@ export function TransactionDialog({
           ))}
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3 *:min-w-0">
           <label className="block">
             <span className={dialogLabel}>{kind === 'transfer' ? t('Debit') : t('Amount')}</span>
             <input
@@ -329,7 +329,7 @@ export function TransactionDialog({
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3 *:min-w-0">
           <label className="block">
             <span className={dialogLabel}>{t('Where')}</span>
             <input

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -73,6 +73,18 @@
 }
 
 /*
+  iOS Safari gives date/time inputs a fixed intrinsic width and refuses
+  to shrink them below it — inside a two-column dialog grid on a phone
+  the Date field punched through the card's edge (Chrome compresses
+  such inputs, so only WebKit shows it). min-width lets them compress
+  to the column; w-full on the field class does the rest.
+*/
+input[type='date'],
+input[type='time'] {
+  min-width: 0;
+}
+
+/*
   Custom select arrow: the native glyph ignores the field's padding and
   sticks to the right edge (and the OS recolors it on the dark theme).
   #848f98 is picked as a middle tone readable on both themes; a CSS


### PR DESCRIPTION
## The bug class

Three list rows shared one flexbox trap: a text column with `flex-1 min-w-0` inside a `flex-wrap` row next to fixed-width controls. Flexbox shrinks the flexible column to almost nothing *before* wrapping kicks in, so on a 375px phone:

- the recurring-**confirm** rows rendered their meta one word per line (`6 July · Joint\ncard ·\nSalary`) squeezed into a ~60px column;
- the recurring-**transactions** rows cut their meta at `Joint car…`;
- the **member rows** in Settings showed a member named Sam as `S…`.

## The fix

The text block takes the full row on phones (`w-full min-w-0`, controls wrap to a second line) and returns to a single inline row from `sm` up (`sm:w-auto sm:flex-1`). Same treatment in all three places, commented at the first one.

## Sweep coverage

Walked every page and interactive state at 375px with a programmatic overflow probe (element rects vs viewport) plus screenshots: dashboard, tasks list/board, task panel, calendar week/month/agenda, event dialog, notes list/editor/history, money (accounts, expense quick-add, transactions, budgets + new-budget dialog, recurring, reconcile, transaction dialog), mail list/reader, settings top-to-bottom (incl. the mailbox and people sections), quick-add, More sheet. No horizontal page scroll anywhere and no other collapsed columns found. Before/after verified live for all three fixed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)