### PR TITLE
fix: let a forced password change sign out, settle two auth edges

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,13 @@ import { log, logLevel } from './lib/log.js';
 
 migrate();
 pruneSessions();
+// Boot-only pruning was enough while every deploy restarted the process,
+// but a home server can stay up for months — repeat daily so expiry and
+// the 30-day idle rule actually retire rows from the Devices list.
+// Nothing leaks either way (userForToken enforces expiry); this is about
+// the table and the list not growing stale. Same pattern as the attempt
+// and MFA sweeps in routes/auth.ts.
+setInterval(pruneSessions, 24 * 60 * 60_000).unref();
 
 // Production without Secure cookies is almost certainly a forgotten flag,
 // not intent: the session cookie would then travel over plaintext too

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -133,8 +133,17 @@ export async function authenticate(req: FastifyRequest, reply: FastifyReply): Pr
   }
   touchSession(token!, req.ip);
 
-  // Until the password is changed, only the change endpoint is available
-  if (user.must_change_password && path !== '/api/auth/change-password' && path !== '/api/auth/me') {
+  // Until the password is changed, only the change endpoint is available —
+  // plus the way out. Signing out is not "doing something else with the
+  // account": a person parked on the change-password screen ("this is not
+  // my account", "later") must be able to leave, and the first sign-out
+  // button added to that screen would otherwise hit a 403 about passwords.
+  if (
+    user.must_change_password &&
+    path !== '/api/auth/change-password' &&
+    path !== '/api/auth/me' &&
+    path !== '/api/auth/logout'
+  ) {
     return reply.code(403).send({ error: 'Change your password first', code: 'must_change_password' });
   }
 
@@ -180,7 +189,7 @@ export function announceSetupIfEmpty(): void {
   ]);
 }
 
-/** Expired sessions are removed at startup so the table doesn't grow forever. */
+/** Expired sessions are removed at startup and once a day thereafter. */
 export function pruneSessions(): void {
   const now = new Date();
   db.prepare('DELETE FROM sessions WHERE expires_at <= ?').run(now.toISOString());

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -156,6 +156,12 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(401).send({ error: 'Wrong login or password' });
     }
 
+    // Only the per-login counter clears on success. The ip: counter
+    // deliberately survives: it exists to catch a dictionary sweep, and if
+    // success reset it, anyone holding one valid account behind the same
+    // address could interleave their own sign-ins to keep the sweep alive
+    // forever. A family's honest typos ride out the 15-minute window
+    // instead — the 20-per-address threshold is sized for exactly that.
     attempts.delete(email);
 
     // Second factor: the password alone opens nothing when TOTP is


### PR DESCRIPTION
## Why

Both from the v1.0.0 review (#59, #65): one real trap and two undocumented decisions in the login brakes and session pruning.

## What

- **#59** — `/api/auth/logout` joins the `must_change_password` allowlist. The gate should stop an account from *doing* things, not from leaving. No UI reaches the path today, which is precisely the trap: the first sign-out button added to that screen would 403 with a message about passwords.
- **#65a** — the per-IP failure counter now *documents* that success deliberately does not clear it: if it did, one valid account behind the family NAT could interleave sign-ins to keep a dictionary sweep alive. Chose the comment over the clear — the asymmetric thresholds (5/login, 20/address) already keep a family from locking itself out.
- **#65b** — `pruneSessions()` repeats daily (`setInterval(...).unref()`, same pattern as the attempt/MFA sweeps) instead of boot-only. Nothing leaked — expiry is enforced in `userForToken` — this is about the table and the Devices list on a long-lived home server.

Closes #59, closes #65.

## Verified

typecheck + lint + server tests (73) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)