### PR TITLE
fix: swallow logout request failure to avoid unhandled rejection

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -74,7 +74,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     try {
-      await api.post('/auth/logout', {});
+      // The server has often already destroyed the session by the time this
+      // runs (e.g. "sign in again" after a password change), so a 401 here
+      // is expected — the cleanup below is the point, not the request.
+      await api.post('/auth/logout', {}).catch(() => {});
     } finally {
       setUser(null);
       // The service worker's offline caches hold family data and the


### PR DESCRIPTION
## Why

Closes #60. `logout()`'s `try`/`finally` (without a `catch`) re-throws
whenever `POST /auth/logout` fails, and every caller uses `void logout()`,
which discards the rejection and logs it as unhandled. This isn't an edge
case: the "sign in again" button shown after a password change
(`Login.tsx`) runs after the server has already destroyed every session,
so that request 401s every time — the normal path hits this console noise
at exactly the moment someone is debugging a sign-in problem.

The fix swallows the request failure explicitly with `.catch(() => {})`.
The `finally` block already runs the cleanup (clearing user state and the
service worker's offline caches) unconditionally, which is what actually
matters — the request outcome doesn't change that.

## What you considered and rejected

Removing the `try`/`finally` wrapper entirely (since `.catch(() => {})`
means the `await` can no longer throw) was considered, but kept as-is to
minimize the diff — `finally` already guarantees the cleanup runs
unconditionally, and restructuring it would just re-indent unrelated
lines for no behavioral change.

The other `finally` in this file (in `refresh`, pairing with
`setLoading(false)`) is untouched — it's correct as-is and outside the
scope of this issue.

## How you know it works

`npm run typecheck`, `npm run lint`, and `npm test` all pass locally (73
server tests + 37 web tests). This particular path isn't covered by an
automated test (it's a promise-rejection/console-noise fix, not a
behavioral one), but the code change is a single line plus a comment and
easy to verify by inspection: `.catch(() => {})` on the request means the
`await` can no longer reject, so `void logout()` at every call site no
longer produces an unhandled rejection.

## Anything you are unsure about

Nothing major — this is exactly the fix described in the issue.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [ ] Docs updated, if behaviour changed (no behavior change, just removes console noise)