### PR TITLE
fix: correct two Settings strings that misread in English

### DIFF
--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -513,7 +513,7 @@ export const ru: Record<string, string> = {
   'The event ends before it starts': 'Конец события раньше начала',
   'The event needs a title': 'У события должно быть название',
   'The file is missing on disk': 'Файл потерян на диске',
-  'The guideline is {n} GB. There is no hard limit, but keep an eye on growth: attachments are not part of the GitHub backup.': 'Ориентир — {n} ГБ. Жёсткого запрета нет, но за ростом стоит следить: вложения не попадают в бэкап на GitHub.',
+  'The budget is {n} GB — once it runs out, new uploads are refused. Attachments are not part of the backup archive, so keep an eye on growth.': 'Бюджет — {n} ГБ, при исчерпании новые загрузки отклоняются. Вложения не попадают в архив бэкапа, так что за ростом стоит следить.',
   'The hub is already set up': 'Хаб уже настроен',
   'The issued password was shown once. Set your own before continuing.': 'Выданный пароль виден в логе сервера. Задайте свой, прежде чем продолжить.',
   'The link is invalid: expired or already used': 'Ссылка не действует: истекла или уже использована',

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -480,7 +480,13 @@ export function Settings() {
       </div>
 
       <section className="mb-5 break-inside-avoid rounded-card border border-line bg-surface p-5">
-        <h2 className="eyebrow mb-4">{t('Language')} / Language</h2>
+        {/* The English word is kept alongside the translation so the setting
+            is findable in a language you do not read — but only when the two
+            actually differ, or English shows "Language / Language". */}
+        <h2 className="eyebrow mb-4">
+          {t('Language')}
+          {t('Language') !== 'Language' && ' / Language'}
+        </h2>
         <div className="flex gap-2">
           <button
             type="button"
@@ -554,7 +560,7 @@ export function Settings() {
             />
           </div>
           <p className="mt-2 text-xs text-muted">
-            {t('The guideline is {n} GB. There is no hard limit, but keep an eye on growth: attachments are not part of the GitHub backup.', { n: Math.round(usage.budget / 1024 / 1024 / 1024) })}
+            {t('The budget is {n} GB — once it runs out, new uploads are refused. Attachments are not part of the backup archive, so keep an eye on growth.', { n: Math.round(usage.budget / 1024 / 1024 / 1024) })}
           </p>
         </section>
       )}


### PR DESCRIPTION
Two strings in Settings that say the wrong thing to an English reader. Both surfaced while regenerating the documentation screenshots — they are the kind of wording nobody re-reads once it is written.

## "Language / Language"

```tsx
<h2 className="eyebrow mb-4">{t('Language')} / Language</h2>
```

Pairing the translated word with the English one is the right idea: it keeps the setting findable when the interface is in a language you cannot read. It just reads as a duplicate in English, where the two are the same word — and that heading sits in the README screenshot.

Now the pair only appears when the halves differ, so it keeps working for any language added later without another special case:

```tsx
{t('Language')}
{t('Language') !== 'Language' && ' / Language'}
```

Verified in both locales against a running hub: English shows `Language`, Russian still shows `Язык / Language`.

## The attachment budget

The caption said there is no hard limit. There is — `receiveFiles` answers `413 Attachment storage is full` once the store passes the 2 GB budget (`server/src/routes/attachments.ts:155`), which is what the code comment on `BUDGET_BYTES` intends.

Telling someone there is no limit invites them to fill the disk and then meet an error the interface promised would not happen. The new wording says what actually occurs, and keeps the part that was true — attachments are outside the backup archive, so growth is still worth watching.

Both the English key and its Russian entry are updated; the scan of all 521 `t()` keys against `i18n.ru.ts` shows no new gaps.

The same "no hard limit" claim in `docs/features.md` is corrected in #53, which is documentation-only.

## Checks

`npm run typecheck`, `npm run lint`, `npm test` (70) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)