### PR TITLE
fix: give the first admin a distinct avatar color

### DIFF
--- a/server/src/routes/setup.test.ts
+++ b/server/src/routes/setup.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildTestApp } from '../test-harness.js';
+import { USER_COLORS } from './setup.js';
+
+/*
+  Issue #48: the admin created by POST /api/auth/setup used to skip the
+  color column, so the row took the schema default (#2E6F8E) — a
+  near-twin of USER_COLORS[0] (#1F6E8C), the color the very first
+  invited member gets. A two-person household ended up with matching
+  avatars. The fix binds nextColor() on the admin insert too, so the
+  admin should land on a real palette entry, not the schema default.
+
+  Called directly through app.inject rather than the join() harness
+  helper: join() exists for guard tests and inserts a user without going
+  through the setup route at all, which is exactly the code path under
+  test here. The harness's database starts empty, so this is the one
+  request that is allowed to hit /api/auth/setup and succeed.
+*/
+describe('POST /api/auth/setup', () => {
+  it('gives the admin a real palette color, not the schema default', async () => {
+    const hub = await buildTestApp();
+
+    const res = await hub.app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      payload: {
+        name: 'Alex',
+        email: 'alex@hub.local',
+        password: 'correct horse battery staple',
+      },
+    });
+    expect(res.statusCode).toBe(201);
+
+    const row = hub.db.prepare('SELECT color FROM users').get() as { color: string };
+    expect(row.color).not.toBe('#2E6F8E');
+    expect(USER_COLORS).toContain(row.color);
+    expect(row.color).toBe(USER_COLORS[0]);
+  });
+});

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -12,7 +12,7 @@ import { log } from '../lib/log.js';
  * the schema default alone the whole family came out the same blue —
  * "Mom" and "Daughter" indistinguishable at a glance.
  */
-const USER_COLORS = ['#1F6E8C', '#C4842B', '#6B8F5E', '#8C4A6B', '#7A5C9E', '#4A6B8C'];
+export const USER_COLORS = ['#1F6E8C', '#C4842B', '#6B8F5E', '#8C4A6B', '#7A5C9E', '#4A6B8C'];
 
 function nextColor(): string {
   const used = (db.prepare('SELECT color FROM users').all() as { color: string }[]).map((r) =>
@@ -86,10 +86,14 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
     const created = db.transaction(() => {
       const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
       if (n > 0) return false;
+      // Explicit color: the schema default (#2E6F8E) is a near-twin of
+      // USER_COLORS[0] (#1F6E8C) — without this, the palette that gives
+      // invited members distinct colors never covered the admin, so a
+      // two-person household still ended up with two look-alike avatars.
       db.prepare(
-        `INSERT INTO users (id, email, name, role, password_hash, must_change_password, created_at)
-         VALUES (?, ?, ?, 'admin', ?, 0, ?)`,
-      ).run(userId, parsed.data.email, parsed.data.name, passwordHash, now());
+        `INSERT INTO users (id, email, name, role, password_hash, color, must_change_password, created_at)
+         VALUES (?, ?, ?, 'admin', ?, ?, 0, ?)`,
+      ).run(userId, parsed.data.email, parsed.data.name, passwordHash, nextColor(), now());
       return true;
     })();
 


### PR DESCRIPTION
## Why

`POST /api/auth/setup` inserts the administrator without a `color`, so the row falls back to the schema default `#2E6F8E`. That default is a near-twin of `#1F6E8C` — `USER_COLORS[0]`, the palette color `nextColor()` hands the first invited member. A two-person household therefore gets two avatars that look identical at a glance.

## Repro (from the issue)

1. Run `POST /api/auth/setup` on a fresh database → admin gets `#2E6F8E`.
2. Invite and accept a family member → they get `#1F6E8C` via `nextColor()`.
3. Compare the two colors: visually indistinguishable.

## Fix

`server/src/routes/setup.ts`: the admin `INSERT` now includes `color` and binds `nextColor()`, exactly like the invite-join route already does. On an empty database `nextColor()` returns `USER_COLORS[0]` (`#1F6E8C`), so the admin gets that and the first invited member gets the next one (`#C4842B`) — clearly distinct. Added an inline comment explaining why the schema default can't be trusted here. Also exported `USER_COLORS` from `setup.ts` so the test can assert palette membership without duplicating the list.

**Scope**: only affects newly created hubs. Existing installs keep whatever color their admin already has — this does not touch existing rows.

## Test

Added `server/src/routes/setup.test.ts`, calling `POST /api/auth/setup` directly through `hub.app.inject` (via the existing `buildTestApp()` harness from `test-harness.ts`, in-memory DB, migrations applied). This is the one request allowed to hit that route in a fresh harness — `join()` is a harness shortcut for guard tests and bypasses the setup route entirely, which is exactly the code path under test here. The test asserts the created admin's `color` is not the schema default and is a member of `USER_COLORS` (specifically `USER_COLORS[0]` on an empty DB).

`npm run typecheck && npm run lint && npm test` — all green (server 74/74, web 37/37).

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)