### PR TITLE
fix: template expansion — interface-language placeholders, inherited privacy

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -156,7 +156,7 @@ Common currencies (EUR, RSD, USD, GBP, CHF, PLN, CZK, SEK, HUF) are one click wh
 
 Balances are computed, not stored: opening balance plus movements. A stored balance drifts from history after any backdated edit.
 
-Privacy is attached to the account, not the transaction. An account is shared or personal; a personal account's transactions and balance are visible only to the owner. There is no separate "hidden expense" flag, and thanks to that the shared account's balance is identical for everyone — there are no hidden withdrawals from it. A transfer from a shared account to a personal one is visible to the other person as an amount, without the account name or details: money leaving a shared account cannot be hidden, or the balance would be wrong.
+Privacy is attached to the account, not the transaction. An account is shared or personal; a personal account's transactions and balance are visible only to the owner. There is no separate "hidden expense" flag, and thanks to that the shared account's balance is identical for everyone — there are no hidden withdrawals from it. A transfer from a shared account to a personal one is visible to the other person as an amount, without the account name or details: money leaving a shared account cannot be hidden, or the balance would be wrong. The free-text note on such a transfer stays visible along with the amount — it is part of the shared account's transaction, not of the masked destination. Write the details you want private in the personal account's own records, not in the transfer note.
 
 A category with history is hidden, not deleted — otherwise past reports would lose their labels.
 

--- a/server/src/routes/guards.test.ts
+++ b/server/src/routes/guards.test.ts
@@ -249,3 +249,42 @@ describe('an event on a personal calendar', () => {
     expect((await as(bobCookie, 'DELETE', `/api/events/${eventId}`)).statusCode).toBe(404);
   });
 });
+
+describe('a note expanded from a private template', () => {
+  it('inherits the template privacy instead of publishing it (#50)', async () => {
+    const created = await as(aliceCookie, 'POST', '/api/notes', {
+      title: 'Gift planning',
+      body_md: 'the thing we discussed',
+      visibility: 'private',
+      is_template: true,
+    });
+    const templateId = created.json<{ id: string }>().id;
+
+    // No explicit visibility in the request — the trap from the issue
+    const note = await as(aliceCookie, 'POST', '/api/notes', {
+      template_id: templateId,
+    });
+    expect(note.statusCode).toBe(201);
+    const { id: noteId, visibility } = note.json<{ id: string; visibility: string }>();
+    expect(visibility).toBe('private');
+
+    // And the receipt: Bob cannot see it
+    const bob = await as(bobCookie, 'GET', `/api/notes/${noteId}`);
+    expect(bob.statusCode).toBe(404);
+  });
+
+  it('an explicit choice in the request still wins', async () => {
+    const created = await as(aliceCookie, 'POST', '/api/notes', {
+      title: 'Shopping list frame',
+      visibility: 'private',
+      is_template: true,
+    });
+    const templateId = created.json<{ id: string }>().id;
+
+    const note = await as(aliceCookie, 'POST', '/api/notes', {
+      template_id: templateId,
+      visibility: 'shared',
+    });
+    expect(note.json<{ visibility: string }>().visibility).toBe('shared');
+  });
+});

--- a/server/src/routes/notes.test.ts
+++ b/server/src/routes/notes.test.ts
@@ -19,3 +19,23 @@ describe('excerptOf', () => {
     expect(excerptOf('я'.repeat(500))).toHaveLength(120);
   });
 });
+
+describe('applyPlaceholders', () => {
+  it('formats {{date}} in the requested locale, English without one', async () => {
+    const { applyPlaceholders } = await import('./notes.js');
+    const russian = applyPlaceholders('{{date}}', 'Alex', 'ru-RU');
+    const english = applyPlaceholders('{{date}}', 'Alex');
+    // Month names are the tell: Cyrillic in ru-RU, Latin otherwise.
+    // Exact strings would chase the clock; the alphabet does not.
+    expect(russian).toMatch(/[а-яё]/i);
+    expect(english).not.toMatch(/[а-яё]/i);
+    // The Russian placeholder KEYS keep working regardless of locale —
+    // they are data compatibility, not language choice
+    expect(applyPlaceholders('{{автор}}', 'Alex')).toBe('Alex');
+  });
+
+  it('survives a malformed locale tag instead of throwing', async () => {
+    const { applyPlaceholders } = await import('./notes.js');
+    expect(() => applyPlaceholders('{{date}}', 'Alex', 'not a tag')).not.toThrow();
+  });
+});

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -380,20 +380,30 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
 
     let body = normalizeWikiLinks(d.body_md ?? '');
     let titleFromTemplate: string | null = null;
+    let inheritedVisibility: 'private' | null = null;
 
     if (d.template_id) {
       // A template obeys the same visibility as a regular note: someone
       // else's private template can't be expanded even knowing its id
       const template = db
         .prepare(
-          `SELECT title, body_md FROM notes
+          `SELECT title, body_md, visibility FROM notes
             WHERE id = ? AND is_template = 1
               AND (visibility = 'shared' OR owner_id = ?)`,
         )
-        .get(d.template_id, userId ?? '') as { title: string; body_md: string } | undefined;
+        .get(d.template_id, userId ?? '') as
+        | { title: string; body_md: string; visibility: 'shared' | 'private' }
+        | undefined;
       if (!template) return reply.code(400).send({ error: 'Template not found' });
       body = applyPlaceholders(template.body_md, authorName, d.locale);
       titleFromTemplate = applyPlaceholders(template.title, authorName, d.locale);
+      // A template is private because its CONTENT is private — a journal
+      // structure, a medical log. Expanding it must not silently publish
+      // that content to the family: without an explicit choice in the
+      // request, the note inherits the template's visibility. (#50)
+      if (d.visibility === undefined && template.visibility === 'private') {
+        inheritedVisibility = 'private';
+      }
     }
 
     if (d.daily_date) {
@@ -426,7 +436,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
       title,
       body,
       d.folder_id ?? null,
-      d.visibility ?? 'shared',
+      d.visibility ?? inheritedVisibility ?? 'shared',
       userId,
       d.daily_date ?? null,
       d.is_template ? 1 : 0,

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -113,22 +113,46 @@ function resolveIncoming(noteId: string, title: string): void {
 }
 
 /**
+ * The client names the locale for {{date}}/{{time}} (it is the only side
+ * that knows the interface language); anything absent or unformattable
+ * falls back to English — the source language, and what a self-hoster who
+ * never chose Russian must get. Intl throws RangeError on a malformed tag
+ * rather than falling back, hence the probe.
+ */
+function resolveLocale(locale: string | undefined): string {
+  if (!locale) return 'en-GB';
+  try {
+    new Intl.DateTimeFormat(locale);
+    return locale;
+  } catch {
+    return 'en-GB';
+  }
+}
+
+/**
  * Template placeholders. Expanded once, at note creation: after that it
  * is plain editable text. Live, recomputed values are deliberately absent
  * here — a note must mean the same thing a year later.
+ *
+ * The Russian placeholder KEYS ({{дата}}, {{время}}, {{автор}}) are
+ * backwards compatibility for pre-English-first templates and stay; only
+ * the output locale follows the request (#47).
  */
-export function applyPlaceholders(text: string, authorName: string): string {
+export function applyPlaceholders(text: string, authorName: string, locale?: string): string {
   const date = new Date();
+  const tag = resolveLocale(locale);
+  const longDate = new Intl.DateTimeFormat(tag, { dateStyle: 'long' }).format(date);
+  const shortTime = new Intl.DateTimeFormat(tag, { timeStyle: 'short' }).format(date);
   const values: Record<string, string> = {
-    дата: new Intl.DateTimeFormat('ru-RU', { dateStyle: 'long' }).format(date),
-    date: new Intl.DateTimeFormat('ru-RU', { dateStyle: 'long' }).format(date),
+    дата: longDate,
+    date: longDate,
     // By the local clock, like the date and time placeholders: toISOString()
     // would give the Greenwich date, and a note created at 00:30 would be
     // stamped with yesterday
     изо: today(),
     iso: today(),
-    время: new Intl.DateTimeFormat('ru-RU', { timeStyle: 'short' }).format(date),
-    time: new Intl.DateTimeFormat('ru-RU', { timeStyle: 'short' }).format(date),
+    время: shortTime,
+    time: shortTime,
     автор: authorName,
     author: authorName,
   };
@@ -178,6 +202,9 @@ const createInput = z.object({
   folder_id: z.string().uuid().nullable().optional(),
   visibility: z.enum(['shared', 'private']).optional(),
   template_id: z.string().uuid().optional(),
+  // BCP-47-ish tag for {{date}}/{{time}} expansion; validated leniently,
+  // resolveLocale() probes the rest
+  locale: z.string().regex(/^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$/).optional(),
   is_template: z.boolean().optional(),
   daily_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
@@ -365,8 +392,8 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
         )
         .get(d.template_id, userId ?? '') as { title: string; body_md: string } | undefined;
       if (!template) return reply.code(400).send({ error: 'Template not found' });
-      body = applyPlaceholders(template.body_md, authorName);
-      titleFromTemplate = applyPlaceholders(template.title, authorName);
+      body = applyPlaceholders(template.body_md, authorName, d.locale);
+      titleFromTemplate = applyPlaceholders(template.title, authorName, d.locale);
     }
 
     if (d.daily_date) {

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -1,4 +1,4 @@
-import { t } from '../lib/i18n';
+import { intlLocale, t } from '../lib/i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { api } from '../lib/api';
@@ -240,7 +240,9 @@ export function Notes() {
       folder_id:
         folderId && folderId !== 'none' && folderId !== 'templates' ? folderId : null,
       ...(inTemplates ? { is_template: true } : {}),
-      ...(templateId ? { template_id: templateId } : {}),
+      // The locale rides along only where placeholders expand — the server
+      // formats {{date}}/{{time}} in the interface language (#47)
+      ...(templateId ? { template_id: templateId, locale: intlLocale } : {}),
     });
     await loadNotes();
     if (inTemplates) await loadTemplates();
@@ -269,7 +271,7 @@ export function Notes() {
       const created = await api.post<Note>('/notes', {
         daily_date: date,
         title: date,
-        ...(template ? { template_id: template.id } : {}),
+        ...(template ? { template_id: template.id, locale: intlLocale } : {}),
       });
       await loadNotes();
       await openNote(created.id);


### PR DESCRIPTION
## Why

Three findings from the v1.0.0 QA pass, one branch because #47 and #50 edit the same `template_id` block of the notes create route.

## What

- **#47** — `applyPlaceholders` formatted `{{date}}`/`{{time}}` with a hardcoded `ru-RU` for every hub in every language (an English-first leftover; permanent, since expansion happens once). The client — the only side that knows the interface language — now sends its locale alongside `template_id`; the server probes the tag against `Intl` and falls back to English, the source language. The Russian placeholder *keys* stay: data compatibility, not language choice.
- **#50** — a note expanded from a **private** template inherited `shared` by default, silently publishing the template's content. Decision (Denis): inherit the template's visibility when the request makes no explicit choice; an explicit `visibility` still wins. Guard tests cover both directions, including the other member's 404.
- **#51** — decision (Denis): the note on a shared→personal transfer **stays visible** — it is part of the shared account's transaction, not of the masked destination. Now documented in `docs/features.md` instead of implied.

## Tests

New `applyPlaceholders` locale tests (Cyrillic-vs-Latin month, malformed tag survives) and two privacy-inheritance guard tests. 77 server + 37 web green, typecheck + lint clean.

Closes #47, closes #50, closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)