### PR TITLE
test: build the app without starting it, and sweep the privacy guards

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,262 @@
+import Fastify, { type FastifyError, type FastifyInstance } from 'fastify';
+import { ZodError } from 'zod';
+import fastifyStatic from '@fastify/static';
+import fastifyCookie from '@fastify/cookie';
+import fastifyHelmet from '@fastify/helmet';
+import fastifyMultipart from '@fastify/multipart';
+import fastifyRateLimit from '@fastify/rate-limit';
+import { existsSync } from 'node:fs';
+import { env } from './env.js';
+import { registerRoutes } from './routes/index.js';
+import { registerAuthRoutes } from './routes/auth.js';
+import { registerGoogleRoutes } from './routes/google.js';
+import { registerSetupRoutes } from './routes/setup.js';
+import { registerUserRoutes } from './routes/users.js';
+import { registerProjectRoutes } from './routes/projects.js';
+import { registerTaskRoutes } from './routes/tasks.js';
+import { registerNoteRoutes } from './routes/notes.js';
+import { MAX_FILE_BYTES, registerAttachmentRoutes } from './routes/attachments.js';
+import { registerCalendarRoutes } from './routes/calendar.js';
+import { registerMailRoutes } from './routes/mail.js';
+import { registerMoneyRoutes } from './routes/money.js';
+import { registerBudgetRoutes } from './routes/budgets.js';
+import { authenticate } from './lib/auth.js';
+import { log } from './lib/log.js';
+
+/*
+  Everything that shapes the HTTP surface — hooks, plugins, routes — and
+  nothing that touches the world. No migrations, no listening port, no
+  background pollers, no process handlers: those belong to starting the
+  server, which is index.ts.
+
+  Split out so the routes can be exercised through app.inject() without a
+  socket. Before this, importing the app started it, and the guards that
+  carry this project's privacy promise had no way to be tested at all.
+*/
+/*
+  Query parameter values never reach the log: that is where secrets live —
+  the invite token (?token=), the OAuth callback code and state.
+  A failed invite check is a 404 at warn level, and without masking
+  the secret ended up in the log by default. Parameter names are kept:
+  for diagnostics "which parameter came in" matters, not "with which value".
+*/
+export function redactUrl(url: string): string {
+  const q = url.indexOf('?');
+  if (q === -1) return url;
+  const params = new URLSearchParams(url.slice(q + 1));
+  const names = [...new Set([...params.keys()])];
+  return names.length ? `${url.slice(0, q)}?${names.map((n) => `${n}=…`).join('&')}` : url.slice(0, q);
+}
+
+export async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({
+    // The built-in logger is off entirely: it writes a JSON line per request,
+    // and on a home server that is noise drowning out real errors.
+    // With logger: false there is no need to disable request logging separately.
+    logger: false,
+    trustProxy: env.trustProxy,
+  });
+
+  /*
+    We log ourselves and only what deserves attention:
+    server errors at error level, client rejections at warn,
+    everything else at debug, hidden by default.
+  */
+  app.addHook('onResponse', (req, reply, done) => {
+    // The error handler already wrote a detailed line — don't repeat it
+    if (req.errorLogged) return done();
+
+    const status = reply.statusCode;
+    const line = `${status} ${req.method} ${redactUrl(req.url)}`;
+    if (status >= 500) log.error(line);
+    else if (status >= 400) log.warn(line);
+    else log.debug(line, `${Math.round(reply.elapsedTime)}ms`);
+    done();
+  });
+
+  app.setErrorHandler((err: FastifyError, req, reply) => {
+    req.errorLogged = true;
+
+    // Bad parameters in the path or query string are a client error.
+    // This used to blow up as a 500 and land in the log as a server error.
+    if (err instanceof ZodError) {
+      log.warn(`400 ${req.method} ${redactUrl(req.url)}`, err.issues[0]?.message ?? '');
+      return reply.code(400).send({ error: 'Invalid request parameters' });
+    }
+
+    const status = err.statusCode ?? 500;
+    if (status >= 500) log.error(`${req.method} ${redactUrl(req.url)}`, err);
+    else log.warn(`${status} ${req.method} ${redactUrl(req.url)}`, err.message);
+
+    return reply.code(status).send({
+      error: status < 500 ? err.message : 'Internal server error',
+    });
+  });
+
+  await app.register(fastifyCookie);
+
+  /*
+    Demo: route the request into the visitor's sandbox. The hook sits right
+    after cookie parsing and wraps the rest of the handling in that sandbox's
+    database context (AsyncLocalStorage, see db/index.ts) — from there all
+    code, session check included, transparently works with that sandbox's
+    database. A cookie without a live sandbox (expired, evicted, restart) —
+    no context is set, the session won't be found in the main database,
+    the client gets an honest 401 and returns to the login screen
+    for a fresh sandbox.
+  */
+  if (env.demoMode) {
+    const { SANDBOX_COOKIE, getSandbox, trackRequest } = await import('./lib/sandbox.js');
+    const { runWithDb } = await import('./db/index.js');
+    app.addHook('onRequest', (req, _reply, done) => {
+      const sandboxId = req.cookies[SANDBOX_COOKIE];
+      const sandbox = sandboxId ? getSandbox(sandboxId) : null;
+      if (sandbox) {
+        trackRequest(sandbox, req.method, req.url);
+        return runWithDb(sandbox.db, done);
+      }
+      done();
+    });
+  }
+  await app.register(fastifyMultipart, {
+    limits: { fileSize: MAX_FILE_BYTES, files: 10 },
+  });
+
+  /*
+    Security headers. CSP is strict because we can afford it:
+    the frontend is built by Vite into its own files, no external fonts
+    or scripts. 'unsafe-inline' only for styles — React sets inline style
+    attributes (project colors, avatars), without it they stop applying.
+    HSTS is not set here: the proxy that terminates TLS owns it.
+  */
+  await app.register(fastifyHelmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'blob:'],
+        fontSrc: ["'self'", 'data:'],
+        connectSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        baseUri: ["'self'"],
+        formAction: ["'self'"],
+      },
+    },
+    hsts: false,
+  });
+
+  /*
+    A general rate-limit fuse — API only. The threshold is generous:
+    a family of a few people will never hit it, but it cuts the tempo
+    of a scanner or a script hammering the API. Key — client IP
+    (with trustProxy that is the real address, not Caddy's). Login has
+    its own, much stricter limit — set on the route itself in auth.ts.
+
+    Exempt from the limit:
+    — static files and app pages: an interface of dozens of files must not
+      compete with the API for budget, and a rate-limit error on the page
+      itself looks like the whole hub is broken;
+    — attachment reads: note images go through /api/attachments,
+      a note with fifty receipt photos is fifty requests at once,
+      and honest browsing of the family archive would eat the budget
+      instantly. Attachments sit behind auth and are cached by the
+      browser forever.
+  */
+  await app.register(fastifyRateLimit, {
+    max: 300,
+    timeWindow: '1 minute',
+    allowList: (req) =>
+      !req.url.startsWith('/api') ||
+      (req.method === 'GET' && req.url.startsWith('/api/attachments/')),
+    errorResponseBuilder: (_req, context) => ({
+      statusCode: 429,
+      error: 'Too Many Requests',
+      message: `Too many requests. Wait ${Math.ceil(context.ttl / 1000)} s.`,
+    }),
+  });
+
+  // Logout and similar methods are called without a body. Fastify answers
+  // that with a 400 by default — allow an empty body explicitly.
+  app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
+    const raw = (body as string).trim();
+    if (raw === '') return done(null, {});
+    try {
+      done(null, JSON.parse(raw));
+    } catch {
+      done(Object.assign(new Error('The request body is not valid JSON'), { statusCode: 400 }), undefined);
+    }
+  });
+
+  /*
+    A CSRF barrier on top of SameSite=Lax: on a cross-site request the
+    browser must send Origin, and it won't match our Host. A request
+    without the header (curl, apps, same-origin GET) passes — that is not
+    the cross-site browser scenario we defend against. Only hosts are
+    compared: behind the proxy only Caddy knows the scheme.
+
+    Production only: the Vite dev proxy rewrites Host to the API address
+    (localhost:8787) while Origin stays the frontend's (localhost:5173) —
+    the check would cut every legitimate dev request. In production Host
+    arrives untouched both on direct access and via Caddy.
+  */
+  if (env.isProd) {
+    app.addHook('onRequest', (req, reply, done) => {
+      if (req.method === 'GET' || req.method === 'HEAD') return done();
+      if (!req.url.startsWith('/api')) return done();
+      const origin = req.headers.origin;
+      if (!origin || origin === 'null') return done();
+      let originHost: string;
+      try {
+        originHost = new URL(origin).host;
+      } catch {
+        return reply.code(403).send({ error: 'Cross-site request rejected' });
+      }
+      if (originHost !== req.headers.host) {
+        return reply.code(403).send({ error: 'Cross-site request rejected' });
+      }
+      done();
+    });
+  }
+
+  app.addHook('preHandler', authenticate);
+
+  await registerAuthRoutes(app);
+  await registerGoogleRoutes(app);
+  await registerSetupRoutes(app);
+  await registerUserRoutes(app);
+  await registerProjectRoutes(app);
+  await registerTaskRoutes(app);
+  await registerNoteRoutes(app);
+  await registerAttachmentRoutes(app);
+  await registerCalendarRoutes(app);
+  await registerMailRoutes(app);
+  await registerMoneyRoutes(app);
+  await registerBudgetRoutes(app);
+
+  await registerRoutes(app);
+
+  // In dev the frontend lives on Vite. So hitting the API port doesn't look broken:
+  if (!env.isProd) {
+    app.get('/', (_req, reply) =>
+      reply
+        .type('text/plain; charset=utf-8')
+        .send('The API is up. The UI runs in dev mode at http://localhost:5173'),
+    );
+  }
+
+  // In production the same process serves the built frontend.
+  // In dev the frontend lives on Vite and proxies /api here.
+  if (env.isProd && existsSync(env.webDist)) {
+    await app.register(fastifyStatic, { root: env.webDist });
+    app.setNotFoundHandler((req, reply) => {
+      if (req.url.startsWith('/api')) {
+        return reply.code(404).send({ error: 'No such endpoint' });
+      }
+      return reply.sendFile('index.html');
+    });
+  }
+
+  return app;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,87 +1,16 @@
-import Fastify, { type FastifyError } from 'fastify';
-import { ZodError } from 'zod';
-import fastifyStatic from '@fastify/static';
-import fastifyCookie from '@fastify/cookie';
-import fastifyHelmet from '@fastify/helmet';
-import fastifyMultipart from '@fastify/multipart';
-import fastifyRateLimit from '@fastify/rate-limit';
-import { existsSync } from 'node:fs';
 import { env } from './env.js';
+import { buildApp } from './app.js';
 import { migrate } from './db/migrate.js';
-import { registerRoutes } from './routes/index.js';
-import { registerAuthRoutes } from './routes/auth.js';
-import { registerGoogleRoutes } from './routes/google.js';
-import { registerSetupRoutes } from './routes/setup.js';
-import { registerUserRoutes } from './routes/users.js';
-import { registerProjectRoutes } from './routes/projects.js';
-import { registerTaskRoutes } from './routes/tasks.js';
-import { registerNoteRoutes } from './routes/notes.js';
-import { MAX_FILE_BYTES, registerAttachmentRoutes } from './routes/attachments.js';
-import { registerCalendarRoutes } from './routes/calendar.js';
-import { registerMailRoutes } from './routes/mail.js';
-import { registerMoneyRoutes } from './routes/money.js';
-import { registerBudgetRoutes, runAutoCreate } from './routes/budgets.js';
-import { authenticate, announceSetupIfEmpty, pruneSessions } from './lib/auth.js';
+import { runAutoCreate } from './routes/budgets.js';
+import { announceSetupIfEmpty, pruneSessions } from './lib/auth.js';
 import { log, logLevel } from './lib/log.js';
 
-const app = Fastify({
-  // The built-in logger is off entirely: it writes a JSON line per request,
-  // and on a home server that is noise drowning out real errors.
-  // With logger: false there is no need to disable request logging separately.
-  logger: false,
-  trustProxy: env.trustProxy,
-});
-
 /*
-  Query parameter values never reach the log: that is where secrets live —
-  the invite token (?token=), the OAuth callback code and state.
-  A failed invite check is a 404 at warn level, and without masking
-  the secret ended up in the log by default. Parameter names are kept:
-  for diagnostics "which parameter came in" matters, not "with which value".
+  Starting the server: everything that touches the world once, in order.
+  The HTTP surface itself — hooks, plugins, routes — is built by buildApp
+  in app.ts, which knows nothing about ports, migrations or signals so
+  that tests can build the same app and drive it through inject().
 */
-export function redactUrl(url: string): string {
-  const q = url.indexOf('?');
-  if (q === -1) return url;
-  const params = new URLSearchParams(url.slice(q + 1));
-  const names = [...new Set([...params.keys()])];
-  return names.length ? `${url.slice(0, q)}?${names.map((n) => `${n}=…`).join('&')}` : url.slice(0, q);
-}
-
-/*
-  We log ourselves and only what deserves attention:
-  server errors at error level, client rejections at warn,
-  everything else at debug, hidden by default.
-*/
-app.addHook('onResponse', (req, reply, done) => {
-  // The error handler already wrote a detailed line — don't repeat it
-  if (req.errorLogged) return done();
-
-  const status = reply.statusCode;
-  const line = `${status} ${req.method} ${redactUrl(req.url)}`;
-  if (status >= 500) log.error(line);
-  else if (status >= 400) log.warn(line);
-  else log.debug(line, `${Math.round(reply.elapsedTime)}ms`);
-  done();
-});
-
-app.setErrorHandler((err: FastifyError, req, reply) => {
-  req.errorLogged = true;
-
-  // Bad parameters in the path or query string are a client error.
-  // This used to blow up as a 500 and land in the log as a server error.
-  if (err instanceof ZodError) {
-    log.warn(`400 ${req.method} ${redactUrl(req.url)}`, err.issues[0]?.message ?? '');
-    return reply.code(400).send({ error: 'Invalid request parameters' });
-  }
-
-  const status = err.statusCode ?? 500;
-  if (status >= 500) log.error(`${req.method} ${redactUrl(req.url)}`, err);
-  else log.warn(`${status} ${req.method} ${redactUrl(req.url)}`, err.message);
-
-  return reply.code(status).send({
-    error: status < 500 ? err.message : 'Internal server error',
-  });
-});
 
 migrate();
 pruneSessions();
@@ -98,174 +27,12 @@ if (env.demoMode) {
   announceSetupIfEmpty();
 }
 
-await app.register(fastifyCookie);
-
-/*
-  Demo: route the request into the visitor's sandbox. The hook sits right
-  after cookie parsing and wraps the rest of the handling in that sandbox's
-  database context (AsyncLocalStorage, see db/index.ts) — from there all
-  code, session check included, transparently works with that sandbox's
-  database. A cookie without a live sandbox (expired, evicted, restart) —
-  no context is set, the session won't be found in the main database,
-  the client gets an honest 401 and returns to the login screen
-  for a fresh sandbox.
-*/
-if (env.demoMode) {
-  const { SANDBOX_COOKIE, getSandbox, trackRequest } = await import('./lib/sandbox.js');
-  const { runWithDb } = await import('./db/index.js');
-  app.addHook('onRequest', (req, _reply, done) => {
-    const sandboxId = req.cookies[SANDBOX_COOKIE];
-    const sandbox = sandboxId ? getSandbox(sandboxId) : null;
-    if (sandbox) {
-      trackRequest(sandbox, req.method, req.url);
-      return runWithDb(sandbox.db, done);
-    }
-    done();
-  });
-}
-await app.register(fastifyMultipart, {
-  limits: { fileSize: MAX_FILE_BYTES, files: 10 },
-});
-
-/*
-  Security headers. CSP is strict because we can afford it:
-  the frontend is built by Vite into its own files, no external fonts
-  or scripts. 'unsafe-inline' only for styles — React sets inline style
-  attributes (project colors, avatars), without it they stop applying.
-  HSTS is not set here: the proxy that terminates TLS owns it.
-*/
-await app.register(fastifyHelmet, {
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'"],
-      imgSrc: ["'self'", 'data:', 'blob:'],
-      fontSrc: ["'self'", 'data:'],
-      connectSrc: ["'self'"],
-      objectSrc: ["'none'"],
-      frameAncestors: ["'none'"],
-      baseUri: ["'self'"],
-      formAction: ["'self'"],
-    },
-  },
-  hsts: false,
-});
-
-/*
-  A general rate-limit fuse — API only. The threshold is generous:
-  a family of a few people will never hit it, but it cuts the tempo
-  of a scanner or a script hammering the API. Key — client IP
-  (with trustProxy that is the real address, not Caddy's). Login has
-  its own, much stricter limit — set on the route itself in auth.ts.
-
-  Exempt from the limit:
-  — static files and app pages: an interface of dozens of files must not
-    compete with the API for budget, and a rate-limit error on the page
-    itself looks like the whole hub is broken;
-  — attachment reads: note images go through /api/attachments,
-    a note with fifty receipt photos is fifty requests at once,
-    and honest browsing of the family archive would eat the budget
-    instantly. Attachments sit behind auth and are cached by the
-    browser forever.
-*/
-await app.register(fastifyRateLimit, {
-  max: 300,
-  timeWindow: '1 minute',
-  allowList: (req) =>
-    !req.url.startsWith('/api') ||
-    (req.method === 'GET' && req.url.startsWith('/api/attachments/')),
-  errorResponseBuilder: (_req, context) => ({
-    statusCode: 429,
-    error: 'Too Many Requests',
-    message: `Too many requests. Wait ${Math.ceil(context.ttl / 1000)} s.`,
-  }),
-});
-
-// Logout and similar methods are called without a body. Fastify answers
-// that with a 400 by default — allow an empty body explicitly.
-app.addContentTypeParser('application/json', { parseAs: 'string' }, (_req, body, done) => {
-  const raw = (body as string).trim();
-  if (raw === '') return done(null, {});
-  try {
-    done(null, JSON.parse(raw));
-  } catch {
-    done(Object.assign(new Error('The request body is not valid JSON'), { statusCode: 400 }), undefined);
-  }
-});
-
-/*
-  A CSRF barrier on top of SameSite=Lax: on a cross-site request the
-  browser must send Origin, and it won't match our Host. A request
-  without the header (curl, apps, same-origin GET) passes — that is not
-  the cross-site browser scenario we defend against. Only hosts are
-  compared: behind the proxy only Caddy knows the scheme.
-
-  Production only: the Vite dev proxy rewrites Host to the API address
-  (localhost:8787) while Origin stays the frontend's (localhost:5173) —
-  the check would cut every legitimate dev request. In production Host
-  arrives untouched both on direct access and via Caddy.
-*/
-if (env.isProd) {
-  app.addHook('onRequest', (req, reply, done) => {
-    if (req.method === 'GET' || req.method === 'HEAD') return done();
-    if (!req.url.startsWith('/api')) return done();
-    const origin = req.headers.origin;
-    if (!origin || origin === 'null') return done();
-    let originHost: string;
-    try {
-      originHost = new URL(origin).host;
-    } catch {
-      return reply.code(403).send({ error: 'Cross-site request rejected' });
-    }
-    if (originHost !== req.headers.host) {
-      return reply.code(403).send({ error: 'Cross-site request rejected' });
-    }
-    done();
-  });
-}
-
-app.addHook('preHandler', authenticate);
-
-await registerAuthRoutes(app);
-await registerGoogleRoutes(app);
-await registerSetupRoutes(app);
-await registerUserRoutes(app);
-await registerProjectRoutes(app);
-await registerTaskRoutes(app);
-await registerNoteRoutes(app);
-await registerAttachmentRoutes(app);
-await registerCalendarRoutes(app);
-await registerMailRoutes(app);
-await registerMoneyRoutes(app);
-await registerBudgetRoutes(app);
+const app = await buildApp();
 
 // Recurring payments marked "create automatically" catch up at startup:
 // the Mac may have been asleep, and a couple of dates may have passed us by
 const createdOnBoot = runAutoCreate();
 if (createdOnBoot > 0) log.info(`recurring transactions: created ${createdOnBoot}`);
-await registerRoutes(app);
-
-// In dev the frontend lives on Vite. So hitting the API port doesn't look broken:
-if (!env.isProd) {
-  app.get('/', (_req, reply) =>
-    reply
-      .type('text/plain; charset=utf-8')
-      .send('The API is up. The UI runs in dev mode at http://localhost:5173'),
-  );
-}
-
-// In production the same process serves the built frontend.
-// In dev the frontend lives on Vite and proxies /api here.
-if (env.isProd && existsSync(env.webDist)) {
-  await app.register(fastifyStatic, { root: env.webDist });
-  app.setNotFoundHandler((req, reply) => {
-    if (req.url.startsWith('/api')) {
-      return reply.code(404).send({ error: 'No such endpoint' });
-    }
-    return reply.sendFile('index.html');
-  });
-}
 
 try {
   await app.listen({ port: env.port, host: env.host });

--- a/server/src/routes/calendar.ts
+++ b/server/src/routes/calendar.ts
@@ -266,6 +266,12 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
 
   app.delete('/api/calendars/:id', (req, reply) => {
     const { id: calendarId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    // Same lookup as the patch above: a personal calendar belongs to its
+    // owner for deleting too, not only for reading.
+    const visible = db
+      .prepare(`SELECT c.id FROM calendars c WHERE c.id = ? AND ${CALENDAR_VISIBLE}`)
+      .get(calendarId, req.user?.id ?? '');
+    if (!visible) return reply.code(404).send({ error: 'Calendar not found' });
 
     const count = (
       db.prepare('SELECT count(*) AS n FROM events WHERE calendar_id = ?').get(calendarId) as {

--- a/server/src/routes/guards.test.ts
+++ b/server/src/routes/guards.test.ts
@@ -1,0 +1,181 @@
+import type { FastifyInstance, InjectOptions } from 'fastify';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../app.js';
+import { openDatabase, runWithDb, id, now } from '../db/index.js';
+import { migrate } from '../db/migrate.js';
+import { SESSION_COOKIE, createSession } from '../lib/auth.js';
+
+/*
+  The privacy promise, as a test.
+
+  "Private" here is enforced by the server, per owner, with no exception
+  for the administrator — it is the thing the README tells strangers on
+  the internet, and the single most likely place to introduce a serious
+  bug: a new route that takes an :id and forgets its visibility guard
+  looks exactly like a correct one.
+
+  Until buildApp existed there was no way to check it. Now the app can be
+  built against an in-memory database and driven through inject(), with
+  no socket and no fixtures beyond two users.
+
+  The shape of every case is the same: Alice creates something private,
+  Bob asks for it by id, and the answer must be 404 — not 200, and not
+  403 either, which would confirm the thing exists.
+*/
+
+let app: FastifyInstance;
+const db = openDatabase(':memory:');
+let alice = '';
+let bob = '';
+let aliceCookie = '';
+let bobCookie = '';
+
+function member(name: string): string {
+  const userId = id();
+  db.prepare(
+    `INSERT INTO users (id, email, name, role, password_hash, created_at)
+     VALUES (?, ?, ?, 'admin', 'x', ?)`,
+  ).run(userId, `${name}@hub.local`, name, now());
+  return userId;
+}
+
+function as(cookie: string, method: InjectOptions['method'], url: string, payload?: unknown) {
+  const options: InjectOptions = {
+    method,
+    url,
+    headers: { cookie: `${SESSION_COOKIE}=${cookie}` },
+  };
+  if (payload !== undefined) options.payload = payload as InjectOptions['payload'];
+  return app.inject(options);
+}
+
+beforeAll(async () => {
+  app = await buildApp();
+
+  // Bind every request to this database, exactly the way demo mode binds
+  // one to a visitor's sandbox (see the onRequest hook in index.ts).
+  // Wrapping the inject() call itself does not work: the request is
+  // dispatched onto its own async chain, and the context does not follow.
+  app.addHook('onRequest', (_req, _reply, done) => runWithDb(db, done));
+
+  runWithDb(db, () => {
+    migrate();
+    alice = member('alice');
+    bob = member('bob');
+    // The administrator is deliberately included on both sides: the guard
+    // has no role exception, and a test that only checked member-to-member
+    // would miss exactly the backdoor the project promises not to have
+    aliceCookie = createSession(alice, 'alice-device');
+    bobCookie = createSession(bob, 'bob-device');
+  });
+});
+
+describe('a private note', () => {
+  let noteId = '';
+
+  beforeAll(async () => {
+    const created = await as(aliceCookie, 'POST', '/api/notes', {
+      title: 'Alice only',
+      body_md: 'surprise party budget',
+      visibility: 'private',
+    });
+    noteId = created.json<{ id: string }>().id;
+    expect(created.statusCode).toBe(201);
+  });
+
+  it('is hers to read', async () => {
+    expect((await as(aliceCookie, 'GET', `/api/notes/${noteId}`)).statusCode).toBe(200);
+  });
+
+  it('is not in his list', async () => {
+    const list = (await as(bobCookie, 'GET', '/api/notes')).json<{ title: string }[]>();
+    expect(list.map((n) => n.title)).not.toContain('Alice only');
+  });
+
+  it('is not his to read, edit or delete', async () => {
+    expect((await as(bobCookie, 'GET', `/api/notes/${noteId}`)).statusCode).toBe(404);
+    expect((await as(bobCookie, 'PATCH', `/api/notes/${noteId}`, { title: 'x' })).statusCode).toBe(404);
+    expect((await as(bobCookie, 'DELETE', `/api/notes/${noteId}`)).statusCode).toBe(404);
+  });
+
+  it('is not in his search results', async () => {
+    const found = (await as(bobCookie, 'GET', '/api/search?q=surprise')).json<{
+      results: unknown[];
+    }>();
+    expect(found.results).toEqual([]);
+  });
+
+  it('has no readable version history', async () => {
+    expect((await as(bobCookie, 'GET', `/api/notes/${noteId}/versions`)).statusCode).toBe(404);
+  });
+});
+
+describe('a personal money account', () => {
+  let accountId = '';
+
+  beforeAll(async () => {
+    const created = await as(aliceCookie, 'POST', '/api/accounts', {
+      name: 'Alice personal',
+      currency: 'EUR',
+      opening_balance: 42000,
+      shared: false,
+    });
+    accountId = created.json<{ id: string }>().id;
+    expect(created.statusCode).toBe(201);
+  });
+
+  it('is not in his list', async () => {
+    const list = (await as(bobCookie, 'GET', '/api/accounts')).json<{ name: string }[]>();
+    expect(list.map((a) => a.name)).not.toContain('Alice personal');
+  });
+
+  it('is not his to edit, reconcile or delete', async () => {
+    expect((await as(bobCookie, 'PATCH', `/api/accounts/${accountId}`, { name: 'x' })).statusCode).toBe(404);
+    expect(
+      (await as(bobCookie, 'POST', `/api/accounts/${accountId}/reconcile`, {
+        actual_balance: 1,
+        checked_on: '2026-08-19',
+      })).statusCode,
+    ).toBe(404);
+    // The one the sweep was written for: delete had no guard at all, so an
+    // empty account anyone knew the id of could be removed by anyone
+    expect((await as(bobCookie, 'DELETE', `/api/accounts/${accountId}`)).statusCode).toBe(404);
+  });
+
+  it('survives his attempt', async () => {
+    const list = (await as(aliceCookie, 'GET', '/api/accounts')).json<{ name: string }[]>();
+    expect(list.map((a) => a.name)).toContain('Alice personal');
+  });
+});
+
+describe('a personal calendar', () => {
+  let calendarId = '';
+
+  beforeAll(async () => {
+    const created = await as(aliceCookie, 'POST', '/api/calendars', {
+      name: 'Alice personal',
+      shared: false,
+    });
+    calendarId = created.json<{ id: string }>().id;
+    expect(created.statusCode).toBe(201);
+  });
+
+  it('is not in his list', async () => {
+    const list = (await as(bobCookie, 'GET', '/api/calendars')).json<{ name: string }[]>();
+    expect(list.map((c) => c.name)).not.toContain('Alice personal');
+  });
+
+  it('is not his to edit or delete', async () => {
+    expect((await as(bobCookie, 'PATCH', `/api/calendars/${calendarId}`, { name: 'x' })).statusCode).toBe(404);
+    expect((await as(bobCookie, 'DELETE', `/api/calendars/${calendarId}`)).statusCode).toBe(404);
+  });
+});
+
+describe('an unauthenticated caller', () => {
+  it('gets nowhere near any of it', async () => {
+    for (const url of ['/api/notes', '/api/accounts', '/api/calendars', '/api/tasks']) {
+      const res = await app.inject({ method: 'GET', url });
+      expect(res.statusCode).toBe(401);
+    }
+  });
+});

--- a/server/src/routes/money.ts
+++ b/server/src/routes/money.ts
@@ -292,6 +292,13 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
 
   app.delete('/api/accounts/:id', (req, reply) => {
     const { id: accountId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    // Same lookup as archive above. Without it this route deleted by id
+    // alone: anyone could remove an empty account they could not even see.
+    const visible = db
+      .prepare(`SELECT a.id FROM accounts a WHERE a.id = ? AND ${ACCOUNT_VISIBLE}`)
+      .get(accountId, req.user?.id ?? '');
+    if (!visible) return reply.code(404).send({ error: 'Account not found' });
+
     const count = (
       db
         .prepare('SELECT count(*) AS n FROM transactions WHERE account_id = ? OR to_account_id = ?')


### PR DESCRIPTION
Second of the testing changes, and the one that mattered. Closes #46 — and found a second instance of the same hole on its first run.

## The problem being solved

The privacy promise — private is private, server-side, no exception for the administrator — is the thing the README tells strangers on the internet, and the single most likely place to introduce a serious bug: a route that takes an `:id` and forgets its visibility guard looks exactly like a correct one.

It had **no test coverage at all, and could not have any.** `index.ts` built the app and called `listen()` at module scope, so importing it started a server.

## The split

The HTTP surface moves to `buildApp()` in `app.ts` — hooks, plugins, routes, and nothing that touches the world. `index.ts` keeps what *starting* a server means: migrations, the session pruner, demo init, the port, the mail poller, process and signal handlers.

Nothing about the surface itself changed. Verified against a running server rather than assumed:

```
health 200 · setup 201 · a real task created
CSP header present · x-ratelimit-limit: 300
12:41:16 WARN  404 GET /api/nope?token=...   ← redactUrl still masking
```

## The sweep

Alice creates something private, Bob asks for it by id, and the answer must be **404** — not 200, and not 403, which would confirm the thing exists. Notes, personal accounts, personal calendars, across read, list, edit, delete, search and version history, plus the unauthenticated case. Eleven tests.

Both users are administrators on purpose: the guard has no role exception, and a member-to-member test would miss precisely the backdoor the project promises not to have.

One implementation note worth knowing for anyone writing more of these: wrapping `app.inject()` in `runWithDb` does **not** work — the request is dispatched onto its own async chain and the context does not follow. The test binds the database with an `onRequest` hook instead, which is exactly how demo mode binds a request to a visitor's sandbox.

## What it caught

Two delete routes took an id and nothing else:

| Route | Status |
|---|---|
| `DELETE /api/accounts/:id` | #46, already filed |
| `DELETE /api/calendars/:id` | **new — nobody had noticed** |

Both now do the same lookup their neighbouring `archive` and `patch` handlers already did. Checked that the fix does not break the legitimate path: an owner deleting their own empty account or calendar still gets 200.

I audited the remaining fourteen delete routes by hand as well — no third instance. The ones without an owner check are shared by design (categories, projects, folders, tasks) or admin-gated (invites, mail account).

Removing either guard turns the sweep red, which is the point of writing it this way round:

```
× a personal money account > is not his to edit, reconcile or delete
× a personal money account > survives his attempt
× a personal calendar > is not his to edit or delete
```

## Note on the calendar hole

It is the same shape as #46, which is already public, and it is fixed in the same commit that discloses it — so there is no window. Worth a line in the next release notes: anyone running v1.0.0 has both. The bound is the same as #46's — the caller needs the id, and the route still refuses when the calendar has events.

## Checks

`npm run typecheck`, `npm run lint`, `npm test` — server 43 → 54, 88 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)