### PR TITLE
fix: mobile feedback batch — iOS date inputs, money overflow, donut label, week view

### DIFF
--- a/web/src/components/DonutChart.tsx
+++ b/web/src/components/DonutChart.tsx
@@ -65,18 +65,65 @@ export function DonutChart({ segments, centerLabel, size = 132 }: Props) {
           </circle>
         );
       })}
-      {centerLabel && (
-        <text
-          x="50%"
-          y="50%"
-          textAnchor="middle"
-          dominantBaseline="central"
-          className="fill-[var(--c-text)] font-mono"
-          fontSize={size * 0.095}
-        >
-          {centerLabel}
-        </text>
-      )}
+      {centerLabel &&
+        (() => {
+          /*
+            The label must stay inside the hole: "RSD 129,510.28" is
+            wider than the inner circle and used to lie across the ring.
+            A spaced label (code + amount) splits into two lines, and
+            both shrink to the hole if a monster amount still demands it.
+            Mono glyphs are ~0.62em wide — close enough for a fit check.
+          */
+          const hole = size - 2 * stroke;
+          const fitted = (text: string, base: number) =>
+            Math.min(base, (hole * 0.92) / (Math.max(text.length, 1) * 0.62));
+          // formatMoney separates code and amount with a non-breaking
+          // space — match any whitespace, not the plain one
+          const space = centerLabel.search(/\s/);
+          if (space === -1) {
+            return (
+              <text
+                x="50%"
+                y="50%"
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-[var(--c-text)] font-mono"
+                fontSize={fitted(centerLabel, size * 0.095)}
+              >
+                {centerLabel}
+              </text>
+            );
+          }
+          const unit = centerLabel.slice(0, space);
+          const amount = centerLabel.slice(space + 1);
+          const amountSize = fitted(amount, size * 0.095);
+          return (
+            <>
+              <text
+                x="50%"
+                y="50%"
+                dy={-amountSize * 0.75}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-[var(--c-text-muted)] font-mono"
+                fontSize={fitted(unit, size * 0.07)}
+              >
+                {unit}
+              </text>
+              <text
+                x="50%"
+                y="50%"
+                dy={amountSize * 0.5}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="fill-[var(--c-text)] font-mono"
+                fontSize={amountSize}
+              >
+                {amount}
+              </text>
+            </>
+          );
+        })()}
     </svg>
   );
 }

--- a/web/src/components/MoveBoard.tsx
+++ b/web/src/components/MoveBoard.tsx
@@ -46,7 +46,7 @@ export function MoveBoard({ settings, onChange }: Props) {
 
   return (
     <section className="overflow-hidden rounded-card bg-[#131c24] text-[#e8eae5] shadow-sm">
-      <div className="grid divide-y divide-white/10 sm:grid-cols-[1.1fr_1fr] sm:divide-x sm:divide-y-0">
+      <div className="grid divide-y divide-white/10 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] sm:divide-x sm:divide-y-0">
         {/* Countdown */}
         <div className="px-6 py-5">
           <p className="eyebrow text-white/45!">{settings['move.label'] ?? t('The move')}</p>

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -208,7 +208,7 @@ export function PeopleSection() {
 
       <div className="mb-6 rounded-card border border-line bg-surface p-5">
         <h2 className="eyebrow mb-4">{t('Create manually (with a one-time password)')}</h2>
-        <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto]">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
           <input
             placeholder={t('Name')}
             value={form.name}

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -624,6 +624,7 @@ export const ru: Record<string, string> = {
   'Save and check': 'Сохранить и проверить',
   'Saved. Checking the mailbox…': 'Сохранено. Проверяю ящик…',
   'Send reply': 'Отправить ответ',
+  'Show earlier days ({n})': 'Показать более ранние дни ({n})',
   'Synced {when}': 'Синхронизировано {when}',
   'The household paperwork inbox': 'Домашняя канцелярия',
   'The shared address the Mail section reads. A dedicated mailbox works best; a personal Gmail works too — filter letters into a separate label and set it as the folder below.': 'Общий адрес, который читает раздел «Почта». Лучше всего отдельный ящик; личный Gmail тоже подходит — настройте фильтр в отдельный ярлык и укажите его как папку ниже.',

--- a/web/src/pages/Money.tsx
+++ b/web/src/pages/Money.tsx
@@ -11,7 +11,7 @@ import { DonutChart } from '../components/DonutChart';
 import { DuePanel, RecurringPanel, type DueItem } from '../components/RecurringPanel';
 import { onEnter } from '../lib/keys';
 import { useLatest } from '../lib/latest';
-import { addMonths, formatDate, monthTitle, plural } from '../lib/format';
+import { addDays, addMonths, formatDate, monthTitle, plural } from '../lib/format';
 import { today as todayISO } from '../lib/tasks';
 import {
   ACCOUNT_KIND_LABEL,
@@ -66,6 +66,30 @@ export function Money() {
   const [categoryParent, setCategoryParent] = useState('');
   // Expanded parents in the "By category" summary
   const [expandedCats, setExpandedCats] = useState<Set<string>>(new Set());
+
+  /*
+    The transactions list is a diary, not the destination: the category
+    summary lives below it, and a month of rows on a phone put it a
+    minute of scrolling away. So by default only the last week of days
+    is shown (the rest of the month behind one button), today's day is
+    open and earlier days collapse to a header with a count.
+  */
+  const [showAllDays, setShowAllDays] = useState(false);
+  const [expandedDays, setExpandedDays] = useState<Set<string>>(() => new Set([todayISO()]));
+
+  useEffect(() => {
+    setShowAllDays(false);
+    setExpandedDays(new Set([todayISO()]));
+  }, [anchor]);
+
+  function toggleDay(date: string) {
+    setExpandedDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(date)) next.delete(date);
+      else next.add(date);
+      return next;
+    });
+  }
 
   const { from, to } = useMemo(() => monthBounds(anchor), [anchor]);
 
@@ -162,6 +186,14 @@ export function Money() {
     }
     return [...map.entries()];
   }, [transactions]);
+
+  // The week cutoff applies only while looking at the current month:
+  // a past month is opened deliberately and shows all of its days
+  const viewingCurrentMonth = anchor.slice(0, 7) === today.slice(0, 7);
+  const weekCutoff = addDays(today, -6);
+  const visibleByDate =
+    showAllDays || !viewingCurrentMonth ? byDate : byDate.filter(([date]) => date >= weekCutoff);
+  const hiddenDays = byDate.length - visibleByDate.length;
 
   const expenseTotals = (summary?.byCurrency ?? []).filter((r) => r.kind === 'expense');
   const incomeTotals = (summary?.byCurrency ?? []).filter((r) => r.kind === 'income');
@@ -512,11 +544,29 @@ export function Money() {
                   <Empty>{t('No transactions this month.')}</Empty>
                 ) : (
                   <ul className="space-y-3">
-                    {byDate.map(([date, items]) => (
+                    {visibleByDate.map(([date, items]) => {
+                      const open = expandedDays.has(date);
+                      return (
                       <li key={date} className="overflow-hidden rounded-card border border-line bg-surface">
-                        <p className="border-b border-line px-4 py-2 text-xs text-muted">
-                          {formatDate(date)}
-                        </p>
+                        <button
+                          type="button"
+                          onClick={() => toggleDay(date)}
+                          aria-expanded={open}
+                          className={`flex w-full items-center justify-between gap-3 px-4 py-2 text-left text-xs text-muted transition-colors hover:bg-surface-2 ${
+                            open ? 'border-b border-line' : ''
+                          }`}
+                        >
+                          <span>{formatDate(date)}</span>
+                          <span className="flex items-center gap-2">
+                            {!open && (
+                              <span>
+                                {items.length} {plural(items.length, 'transaction', 'transactions')}
+                              </span>
+                            )}
+                            <span aria-hidden>{open ? '▾' : '▸'}</span>
+                          </span>
+                        </button>
+                        {open && (
                         <ul>
                           {items.map((tx) => (
                             <li key={tx.id}>
@@ -562,8 +612,21 @@ export function Money() {
                             </li>
                           ))}
                         </ul>
+                        )}
                       </li>
-                    ))}
+                      );
+                    })}
+                    {hiddenDays > 0 && (
+                      <li>
+                        <button
+                          type="button"
+                          onClick={() => setShowAllDays(true)}
+                          className="w-full rounded-card border border-dashed border-line px-4 py-2.5 text-sm text-muted transition-colors hover:border-accent hover:text-accent"
+                        >
+                          {t('Show earlier days ({n})', { n: String(hiddenDays) })}
+                        </button>
+                      </li>
+                    )}
                   </ul>
                 )}
               </div>

--- a/web/src/pages/Money.tsx
+++ b/web/src/pages/Money.tsx
@@ -501,7 +501,11 @@ export function Money() {
             )}
 
             {tab === 'operations' && (
-            <div className="grid gap-4 lg:grid-cols-[1fr_20rem]">
+            /* minmax(0,…) on every track: with bare 1fr (and the implicit
+               mobile column) a transaction row with a long note dictates
+               the track's min width and pushes the whole page into a
+               horizontal scroll — same trap Notes hit with its list */
+            <div className="grid grid-cols-[minmax(0,1fr)] gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
               {/* Transactions */}
               <div>
                 {byDate.length === 0 ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -85,6 +85,28 @@ input[type='time'] {
 }
 
 /*
+  min-width alone proved insufficient on a real iPhone (15 Pro Max,
+  standalone shortcut): the native menulist-style chrome of WebKit date
+  fields carries its own intrinsic width that survives min-width: 0.
+  Stripping the appearance makes the field a plain box that obeys the
+  grid column. Scoped to iOS via the -webkit-touch-callout guard so
+  desktop pickers keep their native look; the value pseudo-element
+  keeps an empty field from collapsing to bare padding.
+*/
+@supports (-webkit-touch-callout: none) {
+  input[type='date'],
+  input[type='time'] {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  input[type='date']::-webkit-date-and-time-value,
+  input[type='time']::-webkit-date-and-time-value {
+    min-height: 1.25em;
+    text-align: inherit;
+  }
+}
+
+/*
   Custom select arrow: the native glyph ignores the field's padding and
   sticks to the right edge (and the OS recolors it on the dark theme).
   #848f98 is picked as a middle tone readable on both themes; a CSS


### PR DESCRIPTION
Batch from real-device testing on an iPhone 15 Pro Max. Four commits, independently revertable.

## 1. Date inputs still punched through dialog edges on real WebKit

`min-width: 0` from #35 works in Chrome's emulation but not on a real iPhone: WebKit's native menulist chrome for date/time fields carries its own intrinsic width. Fix: strip `appearance`, scoped to WebKit touch devices via `@supports (-webkit-touch-callout: none)` so desktop pickers keep their native look; a `::-webkit-date-and-time-value` rule keeps empty fields from collapsing. **Needs a real-phone check after deploy** (no full Xcode here for the simulator).

## 2. Money page scrolled horizontally with real-world data

Reproduced with production-shaped data (RSD 123,456.78, long Cyrillic categories, a long transfer note): `scrollWidth` 503 vs 430 viewport — amounts clipped exactly as photographed. Root cause: the money grid used bare `1fr`/implicit tracks, whose min-width is `auto`; a flex row's min-content propagates into the track even though its text truncates. Fix: `minmax(0,…)` on every track (the fix Notes already carries); PeopleSection and MoveBoard grids got the same preventively. Clean at 430px and 375px after.

## 3. Donut center label lay across the ring

`RSD 129,510.28` in mono is wider than the donut hole. Spaced labels (code + amount) now split into two lines — code small and muted above the amount — and both lines auto-shrink to the hole for even longer amounts. Split matches any whitespace (formatMoney uses a non-breaking space).

## 4. Transactions list: last week by default, days fold up

Requested UX change: the category summary sits below the list and was a minute of scrolling away on a phone. Current month now opens on the last seven days ("Show earlier days (n)" reveals the rest), today's group is expanded, other days collapse to a date + count header, tap to expand. Past months show all days, collapsed.

## Verification

typecheck / lint / tests green. Live checks at 430×932 and 375×812 with production-shaped seeded data: no horizontal scroll, donut label inside the hole in both currencies, collapse/expand and "Show earlier" verified interactively. Item 1 is the only one needing the real phone: open the transaction dialog — the Date field must stay inside the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)