### PR TITLE
fix: stop painting upcoming task dates in the overdue colour

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -20,7 +20,10 @@ const PRIORITY_LABEL: Record<Task['priority'], string> = {
   A task opens its card, an event the calendar at the right date, a note
   the note itself. Showing a list with nowhere to go is a dead end.
 */
-function TaskRow({ task, overdue }: { task: Task; overdue?: boolean }) {
+// showDate: whether a date renders at all; overdue: whether it's alarming.
+// Kept separate so "Next 7 days" can show a date without borrowing the
+// overdue colour — nothing in that list is overdue by definition.
+function TaskRow({ task, showDate, overdue }: { task: Task; showDate?: boolean; overdue?: boolean }) {
   return (
     <li className="border-b border-line last:border-0">
       <Link
@@ -37,8 +40,10 @@ function TaskRow({ task, overdue }: { task: Task; overdue?: boolean }) {
           {PRIORITY_LABEL.urgent}
         </span>
       )}
-        {overdue && effectiveDate(task) && (
-          <span className="font-mono text-xs text-urgent">{formatDate(effectiveDate(task)!)}</span>
+        {showDate && effectiveDate(task) && (
+          <span className={`font-mono text-xs ${overdue ? 'text-urgent' : 'text-muted'}`}>
+            {formatDate(effectiveDate(task)!)}
+          </span>
         )}
       </Link>
     </li>
@@ -218,7 +223,7 @@ export function Dashboard() {
           <Panel title={t('Overdue')} count={data.overdue.length}>
             <ul>
               {data.overdue.map((t) => (
-                <TaskRow key={t.id} task={t} overdue />
+                <TaskRow key={t.id} task={t} showDate overdue />
               ))}
             </ul>
           </Panel>
@@ -281,7 +286,7 @@ export function Dashboard() {
             ) : (
               <ul>
                 {data.upcoming.map((t) => (
-                  <TaskRow key={t.id} task={t} overdue />
+                  <TaskRow key={t.id} task={t} showDate />
                 ))}
               </ul>
             )}


### PR DESCRIPTION
## Why

`TaskRow`'s `overdue` prop did two jobs at once: whether the date renders at all, and whether it's coloured as alarming. The "Next 7 days" panel only wanted the first, but passed `overdue` anyway just to get the date shown — so a task due in three days looked exactly as urgent as one that slipped last week, and the colour stopped carrying any information.

Closes #75

## What you considered and rejected

Kept the fix to exactly the split the issue asked for — one prop for visibility, `overdue` for colour — rather than inventing a third state (e.g. a `dueSoon` warning tier). The issue didn't ask for a third colour, and adding one would be a bigger design conversation than this bug warrants.

Also checked the `→ 21 August` arrow convention used elsewhere for stand-in expected dates (per the issue's suggestion to glance at it) — that convention lives outside `TaskRow` entirely (in the task list rows, not the dashboard), so it doesn't interact with this prop and needed no change.

## How you know it works

- `npm run typecheck`, `npm run lint`, `npm test` all pass locally (73 server tests, 37 web tests).
- Read through both call sites: "Overdue" panel now passes `showDate overdue` (date shown, coloured `text-urgent`); "Next 7 days" passes only `showDate` (date shown, coloured `text-muted`). The "For today" panel's `TaskRow` (no date shown) is untouched.

## Anything you are unsure about

Named the new prop `showDate`, per the issue's own suggestion — reads clearly at both call sites.