### PR TITLE
perf: expand recurrences from the window, not from the series start

### DIFF
--- a/server/src/lib/recurrence.test.ts
+++ b/server/src/lib/recurrence.test.ts
@@ -58,3 +58,60 @@ describe('occurrenceAfter', () => {
     expect(occurrenceAfter('2026-01-15', '2026-02-14', 'FREQ=MONTHLY;INTERVAL=1')).toBe('2026-02-15');
   });
 });
+
+describe('window jump (#62)', () => {
+  /*
+    The jump must be invisible: for every rule and window the output has
+    to equal what the from-zero walk produced. The reference here IS that
+    walk — stepping k = 0,1,2,… through the public occurrence semantics
+    (expand each occurrence into a one-day window, which cannot jump).
+  */
+  function reference(anchor: string, rule: string, from: string, to: string): string[] {
+    const out: string[] = [];
+    let cursor = anchor;
+    for (let guard = 0; guard < 5000 && cursor <= to; guard++) {
+      if (cursor >= from) out.push(cursor);
+      const next = occurrenceAfter(anchor, cursor, rule);
+      if (!next) break;
+      cursor = next;
+    }
+    return out;
+  }
+
+  const cases: [string, string, string, string][] = [
+    // a daily series anchored years back — the motivating case
+    ['2023-08-01', 'FREQ=DAILY;INTERVAL=1', '2026-08-01', '2026-08-31'],
+    ['2023-08-15', 'FREQ=DAILY;INTERVAL=3', '2026-08-01', '2026-08-31'],
+    ['2022-01-03', 'FREQ=WEEKLY;INTERVAL=1', '2026-08-01', '2026-08-31'],
+    ['2022-01-03', 'FREQ=WEEKLY;INTERVAL=2', '2026-08-10', '2026-09-10'],
+    // month-length clamping across the jump: "every 31st"
+    ['2020-01-31', 'FREQ=MONTHLY;INTERVAL=1', '2026-02-01', '2026-02-28'],
+    ['2020-01-31', 'FREQ=MONTHLY;INTERVAL=1', '2026-03-01', '2026-03-31'],
+    ['2020-01-31', 'FREQ=MONTHLY;INTERVAL=2', '2026-01-01', '2026-12-31'],
+    // leap-day yearly series read in a non-leap year
+    ['2020-02-29', 'FREQ=YEARLY;INTERVAL=1', '2026-01-01', '2026-12-31'],
+    ['2020-02-29', 'FREQ=YEARLY;INTERVAL=2', '2026-01-01', '2026-12-31'],
+    // window before the series starts, and window containing the anchor
+    ['2026-08-15', 'FREQ=DAILY;INTERVAL=1', '2026-08-01', '2026-08-10'],
+    ['2026-08-15', 'FREQ=WEEKLY;INTERVAL=1', '2026-08-01', '2026-08-31'],
+    // window boundary exactly on an occurrence
+    ['2026-01-01', 'FREQ=DAILY;INTERVAL=7', '2026-01-15', '2026-01-15'],
+  ];
+
+  it('matches the from-zero walk for every rule and window', () => {
+    for (const [anchor, rule, from, to] of cases) {
+      expect(expandOccurrences(anchor, rule, from, to), `${rule} @ ${anchor} in ${from}..${to}`).toEqual(
+        reference(anchor, rule, from, to),
+      );
+    }
+  });
+
+  it('an old daily series no longer hits the step ceiling', () => {
+    // 60 years of daily occurrences ≈ 21 900 steps — past the old
+    // MAX_STEPS truncation. With the jump the window must still fill.
+    const out = expandOccurrences('1966-01-01', 'FREQ=DAILY;INTERVAL=1', '2026-08-01', '2026-08-31');
+    expect(out).toHaveLength(31);
+    expect(out[0]).toBe('2026-08-01');
+    expect(out.at(-1)).toBe('2026-08-31');
+  });
+});

--- a/server/src/lib/recurrence.ts
+++ b/server/src/lib/recurrence.ts
@@ -121,11 +121,14 @@ export function expandOccurrences(
   if (!rec) return anchor >= from && anchor <= to ? [anchor] : [];
 
   const result: string[] = [];
-  // A ceiling on the step count: protection against "daily since 1990"
-  // and against a rule that somehow fails to move the date forward.
+  // A ceiling on the step count: protection against a rule that somehow
+  // fails to move the date forward. Thanks to the jump below it no longer
+  // doubles as a truncation of old series — iterations are proportional
+  // to the occurrences inside the window, not to the age of the series.
   const MAX_STEPS = 20_000;
 
-  for (let k = 0; k < MAX_STEPS; k++) {
+  const start = firstStepNear(anchor, rec, from);
+  for (let k = start; k < start + MAX_STEPS; k++) {
     const date = k === 0 ? anchor : occurrence(anchor, rec, k);
     if (!date) break;
     if (date > to) break;
@@ -135,4 +138,38 @@ export function expandOccurrences(
     }
   }
   return result;
+}
+
+function daysBetween(a: string, b: string): number {
+  return Math.round((Date.parse(`${b}T00:00:00Z`) - Date.parse(`${a}T00:00:00Z`)) / 86_400_000);
+}
+
+/**
+ * The step index at (or just before) the window start, so expansion is
+ * O(occurrences in the window) rather than O(age of the series) — a daily
+ * series anchored three years back used to burn ~1100 discarded
+ * iterations per calendar request (#62).
+ *
+ * DAILY and WEEKLY advance by a fixed day count, so the first step inside
+ * the window is exact: ceil(days / step). MONTHLY and YEARLY clamp the
+ * anchor day to each month's length, which makes an exact formula fiddly
+ * — a month-count estimate one step early is used instead, and the loop
+ * skips the at most one occurrence that lands before the window.
+ */
+function firstStepNear(anchor: string, rec: Recurrence, from: string): number {
+  if (from <= anchor) return 0;
+  switch (rec.freq) {
+    case 'DAILY':
+      return Math.ceil(daysBetween(anchor, from) / rec.interval);
+    case 'WEEKLY':
+      return Math.ceil(daysBetween(anchor, from) / (7 * rec.interval));
+    case 'MONTHLY':
+    case 'YEARLY': {
+      const months =
+        (Number(from.slice(0, 4)) - Number(anchor.slice(0, 4))) * 12 +
+        (Number(from.slice(5, 7)) - Number(anchor.slice(5, 7)));
+      const step = rec.freq === 'MONTHLY' ? rec.interval : 12 * rec.interval;
+      return Math.max(0, Math.floor(months / step) - 1);
+    }
+  }
 }


### PR DESCRIPTION
## Why

#62: `expandOccurrences` was O(age of the series) per request — a daily series anchored three years back burned ~1100 discarded iterations on every calendar/dashboard load, and the `MAX_STEPS` ceiling silently truncated daily series older than ~55 years.

## What

`firstStepNear()` jumps to the first step at (or just before) the window: exact `ceil` division for DAILY/WEEKLY, month-count estimate minus one step for MONTHLY/YEARLY (day-of-month clamping makes exact fiddly; one occurrence early is harmless — the loop skips it). `MAX_STEPS` remains purely a guard against a non-advancing rule.

## Tests

An equivalence matrix: for 12 rule/window combinations the jumped expansion must equal the from-zero walk (reference rebuilt through `occurrenceAfter` in the test) — including "every 31st" clamping read years later and a Feb-29 yearly series in a non-leap year. Plus the formerly-truncated case: a 60-year-old daily series now fills its window. 11 recurrence tests green, full suite + typecheck + lint clean.

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)