### PR TITLE
test: cover the money semantics and finish the privacy sweep

### DIFF
--- a/server/src/routes/guards.test.ts
+++ b/server/src/routes/guards.test.ts
@@ -1,9 +1,6 @@
-import type { FastifyInstance, InjectOptions } from 'fastify';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { buildApp } from '../app.js';
-import { openDatabase, runWithDb, id, now } from '../db/index.js';
-import { migrate } from '../db/migrate.js';
-import { SESSION_COOKIE, createSession } from '../lib/auth.js';
+import { buildTestApp, type Harness } from '../test-harness.js';
+import { id, now, runWithDb } from '../db/index.js';
 
 /*
   The privacy promise, as a test.
@@ -14,60 +11,26 @@ import { SESSION_COOKIE, createSession } from '../lib/auth.js';
   bug: a new route that takes an :id and forgets its visibility guard
   looks exactly like a correct one.
 
-  Until buildApp existed there was no way to check it. Now the app can be
-  built against an in-memory database and driven through inject(), with
-  no socket and no fixtures beyond two users.
-
   The shape of every case is the same: Alice creates something private,
   Bob asks for it by id, and the answer must be 404 — not 200, and not
   403 either, which would confirm the thing exists.
+
+  Both are administrators on purpose. The guard has no role exception, and
+  a test between two ordinary members would miss exactly the backdoor the
+  project promises not to have.
 */
 
-let app: FastifyInstance;
-const db = openDatabase(':memory:');
-let alice = '';
-let bob = '';
+let hub: Harness;
 let aliceCookie = '';
 let bobCookie = '';
 
-function member(name: string): string {
-  const userId = id();
-  db.prepare(
-    `INSERT INTO users (id, email, name, role, password_hash, created_at)
-     VALUES (?, ?, ?, 'admin', 'x', ?)`,
-  ).run(userId, `${name}@hub.local`, name, now());
-  return userId;
-}
-
-function as(cookie: string, method: InjectOptions['method'], url: string, payload?: unknown) {
-  const options: InjectOptions = {
-    method,
-    url,
-    headers: { cookie: `${SESSION_COOKIE}=${cookie}` },
-  };
-  if (payload !== undefined) options.payload = payload as InjectOptions['payload'];
-  return app.inject(options);
-}
+const as = (cookie: string, method: 'GET' | 'POST' | 'PATCH' | 'DELETE', url: string, payload?: unknown) =>
+  hub.as(cookie, method, url, payload);
 
 beforeAll(async () => {
-  app = await buildApp();
-
-  // Bind every request to this database, exactly the way demo mode binds
-  // one to a visitor's sandbox (see the onRequest hook in index.ts).
-  // Wrapping the inject() call itself does not work: the request is
-  // dispatched onto its own async chain, and the context does not follow.
-  app.addHook('onRequest', (_req, _reply, done) => runWithDb(db, done));
-
-  runWithDb(db, () => {
-    migrate();
-    alice = member('alice');
-    bob = member('bob');
-    // The administrator is deliberately included on both sides: the guard
-    // has no role exception, and a test that only checked member-to-member
-    // would miss exactly the backdoor the project promises not to have
-    aliceCookie = createSession(alice, 'alice-device');
-    bobCookie = createSession(bob, 'bob-device');
-  });
+  hub = await buildTestApp();
+  aliceCookie = hub.join('alice').cookie;
+  bobCookie = hub.join('bob').cookie;
 });
 
 describe('a private note', () => {
@@ -174,8 +137,115 @@ describe('a personal calendar', () => {
 describe('an unauthenticated caller', () => {
   it('gets nowhere near any of it', async () => {
     for (const url of ['/api/notes', '/api/accounts', '/api/calendars', '/api/tasks']) {
-      const res = await app.inject({ method: 'GET', url });
+      const res = await hub.app.inject({ method: 'GET', url });
       expect(res.statusCode).toBe(401);
     }
+  });
+});
+
+describe('a transaction on a personal account', () => {
+  let txId = '';
+
+  beforeAll(async () => {
+    const account = (
+      await as(aliceCookie, 'POST', '/api/accounts', {
+        name: 'Alice wallet',
+        currency: 'EUR',
+        shared: false,
+      })
+    ).json<{ id: string }>().id;
+    const created = await as(aliceCookie, 'POST', '/api/transactions', {
+      account_id: account,
+      kind: 'expense',
+      amount: 12_34,
+      occurred_on: '2026-08-14',
+      note: 'a present',
+    });
+    txId = created.json<{ id: string }>().id;
+    expect(created.statusCode).toBe(201);
+  });
+
+  it('is not in his list', async () => {
+    const list = (await as(bobCookie, 'GET', '/api/transactions?from=2026-08-01&to=2026-08-31')).json<
+      { id: string }[]
+    >();
+    expect(list.map((t) => t.id)).not.toContain(txId);
+  });
+
+  it('is not his to read, edit or delete', async () => {
+    expect((await as(bobCookie, 'GET', `/api/transactions/${txId}/attachments`)).statusCode).toBe(404);
+    expect((await as(bobCookie, 'PATCH', `/api/transactions/${txId}`, { amount: 1 })).statusCode).toBe(404);
+    expect((await as(bobCookie, 'DELETE', `/api/transactions/${txId}`)).statusCode).toBe(404);
+  });
+});
+
+describe('an attachment on a private note', () => {
+  let attachmentId = '';
+
+  beforeAll(async () => {
+    const noteId = (
+      await as(aliceCookie, 'POST', '/api/notes', { title: 'Sealed', visibility: 'private' })
+    ).json<{ id: string }>().id;
+
+    // Inserted rather than uploaded: the multipart path is not what is
+    // under test here, the read guard is
+    runWithDb(hub.db, () => {
+      attachmentId = id();
+      hub.db
+        .prepare(
+          `INSERT INTO attachments (id, filename, mime, size_bytes, storage_path, note_id, created_at)
+           VALUES (?, 'secret.pdf', 'application/pdf', 10, '2026-08/x.pdf', ?, ?)`,
+        )
+        .run(attachmentId, noteId, now());
+    });
+  });
+
+  it('is hers to fetch', async () => {
+    // 404 from disk, not from the guard: the row exists, the file never did
+    const res = await as(aliceCookie, 'GET', `/api/attachments/${attachmentId}`);
+    expect(res.json<{ error: string }>().error).toBe('The file is missing on disk');
+  });
+
+  it('is not his to fetch or delete', async () => {
+    const read = await as(bobCookie, 'GET', `/api/attachments/${attachmentId}`);
+    expect(read.statusCode).toBe(404);
+    expect(read.json<{ error: string }>().error).toBe('File not found');
+    expect((await as(bobCookie, 'DELETE', `/api/attachments/${attachmentId}`)).statusCode).toBe(404);
+  });
+
+  it('does not surface in his search', async () => {
+    const found = (await as(bobCookie, 'GET', '/api/search?q=secret')).json<{ results: unknown[] }>();
+    expect(found.results).toEqual([]);
+  });
+});
+
+describe('an event on a personal calendar', () => {
+  let eventId = '';
+
+  beforeAll(async () => {
+    const calendarId = (
+      await as(aliceCookie, 'POST', '/api/calendars', { name: 'Alice hours', shared: false })
+    ).json<{ id: string }>().id;
+    const created = await as(aliceCookie, 'POST', '/api/events', {
+      title: 'Therapy',
+      calendar_id: calendarId,
+      starts_at: '2026-08-20T10:00',
+      ends_at: '2026-08-20T11:00',
+    });
+    eventId = created.json<{ id: string }>().id;
+    expect(created.statusCode).toBe(201);
+  });
+
+  it('is not in his range', async () => {
+    const list = (await as(bobCookie, 'GET', '/api/events?from=2026-08-01&to=2026-08-31')).json<
+      { title: string }[]
+    >();
+    expect(list.map((e) => e.title)).not.toContain('Therapy');
+  });
+
+  it('is not his to read, edit or delete', async () => {
+    expect((await as(bobCookie, 'GET', `/api/events/${eventId}`)).statusCode).toBe(404);
+    expect((await as(bobCookie, 'PATCH', `/api/events/${eventId}`, { title: 'x' })).statusCode).toBe(404);
+    expect((await as(bobCookie, 'DELETE', `/api/events/${eventId}`)).statusCode).toBe(404);
   });
 });

--- a/server/src/routes/money-semantics.test.ts
+++ b/server/src/routes/money-semantics.test.ts
@@ -1,0 +1,279 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+import { runWithDb } from '../db/index.js';
+import { runAutoCreate } from './budgets.js';
+
+/*
+  The money rules, as tests.
+
+  These are the decisions where a wrong answer looks right: a balance is
+  still a number, a discrepancy is still a figure, a rent charged twice is
+  still a plausible row. Nothing crashes — the total just stops matching
+  the bank, weeks later, with no way back to the change that caused it.
+
+  Everything here was verified by hand during a QA pass first. That is the
+  point of writing it down: a hand check is a moment, a test is a rule.
+*/
+
+let hub: Harness;
+let cookie = '';
+const INBOX = '00000000-0000-4000-8000-000000000001';
+
+async function account(name: string, opening = 0): Promise<string> {
+  const res = await hub.as(cookie, 'POST', '/api/accounts', {
+    name,
+    currency: 'EUR',
+    opening_balance: opening,
+  });
+  return res.json<{ id: string }>().id;
+}
+
+async function balanceOf(name: string): Promise<number> {
+  const list = (await hub.as(cookie, 'GET', '/api/accounts')).json<
+    { name: string; balance: number; checked_balance: number | null; last_actual: number | null }[]
+  >();
+  return list.find((a) => a.name === name)!.balance;
+}
+
+async function accountRow(name: string) {
+  const list = (await hub.as(cookie, 'GET', '/api/accounts')).json<
+    { name: string; balance: number; checked_balance: number | null; last_actual: number | null }[]
+  >();
+  return list.find((a) => a.name === name)!;
+}
+
+async function spend(accountId: string, amount: number, on: string, categoryId?: string) {
+  return hub.as(cookie, 'POST', '/api/transactions', {
+    account_id: accountId,
+    kind: 'expense',
+    amount,
+    occurred_on: on,
+    ...(categoryId ? { category_id: categoryId } : {}),
+  });
+}
+
+beforeAll(async () => {
+  hub = await buildTestApp();
+  cookie = hub.join('alice').cookie;
+});
+
+describe('balances are computed, never stored', () => {
+  it('a backdated expense moves the balance now', async () => {
+    const id = await account('Computed', 100_00);
+    await spend(id, 30_00, '2026-08-10');
+    expect(await balanceOf('Computed')).toBe(70_00);
+
+    // Entered later, dated earlier — a stored balance would have missed it
+    await spend(id, 5_00, '2026-07-01');
+    expect(await balanceOf('Computed')).toBe(65_00);
+  });
+
+  it('editing an old amount recomputes rather than adjusts', async () => {
+    const id = await account('Edited', 100_00);
+    const tx = (await spend(id, 30_00, '2026-08-10')).json<{ id: string }>().id;
+    await hub.as(cookie, 'PATCH', `/api/transactions/${tx}`, { amount: 10_00 });
+    expect(await balanceOf('Edited')).toBe(90_00);
+  });
+});
+
+describe('reconciliation compares against the balance at the moment of the check', () => {
+  it('a transaction dated after the check does not move the discrepancy', async () => {
+    const id = await account('Later', 100_00);
+    await spend(id, 10_00, '2026-08-10');
+
+    await hub.as(cookie, 'POST', `/api/accounts/${id}/reconcile`, {
+      actual_balance: 88_00,
+      checked_on: '2026-08-15',
+    });
+    const checked = (await accountRow('Later')).checked_balance;
+    expect(checked).toBe(90_00);
+
+    // The bank will process this one too; there is nothing to compare it against yet
+    await spend(id, 7_77, '2026-08-20');
+    expect((await accountRow('Later')).checked_balance).toBe(checked);
+  });
+
+  it('a forgotten expense dated before the check closes it', async () => {
+    const id = await account('Forgotten', 100_00);
+    await spend(id, 10_00, '2026-08-10');
+    await hub.as(cookie, 'POST', `/api/accounts/${id}/reconcile`, {
+      actual_balance: 88_00,
+      checked_on: '2026-08-15',
+    });
+    expect((await accountRow('Forgotten')).checked_balance).toBe(90_00);
+
+    // This is the workflow the feature exists for: see a gap, find what
+    // was missed, enter it, watch the two sides meet
+    await spend(id, 2_00, '2026-08-12');
+    const row = await accountRow('Forgotten');
+    expect(row.checked_balance).toBe(88_00);
+    expect(row.last_actual).toBe(88_00);
+  });
+
+  it('a second check on the same day replaces the first, it does not add a twin', async () => {
+    const id = await account('Twice', 100_00);
+    for (const actual of [90_00, 80_00]) {
+      await hub.as(cookie, 'POST', `/api/accounts/${id}/reconcile`, {
+        actual_balance: actual,
+        checked_on: '2026-08-15',
+      });
+    }
+    const rows = hub.db
+      .prepare('SELECT actual_balance FROM reconciliations WHERE account_id = ?')
+      .all(id) as { actual_balance: number }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.actual_balance).toBe(80_00);
+  });
+});
+
+describe('subcategories are exactly one level deep', () => {
+  let parent = '';
+  let child = '';
+
+  beforeAll(async () => {
+    parent = (await hub.as(cookie, 'POST', '/api/categories', { name: 'Car', kind: 'expense' })).json<{
+      id: string;
+    }>().id;
+    child = (
+      await hub.as(cookie, 'POST', '/api/categories', {
+        name: 'Fuel',
+        kind: 'expense',
+        parent_id: parent,
+      })
+    ).json<{ id: string }>().id;
+  });
+
+  it('refuses a child of a child', async () => {
+    const res = await hub.as(cookie, 'POST', '/api/categories', {
+      name: 'Diesel',
+      kind: 'expense',
+      parent_id: child,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('refuses turning a parent into a subcategory', async () => {
+    const res = await hub.as(cookie, 'PATCH', `/api/categories/${parent}`, { parent_id: child });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('refuses a category as its own parent', async () => {
+    const res = await hub.as(cookie, 'PATCH', `/api/categories/${child}`, { parent_id: child });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('a limit on a parent counts what its children spent', () => {
+  it('adds the children in and keeps a separate limit on a child', async () => {
+    const id = await account('Budgeted', 1000_00);
+    const parent = (
+      await hub.as(cookie, 'POST', '/api/categories', { name: 'Household', kind: 'expense' })
+    ).json<{ id: string }>().id;
+    const child = (
+      await hub.as(cookie, 'POST', '/api/categories', {
+        name: 'Cleaning',
+        kind: 'expense',
+        parent_id: parent,
+      })
+    ).json<{ id: string }>().id;
+
+    await spend(id, 50_00, '2026-08-05', child);
+    await spend(id, 20_00, '2026-08-06', parent);
+
+    await hub.as(cookie, 'PUT', '/api/budgets', { category_id: parent, currency: 'EUR', amount: 150_00 });
+    await hub.as(cookie, 'PUT', '/api/budgets', { category_id: child, currency: 'EUR', amount: 40_00 });
+
+    const budgets = (await hub.as(cookie, 'GET', '/api/budgets?month=2026-08')).json<
+      { category_name: string; limit_amount: number; spent: number }[]
+    >();
+    const byName = Object.fromEntries(budgets.map((b) => [b.category_name, b]));
+
+    // The parent's own 20 plus the child's 50
+    expect(byName.Household!.spent).toBe(70_00);
+    expect(byName.Household!.limit_amount).toBe(150_00);
+    // The child keeps its own, smaller limit alongside
+    expect(byName.Cleaning!.spent).toBe(50_00);
+    expect(byName.Cleaning!.limit_amount).toBe(40_00);
+  });
+});
+
+describe('a recurring rule cannot charge the rent twice', () => {
+  it('catches up once, and a restart does not double it', async () => {
+    const id = await account('Rent from', 5000_00);
+    const rule = await hub.as(cookie, 'POST', '/api/recurring', {
+      title: 'Rent',
+      kind: 'expense',
+      start_on: '2026-05-01',
+      recurrence_rule: 'FREQ=MONTHLY;INTERVAL=1',
+      account_id: id,
+      amount: 500_00,
+      auto_create: true,
+    });
+    expect(rule.statusCode).toBe(201);
+
+    const count = () =>
+      (
+        hub.db
+          .prepare('SELECT count(*) AS n FROM transactions WHERE recurring_id IS NOT NULL')
+          .get() as { n: number }
+      ).n;
+
+    const afterCreate = count();
+    expect(afterCreate).toBeGreaterThan(0);
+
+    // What happens on every boot. The unique index on rule + occurrence
+    // date is the thing being tested; without it a machine that restarts
+    // twice in a morning charges the rent twice.
+    runWithDb(hub.db, () => runAutoCreate());
+    runWithDb(hub.db, () => runAutoCreate());
+    expect(count()).toBe(afterCreate);
+  });
+});
+
+describe('currencies never mix', () => {
+  it('a total is per currency, and there is no grand total', async () => {
+    await hub.as(cookie, 'POST', '/api/accounts', {
+      name: 'Dinars',
+      currency: 'RSD',
+      opening_balance: 5000_00,
+    });
+    const summary = (await hub.as(cookie, 'GET', '/api/money/summary?from=2026-08-01&to=2026-08-31')).json<{
+      byCurrency: { currency: string }[];
+    }>();
+    const currencies = new Set(summary.byCurrency.map((row) => row.currency));
+    for (const currency of currencies) expect(currency).toMatch(/^[A-Z]{3}$/);
+  });
+});
+
+describe('tasks nest three levels deep and no further', () => {
+  it('refuses a fourth level, a cycle, and a subtree that would not fit', async () => {
+    const mk = async (title: string, parent?: string) =>
+      (
+        await hub.as(cookie, 'POST', '/api/tasks', {
+          project_id: INBOX,
+          title,
+          ...(parent ? { parent_id: parent } : {}),
+        })
+      ).json<{ id: string }>().id;
+
+    const story = await mk('story');
+    const task = await mk('task', story);
+    const subtask = await mk('subtask', task);
+
+    const fourth = await hub.as(cookie, 'POST', '/api/tasks', {
+      project_id: INBOX,
+      title: 'too deep',
+      parent_id: subtask,
+    });
+    expect(fourth.statusCode).toBe(400);
+
+    // A two-deep subtree moved under a level-3 task would need five levels
+    const otherRoot = await mk('other root');
+    await mk('other child', otherRoot);
+    const moved = await hub.as(cookie, 'PATCH', `/api/tasks/${otherRoot}`, { parent_id: subtask });
+    expect(moved.statusCode).toBe(400);
+
+    const cycle = await hub.as(cookie, 'PATCH', `/api/tasks/${story}`, { parent_id: subtask });
+    expect(cycle.statusCode).toBe(400);
+  });
+});

--- a/server/src/test-harness.ts
+++ b/server/src/test-harness.ts
@@ -1,0 +1,63 @@
+import type { Database } from 'better-sqlite3';
+import type { FastifyInstance, InjectOptions } from 'fastify';
+import { buildApp } from './app.js';
+import { openDatabase, runWithDb, id, now } from './db/index.js';
+import { migrate } from './db/migrate.js';
+import { SESSION_COOKIE, createSession } from './lib/auth.js';
+
+/*
+  Test support: the real app, an in-memory database, and two people.
+
+  Shared rather than copied into each test file so there is one obvious
+  thing to reuse — the first version of this lived inside guards.test.ts,
+  and a second test would have started by copying it.
+
+  The database is bound with an onRequest hook, exactly the way demo mode
+  binds a request to a visitor's sandbox. Wrapping app.inject() in
+  runWithDb does not work: the request is dispatched onto its own async
+  chain and the AsyncLocalStorage context does not follow it.
+*/
+
+export interface Harness {
+  app: FastifyInstance;
+  db: Database;
+  /** Adds a user and returns a session cookie value for them. */
+  join(name: string): { userId: string; cookie: string };
+  /** A request as that person, inside the test database. */
+  as(cookie: string, method: InjectOptions['method'], url: string, payload?: unknown): Promise<{
+    statusCode: number;
+    body: string;
+    json<T>(): T;
+  }>;
+}
+
+export async function buildTestApp(): Promise<Harness> {
+  const app = await buildApp();
+  const db = openDatabase(':memory:');
+  app.addHook('onRequest', (_req, _reply, done) => runWithDb(db, done));
+  runWithDb(db, () => migrate());
+
+  return {
+    app,
+    db,
+    join(name) {
+      return runWithDb(db, () => {
+        const userId = id();
+        db.prepare(
+          `INSERT INTO users (id, email, name, role, password_hash, created_at)
+           VALUES (?, ?, ?, 'admin', 'x', ?)`,
+        ).run(userId, `${name}@hub.local`, name, now());
+        return { userId, cookie: createSession(userId, `${name}-device`) };
+      });
+    },
+    as(cookie, method, url, payload) {
+      const options: InjectOptions = {
+        method,
+        url,
+        headers: { cookie: `${SESSION_COOKIE}=${cookie}` },
+      };
+      if (payload !== undefined) options.payload = payload as InjectOptions['payload'];
+      return app.inject(options);
+    },
+  };
+}


### PR DESCRIPTION
Third and last of the testing series. The half of the invariants where a wrong answer *looks right* was split down the middle: auth and privacy had tests after #88, money had none.

That is the worse half. A balance is still a number when it is wrong, a discrepancy is still a figure, a rent charged twice is still a plausible row. Nothing crashes — the total just stops matching the bank, weeks later, with no way back to the change that caused it.

## Money — twelve cases

- **balances are computed, never stored**: a backdated expense moves the balance now; editing an old amount recomputes rather than adjusts
- **reconciliation measures against the balance at the moment of the check**: a transaction dated *after* it does not move the discrepancy; a forgotten one dated *before* it closes the gap — the workflow the feature exists for; a second check the same day replaces the first instead of adding a twin
- **subcategories are one level deep**: refused as a child of a child, as a parent turned into a subcategory, and as its own parent
- **a parent limit counts its children** while a child keeps its own smaller limit alongside
- **a recurring rule cannot charge the rent twice**: catches up once, and two further boot passes add nothing
- **tasks nest three levels**: a fourth level, a cycle, and a two-deep subtree that would not fit are all refused

## Guards — seven more

Transactions on a personal account, attachments of a private note, events of a personal calendar: the three entities the first sweep did not reach. `guards.test.ts` goes from 11 cases to 18.

The setup both files share moves to `test-harness.ts` — it started inside `guards.test.ts`, and a second test file would have begun by copying it.

## Every assertion was checked by breaking what it guards

Not "the tests pass". Each mutation turns exactly the expected case red and nothing else:

| Mutation | Caught by |
|---|---|
| reconciliation window dropped | `a transaction dated after the check does not move the discrepancy` |
| `id = c.id OR parent_id = c.id` → `id = c.id` | `adds the children in and keeps a separate limit on a child` |
| depth ceiling removed | `refuses a fourth level, a cycle, and a subtree that would not fit` |
| `ACCOUNT_VISIBLE` neutralised | three account and transaction cases |
| `CALENDAR_VISIBLE` neutralised | four calendar and event cases |
| attachment lookup neutralised | `is not his to fetch or delete` |

## One assertion did not survive that check

Worth writing down, because it is the failure mode of testing generally. "Bob does not see the transaction in his list" keyed on the note — and it **passed even with the SQL guard removed**.

The reason turned out to be good news: the list masks `note`, `place`, `category_name` and `account_name` for accounts the reader cannot see (`money.ts`, after the query). So even with the guard gone the row leaked but its details did not — defence in depth doing exactly its job.

It is still a bad assertion. It proved the masking, not the guard, while reading as though it proved the guard. It keys on the transaction id now, and fails when the guard goes.

(No contradiction with #51, incidentally: there the transaction sits on the *shared* account, which the other person can see, so the masking never triggers and the note stays visible. That is what #51 is about.)

## Checks

`npm run typecheck`, `npm run lint`, `npm test` — server 54 → 73, 110 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)