### PR TITLE
docs: document the testing setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,23 +189,79 @@ thing this project has to a schema changelog, and they read like one.
 Then run the tests: `migrate.test.ts` applies every migration to an
 in-memory database.
 
-**A test.** Vitest, in both workspaces. Pure logic tests live next to the
-code (`lib/*.test.ts`). For anything touching the database, the pattern
-is an in-memory database with the migrations applied — see
-`server/src/lib/auth.test.ts`:
+**A test.** See the section below — there is more machinery than there
+used to be, and most of it exists so that the rules worth protecting can
+be protected.
 
-```ts
-const db = openDatabase(':memory:');
-runWithDb(db, () => {
-  migrate();
-  // …
-});
+## Tests
+
+```bash
+npm test                      # both workspaces, what CI runs
+npm test --workspace=server   # just one
 ```
 
-Not everything needs a test. Something you fixed that could silently come
-back does — a wrong sort order, an off-by-one in a date, an amount that
-survives a round trip. If you cannot write the test without extracting a
-function first, extracting it is usually the right move.
+Three kinds, in rough order of how often you will write them.
+
+**Pure logic, next to the code.** `lib/*.test.ts` on both sides. Amount
+parsing, recurrence arithmetic, plural forms, TOTP against the RFC
+vectors. If the thing you are fixing can be reached by a function call,
+this is where it goes, and it is the cheapest test in the repository.
+
+**Through the API, without a socket.** `buildTestApp()` in
+`server/src/test-harness.ts` gives you the real app, an in-memory
+database with the migrations applied, and people to be:
+
+```ts
+const hub = await buildTestApp();
+const alice = hub.join('alice');
+const res = await hub.as(alice.cookie, 'POST', '/api/notes', { title: 'x' });
+expect(res.statusCode).toBe(201);
+```
+
+This is how anything involving routes, guards or status codes is tested —
+see `routes/guards.test.ts` and `routes/money-semantics.test.ts`.
+
+One thing to know before you write your own setup: wrapping
+`app.inject()` in `runWithDb` does **not** work. The request is
+dispatched onto its own async chain and the `AsyncLocalStorage` context
+does not follow it. The harness binds the database with an `onRequest`
+hook instead, exactly the way demo mode binds a request to a visitor's
+sandbox. Use the harness rather than rediscovering this.
+
+**Whole-repository checks.** A couple of tests read the source rather
+than call it: every `t()` key exists in the Russian dictionary, every
+migration applies to an empty database. They catch the class of mistake
+that no individual test would, because nothing is wrong at any one call
+site.
+
+### What deserves a test
+
+Not everything. Something you fixed that could come back **silently**
+does — a wrong sort order, an off-by-one in a date, an amount that has to
+survive a round trip, a guard that could go missing. Visual things do
+not: a colour, a spacing, a dark-theme contrast. Those are caught by
+looking, and a test that asserts a class name is a test that breaks on
+every redesign without ever catching a bug.
+
+If you cannot write the test without extracting a function first,
+extracting it is usually the right move. Both the TOTP replay fix and the
+Devices ordering fix became testable exactly that way.
+
+### Make it fail first
+
+The most useful minute you can spend on a test is breaking the code it
+guards and watching the right case go red. It is not a formality:
+
+- a test can pass for the wrong reason and read as though it proved
+  something;
+- a test can assert on a field that some *other* layer happens to
+  protect, which is what happened to the transaction-list case in
+  `guards.test.ts` — it keyed on the note, and the note is masked
+  independently of the guard being tested, so it passed with the guard
+  removed. It keys on the id now.
+
+Delete the guard, invert the condition, drop the `WHERE` clause — then
+put it back. If nothing went red, the test is decoration.
 
 ## Reporting a bug
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,16 @@ One-off critical messages print **regardless of level**, even at `silent`: appli
 
 Malformed path or query parameters answer 400 and log as `WARN`. Previously that crashed with a 500 and looked like a server error in the log.
 
+## Tests
+
+`app.ts` builds the HTTP surface — hooks, plugins, routes — and `index.ts` starts the world: migrations, the session pruner, the port, the mail poller, signal handlers. The split exists for one reason: importing the app must not start a server. Before it, the guards that carry the privacy promise could not be tested at all, because reaching them meant listening on a port.
+
+With it, a test builds the same app the process does and drives it through `inject()` against an in-memory database. The database is bound per request with an `onRequest` hook — which is the same mechanism demo mode uses to route a visitor to their sandbox. That layer was built for the public demo and turned out to be exactly what makes route tests possible; the alternative would have been threading a database argument through every route.
+
+Two checks read the source instead of calling it: every `t()` key must exist in the Russian dictionary, and every migration must apply to an empty database. They catch what no single test can, because nothing is wrong at any one call site.
+
+What is deliberately not covered: anything whose failure is visible rather than logical — colours, spacing, dark-theme contrast, the service worker. Those are checked by looking, and asserting on class names would break on every redesign without ever catching a bug.
+
 ## Demo mode
 
 `DEMO_MODE=true` turns the hub into a public sandbox where **every visitor gets their own throwaway copy** of a seeded sample family. One button to enter — no password.


### PR DESCRIPTION
Three testing changes landed this week (#87, #88, #89) and the guide still described the state before them: one paragraph saying "vitest, in both workspaces". Someone reaching for the route harness would not have found it, and would have started by rediscovering why wrapping `inject()` in `runWithDb` does not work.

## CONTRIBUTING gains a Tests section

The three kinds and when each applies:

- **pure logic next to the code** — the cheapest test here, and where most fixes belong
- **through the API without a socket** — `buildTestApp()`, with the snippet
- **whole-repository checks** — the dictionary scan and the migration sweep, which catch what no individual test can because nothing is wrong at any one call site

With the async-context trap spelled out, so nobody hits it twice:

> wrapping `app.inject()` in `runWithDb` does **not** work. The request is dispatched onto its own async chain and the `AsyncLocalStorage` context does not follow it.

Plus what does *not* deserve a test — colours, spacing, dark-theme contrast. Those are caught by looking, and a test asserting on a class name breaks on every redesign without ever catching a bug. Worth saying out loud in a repository that just tripled its test count; the failure mode from here is people writing tests because tests are good.

## The part worth reading twice

"Make it fail first", with this repository's own example rather than a hypothetical:

> a test can assert on a field that some *other* layer happens to protect, which is what happened to the transaction-list case in `guards.test.ts` — it keyed on the note, and the note is masked independently of the guard being tested, so it passed with the guard removed.

Written down as a warning rather than quietly fixed in #89 and forgotten.

## architecture.md gains the reasoning, not the how-to

Why `app.ts` and `index.ts` are separate — importing the app must not start a server, and before that split the guards carrying the privacy promise could not be tested at all. And the observation worth keeping: the per-request database binding the tests rely on is the *same mechanism* the public demo uses to route a visitor to their sandbox. Built for one purpose, load-bearing for another.

## Verified

The snippet in the guide was run verbatim as a throwaway test before committing — it compiles and passes as written. Every file, symbol and command referenced was checked against the tree.

`npm run typecheck`, `npm run lint`, `npm test` (110) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)