### PR TITLE
fix: repair the Devices list ordering and the missing address

### DIFF
--- a/server/src/lib/auth.test.ts
+++ b/server/src/lib/auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { id, now, openDatabase, runWithDb } from '../db/index.js';
 import { migrate } from '../db/migrate.js';
-import { consumeTotp, createSession, destroyOtherSessions, hashToken } from './auth.js';
+import { consumeTotp, createSession, destroyOtherSessions, hashToken, listSessions } from './auth.js';
 import { base32Encode, hotp } from './totp.js';
 
 describe('destroyOtherSessions', () => {
@@ -103,6 +103,62 @@ describe('consumeTotp', () => {
       expect(consumeTotp(userId, SECRET, '000000', NOW)).toBe(false);
       // The valid code is untouched by the failed attempt
       expect(consumeTotp(userId, SECRET, hotp(SECRET, STEP), NOW)).toBe(true);
+    });
+  });
+});
+
+describe('listSessions', () => {
+  it('puts the most recently active first, orphans last', () => {
+    const db = openDatabase(':memory:');
+    runWithDb(db, () => {
+      migrate();
+      const userId = id();
+      db.prepare(
+        `INSERT INTO users (id, email, name, role, password_hash, created_at)
+         VALUES (?, 'a@hub.local', 'A', 'member', 'x', ?)`,
+      ).run(userId, now());
+
+      const current = createSession(userId, 'laptop');
+      createSession(userId, 'phone');
+      createSession(userId, 'tablet');
+
+      // An orphan created early and never seen since, against a device
+      // active late the same day. Both stamps share one format, so the
+      // comparison must be plain — reformatting either side floated the
+      // orphan to the top, which is the opposite of what the list is for.
+      const byAgent = (agent: string) =>
+        db.prepare('SELECT id FROM sessions WHERE user_agent = ?').get(agent) as { id: string };
+      db.prepare('UPDATE sessions SET created_at = ?, last_seen_at = NULL WHERE id = ?').run(
+        '2026-08-15 09:00:00',
+        byAgent('phone').id,
+      );
+      db.prepare('UPDATE sessions SET created_at = ?, last_seen_at = ? WHERE id = ?').run(
+        '2026-08-15 08:00:00',
+        '2026-08-15 23:59:59',
+        byAgent('tablet').id,
+      );
+
+      const order = listSessions(userId, current).map((s) => s.user_agent);
+      expect(order.indexOf('tablet')).toBeLessThan(order.indexOf('phone'));
+    });
+  });
+
+  it('marks the requesting session and hides the token hash', () => {
+    const db = openDatabase(':memory:');
+    runWithDb(db, () => {
+      migrate();
+      const userId = id();
+      db.prepare(
+        `INSERT INTO users (id, email, name, role, password_hash, created_at)
+         VALUES (?, 'a@hub.local', 'A', 'member', 'x', ?)`,
+      ).run(userId, now());
+
+      createSession(userId, 'phone');
+      const current = createSession(userId, 'laptop');
+
+      const sessions = listSessions(userId, current);
+      expect(sessions.filter((s) => s.current).map((s) => s.user_agent)).toEqual(['laptop']);
+      expect(Object.keys(sessions[0]!)).not.toContain('token_hash');
     });
   });
 });

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -196,6 +196,40 @@ export function pruneSessions(): void {
   ).run(idleCutoff);
 }
 
+export interface SessionInfo {
+  id: string;
+  created_at: string;
+  last_seen_at: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  /** The session making the request — the row the UI must not offer to revoke. */
+  current: boolean;
+}
+
+/**
+ * Live sessions of one user, most recently active first.
+ *
+ * Both stamps are the same 'YYYY-MM-DD HH:MM:SS' UTC shape, so plain
+ * string ordering holds — but only as long as both sides stay in that
+ * shape. Reformatting one of them inside the ORDER BY is what previously
+ * floated orphaned rows to the top: ' ' sorts below 'T', so anything
+ * falling back to created_at outranked every row with a real
+ * last_seen_at. pruneSessions compares the same pair and is the model.
+ */
+export function listSessions(userId: string, currentToken: string): SessionInfo[] {
+  const currentHash = hashToken(currentToken);
+  const rows = db
+    .prepare(
+      `SELECT id, token_hash, created_at, last_seen_at, ip, user_agent
+         FROM sessions WHERE user_id = ? AND expires_at > ?
+        ORDER BY coalesce(last_seen_at, created_at) DESC`,
+    )
+    .all(userId, new Date().toISOString()) as (Omit<SessionInfo, 'current'> & {
+    token_hash: string;
+  })[];
+  return rows.map(({ token_hash, ...s }) => ({ ...s, current: token_hash === currentHash }));
+}
+
 /**
  * Check a TOTP code and spend it in one move: true only when the code is
  * valid *and* its step has not been used before.

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -13,6 +13,7 @@ import {
   destroyOtherSessions,
   destroySession,
   hashToken,
+  listSessions,
   setSessionCookie,
 } from '../lib/auth.js';
 
@@ -223,7 +224,10 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     pendingMfa.delete(parsed.data.mfa_token);
     log.info(`mfa: completed sign-in for user ${pending.userId} from ${req.ip}`);
     db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?').run(now(), pending.userId);
-    setSessionCookie(reply, createSession(pending.userId, req.headers['user-agent']));
+    // The address goes in here as it does on the password path: without
+    // it the Devices list has no address for exactly the accounts that
+    // bothered to enable a second factor
+    setSessionCookie(reply, createSession(pending.userId, req.headers['user-agent'], req.ip));
 
     return db
       .prepare(
@@ -376,23 +380,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
    * individually revocable instead of silently inflating the count.
    */
   app.get('/api/auth/sessions', (req) => {
-    const currentHash = hashToken(req.cookies[SESSION_COOKIE]!);
-    const sessions = (
-      db
-        .prepare(
-          `SELECT id, token_hash, created_at, last_seen_at, ip, user_agent
-             FROM sessions WHERE user_id = ? AND expires_at > ?
-            ORDER BY coalesce(last_seen_at, replace(created_at, ' ', 'T')) DESC`,
-        )
-        .all(req.user!.id, new Date().toISOString()) as {
-        id: string;
-        token_hash: string;
-        created_at: string;
-        last_seen_at: string | null;
-        ip: string | null;
-        user_agent: string | null;
-      }[]
-    ).map(({ token_hash, ...s }) => ({ ...s, current: token_hash === currentHash }));
+    const sessions = listSessions(req.user!.id, req.cookies[SESSION_COOKIE]!);
     return { count: sessions.length, sessions };
   });
 


### PR DESCRIPTION
Closes #56 and #57 — two defects in the same feature, both making the Devices list say less than it knows.

## The ordering compared two stamp formats

Both columns hold `'YYYY-MM-DD HH:MM:SS'`, but the `ORDER BY` reformatted one of them:

```sql
ORDER BY coalesce(last_seen_at, replace(created_at, ' ', 'T')) DESC
```

`' '` is 0x20 and `'T'` is 0x54, so every row falling back to `created_at` outranked every row with a real `last_seen_at` on the same date.

The rows that fall back are exactly the orphans — a re-login replaces the cookie and leaves the old row idling until the pruner retires it. So the list reliably opened with the dead sessions and buried the device in the reader's hands, which is the opposite of what it is for.

`pruneSessions` compares the same pair without reformatting and was the model to copy.

## The MFA path never recorded the address

`createSession(userId, userAgent, ip?)` takes the address optionally, and the second-factor branch omitted it while the password branch passed it. `sessions.ip` therefore stayed null for anyone using a second factor — no address shown for exactly the accounts that took the trouble to enable one.

## Why the query moved

`lib/auth.ts` gains `listSessions`, beside the other session helpers, and the route keeps only the response shape. That is what makes the ordering testable: the regression test builds an orphan created at 09:00 and never seen against a device last active at 23:59, and asserts the active one comes first.

It genuinely catches this bug — putting the old `ORDER BY` back fails it:

```
❯ src/lib/auth.test.ts (8 tests | 1 failed)
 FAIL  listSessions > puts the most recently active first, orphans last
```

A second test covers what the route used to do inline: the requesting session is marked `current`, and `token_hash` never leaves the helper.

## Checks

`npm run typecheck`, `npm run lint`, `npm test` — server 41 → 43, 77 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)