### PR TITLE
fix: settings admin blocks sat glued to the columns above

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -369,7 +369,10 @@ export function Settings() {
           inside, and user feedback asked for them here rather than in
           a dedicated navigation section */}
       {user?.role === 'admin' && (
-        <div className="mx-auto max-w-md space-y-5 lg:max-w-4xl 3xl:max-w-[86rem] 4xl:max-w-[114rem]">
+        // Explicit mt-5: the columns block above provides no bottom
+        // spacing of its own — the last card's margin is truncated at
+        // the column fragment edge, and the admin block sat glued to it
+        <div className="mx-auto mt-5 max-w-md space-y-5 lg:max-w-4xl 3xl:max-w-[86rem] 4xl:max-w-[114rem]">
           <MailSection />
           <PeopleSection />
         </div>


### PR DESCRIPTION
Follow-up to #37. CSS multicol truncates a child's bottom margin at the column fragment edge, so the columns container ends flush with its last card — and the Family mailbox block below sat at a measured 0px gap. Explicit `mt-5` on the admin wrapper; measured 20px after, matching the page rhythm. (The apparent left-edge misalignment on the screenshot was crop illusion — both wrappers measure identical left/width.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)