### PR TITLE
docs: explain why MoveBoard's progress bar keeps its literal accent color

### DIFF
--- a/web/src/components/MoveBoard.tsx
+++ b/web/src/components/MoveBoard.tsx
@@ -45,6 +45,9 @@ export function MoveBoard({ settings, onChange }: Props) {
   }
 
   return (
+    // Literal colors here are deliberate: this card is always dark, in both themes,
+    // so its inner elements (including the progress bar below) pull from the dark
+    // palette on purpose, regardless of the active theme.
     <section className="overflow-hidden rounded-card bg-[#131c24] text-[#e8eae5] shadow-sm">
       <div className="grid divide-y divide-white/10 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] sm:divide-x sm:divide-y-0">
         {/* Countdown */}
@@ -125,6 +128,8 @@ export function MoveBoard({ settings, onChange }: Props) {
 
           {progress !== null && !editing && (
             <div className="mt-3.5 h-1 overflow-hidden rounded-full bg-white/12">
+              {/* Fixed dark-palette accent, not the bg-accent token: this bar sits on the
+                 always-dark card above, so it must stay #4d9ebb even in the light theme. */}
               <div className="h-full bg-[#4d9ebb]" style={{ width: `${progress}%` }} />
             </div>
           )}


### PR DESCRIPTION
## Why

#72 reported `bg-[#4d9ebb]` on MoveBoard's progress bar
(`web/src/components/MoveBoard.tsx:128`) as a bug — the dark theme's
`--c-accent` leaking into light mode, where the accent is `#1f6e8c`.

That diagnosis was wrong. The bar sits on MoveBoard's hero card,
which is `bg-[#131c24] text-[#e8eae5]` **always**, in both themes —
already flagged in the code as intentional. The bar was never meant
to follow the page theme; its color is part of that fixed dark
palette, picked deliberately against the card it sits on.

I initially implemented the swap to `bg-accent` as the issue
described (that was landed and reviewed in this PR). On review it
turned out to make things worse:

```
#4d9ebb (was)        -> contrast 5.68 against #131c24
#1f6e8c (bg-accent)  -> contrast 3.01 against #131c24
```

Confirmed in a browser on the light theme: with `bg-accent` the bar
nearly disappears into the card.

This PR now reverts that swap and instead documents why the literal
is correct, so nobody (including me) "fixes" it again.

Refs #72 — recommend closing it as not-a-bug rather than merging it
as a fix; I'll leave the explanation for whoever closes it, but the
contrast numbers above are the crux of it.

## What you considered and rejected

- **`bg-accent` (the change #72 asked for):** rejected — see contrast
  numbers above. It looked like the theme-correct token but the card
  it renders on isn't theme-dependent, so tying the bar to the theme
  broke it instead of fixing it.
- **Leaving the code uncommented:** rejected — the confident-but-wrong
  diagnosis in #72 shows this line reads as a bug at a glance. A
  one-line comment costs nothing and heads off the next report/PR.

## How you know it works

- `npm run typecheck`, `npm run lint`, `npm test` all pass locally
  (73 server tests + 37 web tests, all green).
- Contrast of `#4d9ebb` vs `#1f6e8c` against the card background
  `#131c24` computed directly (5.68 vs 3.01) — the literal is the
  higher-contrast, correct choice.
- Verified in-browser on the light theme: the `bg-accent` version of
  the bar visibly loses definition against the card; the reverted
  literal does not.

## Anything you are unsure about

None — this is now a no-behavior-change PR that only adds two
explanatory comments; the diff otherwise matches what was on `master`
before this branch.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [x] Docs updated, if behaviour changed (no behavior change; comments only)