### PR TITLE
fix: make a TOTP code one-time

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -33,6 +33,8 @@ One invariant always holds: **the administrator's password sign-in cannot be dis
 
 An emergency door deserves a second lock: any account can enable **two-factor authentication** (Settings → Two-factor authentication) — a six-digit TOTP code from an authenticator app, required at password sign-in on top of the password. It matters most for the administrator, whose password entrance can never be turned off; family members usually hide behind Google and its own protections instead. Google sign-in is unaffected by the hub's TOTP. Lost authenticator: `npm run admin:reset` clears the second factor together with the password — the escape hatch stays the server owner's console, never a web page.
 
+A code is spent when it is used, as the "one-time" in one-time password promises: the hub records which 30-second step it accepted and refuses that one and every earlier one afterwards. In practice that shows up once — signing in on a second device inside the same half-minute waits for the next code. That is the cost of a code being worthless to anyone who reads it over your shoulder after you have used it.
+
 Settings also shows **Devices** — every live session with browser, IP and last activity, the current one marked. Any session can be revoked individually, or all but the current one at once ("Sign out everywhere else" — the lost-phone button). A revoked device also clears its offline copy of the data the next time it touches the network. Sessions idle for a month retire on their own.
 
 Setting up Google sign-in on a server: [deploy-vps.md](deploy-vps.md), "Google sign-in".

--- a/scripts/admin-reset.mjs
+++ b/scripts/admin-reset.mjs
@@ -59,7 +59,8 @@ const hash = await hashPassword(password);
 // lost authenticator is exactly the lockout it exists to escape.
 db.prepare(
   `UPDATE users SET password_hash = ?, must_change_password = 1, disabled_at = NULL,
-                    totp_secret = NULL, totp_confirmed_at = NULL WHERE id = ?`,
+                    totp_secret = NULL, totp_confirmed_at = NULL, totp_last_step = NULL
+    WHERE id = ?`,
 ).run(hash, user.id);
 
 // Close previous sessions: if the password is being reset, they can't be trusted

--- a/server/src/db/migrations/018_totp_replay.sql
+++ b/server/src/db/migrations/018_totp_replay.sql
@@ -1,0 +1,14 @@
+-- A one-time code has to be usable once.
+--
+-- The code itself carries no notion of having been spent: it is a pure
+-- function of the secret and a 30-second time step, so within that step
+-- (plus the one on either side we accept for clock drift) the answer to
+-- "do these six digits match?" never changes. The duty is the verifier's,
+-- and RFC 6238 §5.2 spells it out — remember the last accepted step and
+-- refuse anything at or below it. Until now nothing was remembered, so a
+-- code observed over a shoulder stayed good for another ~90 seconds and
+-- opened as many sessions as it was replayed into.
+--
+-- NULL means nothing has been spent yet: a freshly minted secret, or an
+-- account that enabled two-factor before this migration.
+ALTER TABLE users ADD COLUMN totp_last_step INTEGER;

--- a/server/src/lib/auth.test.ts
+++ b/server/src/lib/auth.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { id, now, openDatabase, runWithDb } from '../db/index.js';
 import { migrate } from '../db/migrate.js';
-import { createSession, destroyOtherSessions, hashToken } from './auth.js';
+import { consumeTotp, createSession, destroyOtherSessions, hashToken } from './auth.js';
+import { base32Encode, hotp } from './totp.js';
 
 describe('destroyOtherSessions', () => {
   it('keeps exactly the session making the request', () => {
@@ -48,6 +49,60 @@ describe('destroyOtherSessions', () => {
         .prepare('SELECT count(*) AS n FROM sessions WHERE user_id = ?')
         .get(b) as { n: number };
       expect(n).toBe(1);
+    });
+  });
+});
+
+describe('consumeTotp', () => {
+  const SECRET = base32Encode(Buffer.from('12345678901234567890'));
+  // A fixed clock: step 37037036 covers 1111111109 s, an RFC 6238 vector
+  const NOW = 1111111109 * 1000;
+  const STEP = Math.floor(1111111109 / 30);
+
+  function withUser(fn: (userId: string) => void): void {
+    const db = openDatabase(':memory:');
+    runWithDb(db, () => {
+      migrate();
+      const userId = id();
+      db.prepare(
+        `INSERT INTO users (id, email, name, role, password_hash, totp_secret, totp_confirmed_at, created_at)
+         VALUES (?, 'a@hub.local', 'A', 'admin', 'x', ?, ?, ?)`,
+      ).run(userId, SECRET, now(), now());
+      fn(userId);
+    });
+  }
+
+  it('accepts a code once and refuses the replay', () => {
+    withUser((userId) => {
+      const code = hotp(SECRET, STEP);
+      expect(consumeTotp(userId, SECRET, code, NOW)).toBe(true);
+      // Same code, same step, still inside its window — this is the
+      // second browser the vulnerability let in
+      expect(consumeTotp(userId, SECRET, code, NOW)).toBe(false);
+    });
+  });
+
+  it('still accepts the next code', () => {
+    withUser((userId) => {
+      expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP), NOW)).toBe(true);
+      expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP + 1), NOW + 30_000)).toBe(true);
+    });
+  });
+
+  it('refuses an earlier step once a later one is spent', () => {
+    withUser((userId) => {
+      // The drift window accepts step-1, so without the ceiling a spent
+      // sign-in could be followed by the previous code
+      expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP), NOW)).toBe(true);
+      expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP - 1), NOW)).toBe(false);
+    });
+  });
+
+  it('a wrong code changes nothing', () => {
+    withUser((userId) => {
+      expect(consumeTotp(userId, SECRET, '000000', NOW)).toBe(false);
+      // The valid code is untouched by the failed attempt
+      expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP), NOW)).toBe(true);
     });
   });
 });

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -3,6 +3,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import { db, id } from '../db/index.js';
 import { env } from '../env.js';
 import { log } from './log.js';
+import { totpStep } from './totp.js';
 
 export const SESSION_COOKIE = 'hub_session';
 const SESSION_DAYS = 90;
@@ -193,6 +194,36 @@ export function pruneSessions(): void {
   db.prepare(
     `DELETE FROM sessions WHERE coalesce(last_seen_at, created_at) <= ?`,
   ).run(idleCutoff);
+}
+
+/**
+ * Check a TOTP code and spend it in one move: true only when the code is
+ * valid *and* its step has not been used before.
+ *
+ * The guard is the UPDATE itself rather than a read followed by a write.
+ * Two requests arriving with the same code would both pass a read — the
+ * conditional write lets exactly one of them through, which is the
+ * double-submit case as much as the attacker one.
+ *
+ * A wrong code and an already-spent one are deliberately the same answer
+ * to the caller: telling them apart would confirm to whoever replayed it
+ * that the code was genuine.
+ */
+export function consumeTotp(
+  userId: string,
+  secretBase32: string,
+  code: string,
+  now = Date.now(),
+): boolean {
+  const step = totpStep(secretBase32, code, now);
+  if (step === null) return false;
+  const result = db
+    .prepare(
+      `UPDATE users SET totp_last_step = ?
+        WHERE id = ? AND (totp_last_step IS NULL OR totp_last_step < ?)`,
+    )
+    .run(step, userId, step);
+  return result.changes === 1;
 }
 
 /**

--- a/server/src/lib/totp.test.ts
+++ b/server/src/lib/totp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { base32Decode, base32Encode, hotp, otpauthUri, verifyTotp } from './totp.js';
+import { base32Decode, base32Encode, hotp, otpauthUri, totpStep } from './totp.js';
 
 // RFC 6238 appendix B vectors use the ASCII secret "12345678901234567890";
 // its base32 form:
@@ -29,20 +29,27 @@ describe('totp against RFC 6238 vectors', () => {
 
   for (const [seconds, expected] of vectors) {
     it(`T=${seconds} → ${expected}`, () => {
-      expect(verifyTotp(RFC_SECRET, expected, seconds * 1000)).toBe(true);
+      expect(totpStep(RFC_SECRET, expected, seconds * 1000)).toBe(Math.floor(seconds / 30));
     });
   }
 
   it('rejects a wrong code and malformed input', () => {
-    expect(verifyTotp(RFC_SECRET, '000000', 59_000)).toBe(false);
-    expect(verifyTotp(RFC_SECRET, '28708', 59_000)).toBe(false);
-    expect(verifyTotp(RFC_SECRET, 'abcdef', 59_000)).toBe(false);
+    expect(totpStep(RFC_SECRET, '000000', 59_000)).toBeNull();
+    expect(totpStep(RFC_SECRET, '28708', 59_000)).toBeNull();
+    expect(totpStep(RFC_SECRET, 'abcdef', 59_000)).toBeNull();
   });
 
   it('accepts one step of clock drift, not two', () => {
     const t = 1111111109 * 1000;
-    expect(verifyTotp(RFC_SECRET, hotp(RFC_SECRET, Math.floor(1111111109 / 30) - 1), t)).toBe(true);
-    expect(verifyTotp(RFC_SECRET, hotp(RFC_SECRET, Math.floor(1111111109 / 30) - 2), t)).toBe(false);
+    const step = Math.floor(1111111109 / 30);
+    expect(totpStep(RFC_SECRET, hotp(RFC_SECRET, step - 1), t)).toBe(step - 1);
+    expect(totpStep(RFC_SECRET, hotp(RFC_SECRET, step - 2), t)).toBeNull();
+  });
+
+  it('reports which step matched, so the caller can burn it', () => {
+    const t = 1111111109 * 1000;
+    const step = Math.floor(1111111109 / 30);
+    expect(totpStep(RFC_SECRET, hotp(RFC_SECRET, step + 1), t)).toBe(step + 1);
   });
 });
 

--- a/server/src/lib/totp.ts
+++ b/server/src/lib/totp.ts
@@ -67,20 +67,29 @@ export function hotp(secretBase32: string, counter: number): string {
 }
 
 /**
- * Accepts the current 30-second step and one step to either side —
- * clock drift on the phone and the human pause between reading and
- * typing the code. One step, not more: every extra step doubles the
- * brute-force window.
+ * The time step a code belongs to, or null when it matches none of the
+ * accepted ones.
+ *
+ * Accepts the current 30-second step and one step to either side — clock
+ * drift on the phone and the human pause between reading and typing the
+ * code. One step, not more: every extra step doubles the brute-force
+ * window.
+ *
+ * It returns the step rather than a boolean because a caller cannot make
+ * a code one-time without knowing which step to burn — see consumeTotp
+ * in lib/auth.ts. This module stays pure on purpose: it is checked
+ * against the RFC vectors, and a database would only get in the way.
  */
-export function verifyTotp(secretBase32: string, code: string, now = Date.now()): boolean {
+export function totpStep(secretBase32: string, code: string, now = Date.now()): number | null {
   const normalized = code.replace(/\s+/g, '');
-  if (!/^\d{6}$/.test(normalized)) return false;
-  const step = Math.floor(now / 1000 / STEP_SECONDS);
+  if (!/^\d{6}$/.test(normalized)) return null;
+  const current = Math.floor(now / 1000 / STEP_SECONDS);
   for (const delta of [0, -1, 1]) {
-    const expected = hotp(secretBase32, step + delta);
-    if (timingSafeEqual(Buffer.from(expected), Buffer.from(normalized))) return true;
+    const step = current + delta;
+    const expected = hotp(secretBase32, step);
+    if (timingSafeEqual(Buffer.from(expected), Buffer.from(normalized))) return step;
   }
-  return false;
+  return null;
 }
 
 /** The otpauth:// URI that authenticator apps read from the QR code. */

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -7,6 +7,7 @@ import { env } from '../env.js';
 import {
   SESSION_COOKIE,
   clearSessionCookie,
+  consumeTotp,
   createSession,
   destroyAllSessions,
   destroyOtherSessions,
@@ -212,9 +213,10 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     const row = db
       .prepare('SELECT totp_secret FROM users WHERE id = ? AND disabled_at IS NULL')
       .get(pending.userId) as { totp_secret: string | null } | undefined;
-    const { verifyTotp } = await import('../lib/totp.js');
-    if (!row?.totp_secret || !verifyTotp(row.totp_secret, parsed.data.code)) {
-      log.warn(`mfa: wrong code for user ${pending.userId} from ${req.ip}`);
+    // consumeTotp burns the step, so a code that already opened a session
+    // cannot open a second one while its window is still running
+    if (!row?.totp_secret || !consumeTotp(pending.userId, row.totp_secret, parsed.data.code)) {
+      log.warn(`mfa: wrong or reused code for user ${pending.userId} from ${req.ip}`);
       return reply.code(401).send({ error: 'Wrong code' });
     }
 
@@ -245,10 +247,10 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(409).send({ error: 'Two-factor authentication is already enabled' });
     }
     const secret = generateTotpSecret();
-    db.prepare('UPDATE users SET totp_secret = ?, totp_confirmed_at = NULL WHERE id = ?').run(
-      secret,
-      req.user!.id,
-    );
+    db.prepare(
+      `UPDATE users SET totp_secret = ?, totp_confirmed_at = NULL, totp_last_step = NULL
+        WHERE id = ?`,
+    ).run(secret, req.user!.id);
     return { secret, uri: otpauthUri(req.user!.email, secret) };
   });
 
@@ -262,8 +264,9 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     if (!row.totp_secret || row.totp_confirmed_at) {
       return reply.code(409).send({ error: 'Start the setup first' });
     }
-    const { verifyTotp } = await import('../lib/totp.js');
-    if (!verifyTotp(row.totp_secret, parsed.data.code)) {
+    // Spent here too: the code that proved the authenticator works must
+    // not still be good for the sign-in that follows
+    if (!consumeTotp(req.user!.id, row.totp_secret, parsed.data.code)) {
       return reply.code(401).send({ error: 'Wrong code' });
     }
     db.prepare('UPDATE users SET totp_confirmed_at = ? WHERE id = ?').run(now(), req.user!.id);
@@ -281,13 +284,15 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     if (!row.totp_secret || !row.totp_confirmed_at) {
       return reply.code(409).send({ error: 'Two-factor authentication is not enabled' });
     }
-    const { verifyTotp } = await import('../lib/totp.js');
-    if (!verifyTotp(row.totp_secret, parsed.data.code)) {
+    if (!consumeTotp(req.user!.id, row.totp_secret, parsed.data.code)) {
       return reply.code(401).send({ error: 'Wrong code' });
     }
-    db.prepare('UPDATE users SET totp_secret = NULL, totp_confirmed_at = NULL WHERE id = ?').run(
-      req.user!.id,
-    );
+    // The spent step goes with the secret: the next setup starts clean,
+    // and a stale step must never sit in the way of a fresh authenticator
+    db.prepare(
+      `UPDATE users SET totp_secret = NULL, totp_confirmed_at = NULL, totp_last_step = NULL
+        WHERE id = ?`,
+    ).run(req.user!.id);
     log.info(`mfa: disabled for ${req.user!.email}`);
     return { ok: true };
   });


### PR DESCRIPTION
Closes #55.

A one-time code was not one-time. It is a pure function of the secret and a 30-second step, so within that step — plus the one on either side accepted for clock drift — the answer to "do these six digits match" never changed, and nothing recorded that the code had already been used. The same six digits opened as many sessions as they were replayed into, for the ~90 seconds the window lasted.

RFC 6238 §5.2 puts the duty on the verifier: remember the last accepted step and refuse that one and everything below it. Migration 018 adds `users.totp_last_step` to remember it.

## The shape of the fix

**`verifyTotp` → `totpStep`, returning the matched step instead of a boolean.** A caller cannot burn what it cannot name. The rename is not cosmetic: `if (verifyTotp(...))` would still have compiled against a `number | null` and quietly misbehaved on step 0, so the compiler had to be made to point at every call site.

`lib/totp.ts` stays pure — it is checked against the RFC vectors and a database would only get in the way.

**`consumeTotp` in `lib/auth.ts` checks and burns in one move**, and the guard is the UPDATE rather than a read followed by a write:

```sql
UPDATE users SET totp_last_step = ?
 WHERE id = ? AND (totp_last_step IS NULL OR totp_last_step < ?)
```

Two requests carrying the same code both pass a read; only one can win a conditional write. That covers an honest double-submit as much as an attacker.

A wrong code and a spent one answer identically. Distinguishing them would confirm to whoever replayed it that the code was genuine.

**All three paths consume rather than merely verify.** Enabling counts too: the code that proves the authenticator works must not still be good for the sign-in that follows. The spent step is cleared alongside the secret on disable, on a fresh setup, and in `admin-reset`, so a new authenticator never meets a stale ceiling.

## What changes for a person using the hub

One thing, once: signing in on a second device inside the same half-minute now waits for the next code. That is what every correct implementation does, and it is the price of a code being worthless to anyone who reads it over your shoulder after you have used it. `docs/features.md` says so in the two-factor section.

## Verification

Four regression tests in `lib/auth.test.ts` against an in-memory database: a code is accepted once and refused on replay, the next code still works, an earlier step cannot be used once a later one is spent, and a wrong code changes nothing. Plus a `totpStep` case asserting it reports which step matched. Server suite 36 → 41.

And live, against a running hub, with the exact scenario from the issue:

```
fresh step 59563028, code 357408

browser A   → HTTP 200, session works
browser B   → HTTP 401 "Wrong code", no session      ← same code, same step
same step throughout: YES

B with the next code        → HTTP 200, session works
previous step's code        → HTTP 401
both sessions alive afterwards
totp_last_step = 59563029
```

The confirm-time code was separately checked to be dead for signing in.

`npm run typecheck`, `npm run lint` and `npm test` (75) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)