### PR TITLE
chore: drop dead attachments.task_id column

### DIFF
--- a/server/src/db/migrate.test.ts
+++ b/server/src/db/migrate.test.ts
@@ -13,6 +13,37 @@ import { migrate } from './migrate.js';
 
 const migrationsDir = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
 
+const migrationFiles = (): string[] =>
+  readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).sort();
+
+/*
+  Applying a single migration to a database that already holds data — the
+  case an empty-database smoke test cannot reach, and the one that matters
+  for a real hub being upgraded.
+
+  Rather than re-implementing the runner (and drifting from how it wraps
+  each file in a transaction), the target and everything after it are
+  pre-recorded as applied so the real migrate() stops short; then the
+  target's row is removed and migrate() runs again, applying exactly it.
+  Pre-recording the tail as well keeps this correct when a 020 lands.
+*/
+function applyBefore(db: ReturnType<typeof openDatabase>, target: string): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      name       TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  const hold = db.prepare('INSERT INTO _migrations (name) VALUES (?)');
+  for (const file of migrationFiles().filter((f) => f >= target)) hold.run(file);
+  runWithDb(db, () => migrate());
+}
+
+function applyOnly(db: ReturnType<typeof openDatabase>, target: string): void {
+  db.prepare('DELETE FROM _migrations WHERE name = ?').run(target);
+  runWithDb(db, () => migrate());
+}
+
 describe('migrations', () => {
   it('all apply on an empty database and exactly once', () => {
     const db = openDatabase(':memory:');
@@ -60,6 +91,87 @@ describe('migrations', () => {
       .prepare('SELECT id FROM calendars WHERE id = ?')
       .get('00000000-0000-4000-8000-000000000201');
     expect(shared, 'missing the shared calendar').toBeTruthy();
+    db.close();
+  });
+
+  /*
+    019 drops attachments.task_id. Dropping a column rewrites the table, so
+    the risk is not "does the statement parse" — it is what happens to the
+    rows, the remaining foreign keys and the other indexes on a database
+    that is already in use. An empty-database run proves none of that.
+  */
+  it('019 drops attachments.task_id without disturbing existing rows', () => {
+    const db = openDatabase(':memory:');
+    const TARGET = '019_drop_attachment_task_id.sql';
+    applyBefore(db, TARGET);
+
+    const columnsOf = (table: string) =>
+      (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((c) => c.name);
+
+    // Precondition: the column is there to be dropped, or this test proves nothing
+    expect(columnsOf('attachments')).toContain('task_id');
+
+    // A hub in use: a note with two files, one of them carrying the legacy
+    // task_id — a real foreign key, so the row exercises the constraint the
+    // table rewrite has to preserve
+    const project = db.prepare('SELECT id FROM projects LIMIT 1').get() as { id: string };
+    db.prepare(
+      `INSERT INTO tasks (id, project_id, level, title, status, priority, position)
+       VALUES ('t1', ?, 0, 'Legacy task', 'todo', 'normal', 1)`,
+    ).run(project.id);
+    db.prepare(
+      `INSERT INTO notes (id, title, body_md, created_at, updated_at)
+       VALUES ('n1', 'Note', 'body', '2026-01-01', '2026-01-01')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO attachments (id, filename, mime, size_bytes, storage_path, note_id, task_id, created_at)
+       VALUES ('a1', 'receipt.jpg', 'image/jpeg', 1234, '2026-01/x.jpg', 'n1', 't1', '2026-01-01')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO attachments (id, filename, mime, size_bytes, storage_path, note_id, created_at)
+       VALUES ('a2', 'doc.pdf', 'application/pdf', 999, '2026-01/y.pdf', 'n1', '2026-01-01')`,
+    ).run();
+
+    const foreignKeysBefore = (
+      db.prepare(`SELECT count(*) AS n FROM pragma_foreign_key_list('attachments')`).get() as {
+        n: number;
+      }
+    ).n;
+
+    applyOnly(db, TARGET);
+
+    // The column and its index are gone
+    expect(columnsOf('attachments')).not.toContain('task_id');
+    const indexes = (
+      db
+        .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'attachments'`)
+        .all() as { name: string }[]
+    ).map((r) => r.name);
+    expect(indexes).not.toContain('idx_attachments_task');
+
+    // Everything else survived the rewrite: rows, their values, the other
+    // indexes, the remaining foreign keys, and the task that was referenced
+    expect(
+      db.prepare('SELECT id, filename, note_id FROM attachments ORDER BY id').all(),
+    ).toEqual([
+      { id: 'a1', filename: 'receipt.jpg', note_id: 'n1' },
+      { id: 'a2', filename: 'doc.pdf', note_id: 'n1' },
+    ]);
+    expect(indexes).toContain('idx_attachments_note');
+    expect(indexes).toContain('idx_attachments_transaction');
+    expect(
+      (
+        db.prepare(`SELECT count(*) AS n FROM pragma_foreign_key_list('attachments')`).get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(foreignKeysBefore - 1);
+    expect(db.prepare(`SELECT id FROM tasks WHERE id = 't1'`).get()).toBeTruthy();
+
+    // And the chain is complete — nothing was left pending by the two-step run
+    expect(
+      (db.prepare('SELECT count(*) AS n FROM _migrations').get() as { n: number }).n,
+    ).toBe(migrationFiles().length);
     db.close();
   });
 });

--- a/server/src/db/migrations/019_drop_attachment_task_id.sql
+++ b/server/src/db/migrations/019_drop_attachment_task_id.sql
@@ -1,0 +1,11 @@
+-- attachments.task_id was never written or read by any route: uploads only
+-- ever attach to a note (see attachments.ts), and no endpoint exists to
+-- attach a file to a task. The schema is our only source of truth for what
+-- the app can actually do, so a dead column here reads as a capability that
+-- doesn't exist — drop it, along with its now-pointless index.
+--
+-- SQLite has supported DROP COLUMN natively since 3.35 (2021); the
+-- better-sqlite3 build we bundle ships a much newer SQLite, so this is a
+-- plain in-place ALTER, no table-rebuild dance needed.
+DROP INDEX IF EXISTS idx_attachments_task;
+ALTER TABLE attachments DROP COLUMN task_id;

--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -37,7 +37,6 @@ interface AttachmentRow {
   size_bytes: number;
   storage_path: string;
   note_id: string | null;
-  task_id: string | null;
   transaction_id: string | null;
 }
 


### PR DESCRIPTION
## Why

`attachments.task_id` and its index `idx_attachments_task` were never written or read by any route — uploads only ever attach to a note (`attachments.ts`), and no endpoint exists to attach a file to a task. The `AttachmentRow` interface carried a matching `task_id` member that was likewise dead.

The schema is our only source of truth for what the app can actually do, so a dead column reads as a capability that doesn't exist. Removed all three.

Grepped the whole repo (server, web, docs) for `task_id` in an attachments context — found nothing else to clean up. The only other `task_id` hits are unrelated: `task_note_links.task_id` (still active, links tasks to notes) and `mail_messages.task_id` (added in migration 015, actively used by the mail-to-task feature in `routes/mail.ts` and `web/src/pages/Mail.tsx`). Neither was touched.

## What

- New migration `server/src/db/migrations/019_drop_attachment_task_id.sql`: `DROP INDEX IF EXISTS idx_attachments_task` + `ALTER TABLE attachments DROP COLUMN task_id`. Bundled better-sqlite3 ships SQLite 3.49.2, well past the 3.35 minimum for native `DROP COLUMN`.
- Removed `task_id` from `AttachmentRow` in `server/src/routes/attachments.ts`.

The migration applies automatically at startup, in filename order, same as every other migration.

## Test plan

- [x] `npm run typecheck` — clean (server + web)
- [x] `npm run lint` — clean
- [x] `npm test` (server) — 9 files, 73 tests passed; migration chain (001→019) applies cleanly against `:memory:`

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)