### PR TITLE
fix: theme the screens that render before sign-in

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../lib/auth';
 import { applyUpdate, setupPwa } from '../lib/pwa';
 import { QuickAdd } from './QuickAdd';
 import { GlobalSearch, SearchTrigger } from './GlobalSearch';
+import { applyTheme, initialDark, persistTheme } from '../lib/theme';
 
 interface NavItem {
   to: string;
@@ -98,19 +99,26 @@ const SECONDARY: NavItem[] = [
   },
 ];
 
+// The class is already on the document by the time this mounts (lib/theme
+// applies it at import, so the pre-login screens are themed too) — the
+// hook only mirrors it into state and flips it. Persisting stays here, on
+// the explicit toggle: startup must not write a value the person never
+// chose, or "follow the system" would silently become sticky.
 function useTheme() {
-  const [dark, setDark] = useState(() => {
-    const saved = localStorage.getItem('hub.theme');
-    if (saved) return saved === 'dark';
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
-  });
+  const [dark, setDark] = useState(initialDark);
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', dark);
-    localStorage.setItem('hub.theme', dark ? 'dark' : 'light');
+    applyTheme(dark);
   }, [dark]);
 
-  return { dark, toggle: () => setDark((v) => !v) };
+  return {
+    dark,
+    toggle: () => {
+      const next = !dark;
+      setDark(next);
+      persistTheme(next);
+    },
+  };
 }
 
 function ThemeIcon({ dark, className }: { dark: boolean; className: string }) {

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,39 @@
+/*
+  The theme is applied here, at module scope, not inside AppShell: the
+  sign-in, first-run, invite and forced-password screens all render
+  before the shell ever mounts, and used to flash full-brightness light
+  regardless of the saved choice or the system preference (#52). Same
+  shape as i18n.ts setting document.documentElement.lang — the things
+  the whole document needs must not wait for a session.
+
+  Applying at import time also removes the brief flash of the wrong
+  theme on load for signed-in users: the class is set before React
+  renders anything.
+*/
+
+const KEY = 'hub.theme';
+
+export function initialDark(): boolean {
+  // Private-mode Safari throws on storage access rather than returning null
+  try {
+    const saved = localStorage.getItem(KEY);
+    if (saved) return saved === 'dark';
+  } catch {
+    /* fall through to the system preference */
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+export function applyTheme(dark: boolean): void {
+  document.documentElement.classList.toggle('dark', dark);
+}
+
+export function persistTheme(dark: boolean): void {
+  try {
+    localStorage.setItem(KEY, dark ? 'dark' : 'light');
+  } catch {
+    /* nothing to persist to — the choice just will not survive a reload */
+  }
+}
+
+applyTheme(initialDark());

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,8 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles.css';
+// Applies the saved/system theme before anything renders — see lib/theme.ts
+import './lib/theme';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Why

#52: `useTheme` lived inside `AppShell`, but `App.tsx` returns the sign-in / first-run / invite / forced-password screens before the shell mounts — so they were always light. First screen anyone sees; white flash at night; `first-run.png` could not match the dark doc screenshots.

## What

- `web/src/lib/theme.ts` applies the `dark` class at module scope (imported from `main.tsx`) — same shape as `i18n.ts` setting `document.documentElement.lang`. Also removes the flash of the wrong theme on load for signed-in users.
- `AppShell`'s hook now only mirrors state and flips it.
- Deliberate change riding along: `hub.theme` is written **only on an explicit toggle**. The old effect persisted on every mount, so "follow the system" silently became sticky.

## Verified live

- `hub.theme=dark` → sign-in screen renders dark (screenshot checked);
- no stored value → follows `prefers-color-scheme`, stores nothing.
- typecheck + lint + tests green.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)