### PR TITLE
docs: add a badge row to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Family Hub
 
+[![CI](https://img.shields.io/github/actions/workflow/status/burtsdenis/family-hub/ci.yml?branch=master&style=flat-square&labelColor=131c24)](https://github.com/burtsdenis/family-hub/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/burtsdenis/family-hub?style=flat-square&labelColor=131c24&color=1f6e8c)](https://github.com/burtsdenis/family-hub/releases)
+[![Image](https://img.shields.io/badge/ghcr.io-family--hub-1f6e8c?style=flat-square&labelColor=131c24&logo=docker&logoColor=white)](https://github.com/burtsdenis/family-hub/pkgs/container/family-hub)
+[![License](https://img.shields.io/github/license/burtsdenis/family-hub?style=flat-square&labelColor=131c24&color=1f6e8c)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/burtsdenis/family-hub?style=flat-square&labelColor=131c24&color=1f6e8c)](https://github.com/burtsdenis/family-hub/stargazers)
+
 A self-hosted family hub: tasks, notes, calendar and money in one place. Built for a household, not a corporation: one Docker container, one SQLite file, no external services required. Runs on a home machine over the local network or on a cheap VPS with a real domain.
 
 The core is complete and battle-tested by daily family use: accounts and sign-in (password and Google, with optional two-factor codes), projects and tasks with a kanban board, notes with attachments and wiki-links, a calendar with recurring events, a shared family mailbox that turns letters into tasks, full-text search, a dashboard, and a money section — accounts with balances, expenses, income, transfers, bank reconciliation, categories, budgets, recurring transactions, receipts. It installs to the home screen as an app and keeps working read-only when the Wi-Fi does not.


### PR DESCRIPTION
## Why

The README opens cold: nothing tells a visitor at a glance that CI is green, what the latest release is, or where the image lives. A badge row answers that in one strip.

## What

Five badges under the title — CI status, latest release, the GHCR image, license, stars — styled to the hub's own palette (`#131c24` label, `#1f6e8c` value, flat-square) so the row reads as one strip instead of shields' default rainbow.

Deliberately not included:
- **Docker pulls** — GHCR does not expose package download counts; that counter only exists for Docker Hub. The image badge links to the package page instead.
- **Issue counters / last-commit** — noise for a visitor deciding whether to try the thing.

## Check

All five URLs verified against shields.io (200, correct text: `build: passing`, `release: v1.0.0`, `license: AGPL-3.0`). Worth one look at the rendered README in both GitHub themes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)