### PR TITLE
feat: let the dashboard hero follow the theme

### DIFF
--- a/web/src/components/MoveBoard.tsx
+++ b/web/src/components/MoveBoard.tsx
@@ -45,13 +45,13 @@ export function MoveBoard({ settings, onChange }: Props) {
   }
 
   return (
-    <section className="overflow-hidden rounded-card bg-[#131c24] text-[#e8eae5] shadow-sm">
-      <div className="grid divide-y divide-white/10 sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] sm:divide-x sm:divide-y-0">
+    <section className="overflow-hidden rounded-card border border-line bg-surface shadow-sm">
+      <div className="grid divide-y divide-line sm:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] sm:divide-x sm:divide-y-0">
         {/* Countdown */}
         <div className="px-6 py-5">
-          <p className="eyebrow text-white/45!">{settings['move.label'] ?? t('The move')}</p>
+          <p className="eyebrow">{settings['move.label'] ?? t('The move')}</p>
           {days === null ? (
-            <p className="mt-3 text-sm text-white/60">
+            <p className="mt-3 text-sm text-muted">
               {t('The moving date is not set. Add it in Settings and a countdown will appear here.')}
             </p>
           ) : (
@@ -60,20 +60,20 @@ export function MoveBoard({ settings, onChange }: Props) {
                 <span className="font-display text-[3.25rem] leading-none font-bold tabular-nums">
                   {Math.abs(days)}
                 </span>
-                <span className="font-mono text-sm text-white/55">
+                <span className="font-mono text-sm text-muted">
                   {days >= 0
                     ? plural(days, 'day', 'days')
                     : t('{unit} ago', { unit: plural(Math.abs(days), 'day', 'days') })}
                 </span>
               </p>
-              <p className="mt-2 font-mono text-xs text-white/40">{formatDate(targetDate)}</p>
+              <p className="mt-2 font-mono text-xs text-muted">{formatDate(targetDate)}</p>
             </>
           )}
         </div>
 
         {/* Savings */}
         <div className="px-6 py-5">
-          <p className="eyebrow text-white/45!">{settings['savings.label'] ?? t('Saved so far')}</p>
+          <p className="eyebrow">{settings['savings.label'] ?? t('Saved so far')}</p>
 
           {editing ? (
             <div className="mt-2.5">
@@ -90,19 +90,19 @@ export function MoveBoard({ settings, onChange }: Props) {
                     if (e.key === 'Enter') void save();
                     if (e.key === 'Escape') setEditing(false);
                   }}
-                  className="w-36 rounded-md border border-white/25 bg-white/5 px-2.5 py-1.5 font-mono text-lg tabular-nums outline-none focus:border-white/60"
+                  className="w-36 rounded-md border border-line bg-surface-2 px-2.5 py-1.5 font-mono text-lg tabular-nums outline-none focus:border-accent"
                   aria-label={t('Amount in euros')}
                 />
                 <button
                   type="button"
                   onClick={() => void save()}
                   disabled={saving}
-                  className="rounded-md bg-white/15 px-3 py-1.5 text-sm hover:bg-white/25 disabled:opacity-50"
+                  className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
                 >
                   {saving ? t('Saving') : t('Save')}
                 </button>
               </div>
-              {error && <p className="mt-2 text-xs text-[#d9a04f]">{error}</p>}
+              {error && <p className="mt-2 text-xs text-urgent">{error}</p>}
             </div>
           ) : (
             <button
@@ -118,14 +118,14 @@ export function MoveBoard({ settings, onChange }: Props) {
                 {formatEur(saved)}
               </span>
               {goal > 0 && (
-                <span className="ml-2 font-mono text-xs text-white/40">{t('of')} {formatEur(goal)}</span>
+                <span className="ml-2 font-mono text-xs text-muted">{t('of')} {formatEur(goal)}</span>
               )}
             </button>
           )}
 
           {progress !== null && !editing && (
-            <div className="mt-3.5 h-1 overflow-hidden rounded-full bg-white/12">
-              <div className="h-full bg-[#4d9ebb]" style={{ width: `${progress}%` }} />
+            <div className="mt-3.5 h-1 overflow-hidden rounded-full bg-surface-3">
+              <div className="h-full bg-accent" style={{ width: `${progress}%` }} />
             </div>
           )}
         </div>


### PR DESCRIPTION
The countdown-and-savings card was an inverted slab: always dark, in both themes. Now it follows the theme like everything else on the dashboard.

## What it was, and why

Worth writing down, because the literals were not sloppiness. The card's background was `#131c24` — the **light** theme's `--c-text` — and its text `#e8eae5`, the **dark** theme's. So it rendered in the dark palette whichever theme the reader had chosen, and the progress bar's `#4d9ebb` was the dark accent for the same reason.

That is a real design device, an inverted panel, and it has been there since the first commit — the light theme existed then too, so it was never a dark-only leftover. Tokens could not express it: a token gives you the *current* theme's value, and this card wanted the other one.

The cost is what you see on the light theme: one near-black block above a page of pale panels.

## What it is now

An ordinary card in the theme's own colours — `border border-line bg-surface`, matching `Panel` beside it. The large type carries the hierarchy instead of the contrast.

## Twelve values, not one

Everything inside assumed a dark ground: eleven `white/NN` opacities for dividers, muted text, the input, its button and the progress track. Each moved to the token that carries the same *meaning* rather than the same appearance:

| was | now |
|---|---|
| `divide-white/10` | `divide-line` |
| `text-white/45!`, `/60`, `/55`, `/40` | `text-muted` (the eyebrow needed no override at all) |
| `border-white/25 bg-white/5 focus:border-white/60` | `border-line bg-surface-2 focus:border-accent` |
| `bg-white/15 hover:bg-white/25` | the standard accent button |
| `bg-white/12` (track) | `bg-surface-3` |
| `bg-[#4d9ebb]` | `bg-accent` |
| `text-[#d9a04f]` | `text-urgent` |

The last two were the dark palette's accent and ochre spelled out by hand.

## Verified

Both themes, and the amount-editing state — which is where the field and button styles actually show, and the reason this is not a one-line change.

`npm run typecheck`, `npm run lint`, `npm test` (110) pass.

## Supersedes #92

#92 added comments explaining why those literals were deliberate. They are gone now, so that PR has nothing left to document — closing it in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)