### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something behaves differently from what it promises
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The fields below are the shape the issues in this repository already
+        take — they are what makes a report actionable without a round trip
+        of questions. Prose is welcome in any of them; none of this has to
+        be terse.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What you did
+      description: Numbered steps, starting from a hub with nothing special about it. Anything you had to set up first counts as a step.
+      placeholder: |
+        1. Money → Transaction
+        2. Type an amount
+        3. Click a category
+        4. Press Enter
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and why
+      description: The "why" matters more than it looks — if the behaviour contradicts something the docs promise, say which; if it is your own expectation, say that instead. Both are useful, and they lead to different fixes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead
+      description: The actual result — an error message, a number, a screenshot. A paraphrase loses the detail that usually turns out to matter.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: A release tag, or the commit you are running. `docker image inspect` or `git rev-parse --short HEAD`.
+      placeholder: v1.0.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: how
+    attributes:
+      label: How you run it
+      options:
+        - Docker at home
+        - Docker on a VPS
+        - npm run dev
+        - The public demo
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: cause
+    attributes:
+      label: Cause, if you found it
+      description: Entirely optional, and enormously helpful — a `file.ts:line` and the reasoning. If you got as far as knowing why, that is most of the fix.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# The blank issue stays available on purpose. The forms cover the two
+# common shapes; anything that is neither — a question, a design
+# argument, a security report — is better as prose than squeezed into
+# fields that do not fit it.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Before you start contributing code
+    url: https://github.com/burtsdenis/family-hub/blob/master/CONTRIBUTING.md
+    about: Running it locally, the house conventions, and the invariants worth knowing before touching the money or privacy code.
+
+  - name: Security issues
+    url: https://github.com/burtsdenis/family-hub/blob/master/CONTRIBUTING.md#reporting-a-bug
+    about: File them as ordinary public issues — deliberately. This is self-hosted software and people are running the current release; they deserve to know what it does and does not guarantee.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature or improvement
+description: Something the hub should do, or should do differently
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is a deliberately finished product rather than a platform, so
+        the useful question is usually not "can it do X" but "what is the
+        household actually trying to get done". Describing the situation
+        gets you a better answer than describing the feature — sometimes a
+        different one than you had in mind, and occasionally a "no" with a
+        reason, which is also a real outcome here.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The situation, before any solution. Who in the family, how often, and what happens today instead.
+      placeholder: |
+        Every week one of us buys something the other already bought.
+        We keep a list in a chat and nobody reads it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What do you do about it now?
+      description: Whether you work around it with a note, a spreadsheet, another app — or simply live with it. The workaround usually reveals what the real requirement is.
+    validations:
+      required: false
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you have in mind, if anything
+      description: A sketch is fine. It will be argued with, and that is the point rather than a rejection.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: What would make it done?
+      description: The smallest version that would genuinely help. Features here tend to ship small and grow, and knowing the floor is more useful than knowing the ceiling.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+  The diff already says what changed. What a reviewer cannot reconstruct
+  is why — so that is what this asks for. Delete any heading that does
+  not apply; an honest three-line description beats a filled-in form.
+-->
+
+## Why
+
+<!-- The problem, and why this is the right shape of fix. If it closes an
+     issue, "Closes #123" and the part the issue does not already cover. -->
+
+## What you considered and rejected
+
+<!-- Optional, and often the most useful section. The approach you did not
+     take is the question a reviewer will otherwise ask. -->
+
+## How you know it works
+
+<!-- What you ran, clicked or measured, and what you saw. If it is covered
+     by a test, say which. If you verified it by hand, say what you did —
+     that is not a lesser answer, it is just a different one. -->
+
+## Anything you are unsure about
+
+<!-- Naming, a decision that could go either way, a case you could not
+     test. Saying so gets it looked at rather than merged past. -->
+
+---
+
+- [ ] `npm run typecheck`, `npm run lint` and `npm test` pass locally
+- [ ] Branched from `master`
+- [ ] Docs updated, if behaviour changed ([docs/](../docs))


### PR DESCRIPTION
Follows the open question in #80: templates that put the shape the guide describes in front of the person writing a report, in the web UI, at the moment it matters.

## Two forms, for the two common shapes

**Bug report** asks the four things that otherwise cost a round trip of questions — steps from a clean hub, what was expected *and on what grounds*, what actually happened, and the version and how it is run. "Cause, if you found it" is a field but deliberately **not required**: when someone has got that far it is most of the fix, and demanding it would turn a good report into no report at all.

**Feature or improvement** asks about the situation before the solution — who in the family, how often, and what happens today instead. This is a finished product rather than a platform, so "what are you trying to get done" gets a better answer than a feature name: sometimes a different feature, occasionally a reasoned no. The idea itself is an optional field, with a note that it will be argued with and that this is the point rather than a rejection.

## Blank issues stay enabled

On purpose. The forms cover two shapes; a question, a design argument or a security report is better as prose than squeezed into fields that do not fit — and the issues in this repository are mostly prose. Contact links point at `CONTRIBUTING.md` and at its note that **security issues here are public deliberately**, since people are running the current release and deserve to know what it guarantees.

Worth knowing: `gh issue create` bypasses templates entirely, so nothing here adds friction to filing issues from the terminal.

## Pull request template

Asks for **why**, not what — the diff covers what. Plus the approach that was considered and rejected, which is otherwise the first question a reviewer asks, and a place to say what you are unsure about, so it gets looked at rather than merged past. Everything is an HTML comment, so an author who deletes the lot and writes three honest lines produces a clean description rather than a form with empty headings.

Three checkboxes at the end: the three commands, branched from `master`, docs updated if behaviour changed.

## Verified

All three YAML files parse (js-yaml), every non-markdown field carries an `id`, the dropdown has options, no tabs, and both referenced labels (`bug`, `enhancement`) exist in the repository.

One ordering note: the contact links point at `CONTRIBUTING.md` on `master`, so they resolve once #80 lands. Branching from `master` rather than stacking on it, per the project's own rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)