### PR TITLE
docs: catch documentation up with the security and PWA batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A self-hosted family hub: tasks, notes, calendar and money in one place. Built for a household, not a corporation: one Docker container, one SQLite file, no external services required. Runs on a home machine over the local network or on a cheap VPS with a real domain.
 
-The core is complete and battle-tested by daily family use: accounts and sign-in (password and Google), projects and tasks with a kanban board, notes with attachments and wiki-links, a calendar with recurring events, full-text search, a dashboard, and a money section — accounts with balances, expenses, income, transfers, bank reconciliation, categories, budgets, recurring transactions, receipts.
+The core is complete and battle-tested by daily family use: accounts and sign-in (password and Google, with optional two-factor codes), projects and tasks with a kanban board, notes with attachments and wiki-links, a calendar with recurring events, a shared family mailbox that turns letters into tasks, full-text search, a dashboard, and a money section — accounts with balances, expenses, income, transfers, bank reconciliation, categories, budgets, recurring transactions, receipts. It installs to the home screen as an app and keeps working read-only when the Wi-Fi does not.
 
 ## A quick look
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,3 +68,9 @@ Under the hood the app builds a template database at startup (migrations + seedi
 Visitors can create, edit and delete anything — nobody else will ever see it, which is the point: a shared demo is a graffiti wall by lunchtime. Password and membership changes and file uploads stay blocked.
 
 Deploying a public demo next to a production hub: [deploy-vps.md](deploy-vps.md), "Public demo".
+
+## Offline and updates
+
+The frontend is a PWA: a service worker precaches the app shell and answers GET API reads NetworkFirst — fresh when online, the last snapshot when not. Nothing external is involved (the strict CSP allows no third-party scripts); workbox is bundled and self-hosted. Auth is uncached except the single `auth/me` read, without which an offline reload would strand the person on the sign-in screen; signing out — or any 401 — deletes the offline caches, so cached family data never outlives a session.
+
+The same worker solves the long-lived-tab problem: a kiosk that stays open for weeks runs whatever bundle it started with, because a SPA re-reads `index.html` only on full navigation. A deploy now produces a waiting worker, the client shows a "hub was updated" toast, and a tab idle for 15+ minutes reloads itself. The demo never registers the worker: sandboxes are per-visitor, browser caches are not.

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,6 +33,8 @@ One invariant always holds: **the administrator's password sign-in cannot be dis
 
 An emergency door deserves a second lock: any account can enable **two-factor authentication** (Settings → Two-factor authentication) — a six-digit TOTP code from an authenticator app, required at password sign-in on top of the password. It matters most for the administrator, whose password entrance can never be turned off; family members usually hide behind Google and its own protections instead. Google sign-in is unaffected by the hub's TOTP. Lost authenticator: `npm run admin:reset` clears the second factor together with the password — the escape hatch stays the server owner's console, never a web page.
 
+Settings also shows **Devices** — every live session with browser, IP and last activity, the current one marked. Any session can be revoked individually, or all but the current one at once ("Sign out everywhere else" — the lost-phone button). A revoked device also clears its offline copy of the data the next time it touches the network. Sessions idle for a month retire on their own.
+
 Setting up Google sign-in on a server: [deploy-vps.md](deploy-vps.md), "Google sign-in".
 
 ## Tasks


### PR DESCRIPTION
Pre-v1.0 documentation pass:

- **README** intro now mentions the family mailbox, two-factor codes, home-screen install and offline reading — everything the first paragraph promised was two releases stale.
- **features.md** documents the Devices list (sessions with browser/IP/activity, per-session revoke, the lost-phone button, idle retirement) right after the sign-in story.
- **architecture.md** gains an "Offline and updates" section: the service worker, what is cached and what deliberately is not, the 401 cache wipe, the update toast, and why the demo never registers the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)