### PR TITLE
fix: let Enter save a dialog after picking a chip

### DIFF
--- a/web/src/components/EntityDialog.tsx
+++ b/web/src/components/EntityDialog.tsx
@@ -155,6 +155,7 @@ export function EntityDialog({
                 <button
                   key={color}
                   type="button"
+                  data-chip
                   aria-label={t('Colour {color}', { color })}
                   onClick={() => setDraft({ ...draft, color })}
                   style={{ backgroundColor: color }}

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -335,6 +335,7 @@ export function EventDialog({
                     <button
                       key={m.id}
                       type="button"
+                      data-chip
                       onClick={() =>
                         setDraft({
                           ...draft,

--- a/web/src/components/TransactionDialog.tsx
+++ b/web/src/components/TransactionDialog.tsx
@@ -199,6 +199,7 @@ export function TransactionDialog({
             <button
               key={k}
               type="button"
+              data-chip
               onClick={() => {
                 setKind(k);
                 setDraft((d) => ({ ...d, category_id: '' }));
@@ -306,6 +307,7 @@ export function TransactionDialog({
                   <button
                     key={c.id}
                     type="button"
+                    data-chip
                     onClick={() =>
                       setDraft({ ...draft, category_id: draft.category_id === c.id ? '' : c.id })
                     }

--- a/web/src/lib/keys.ts
+++ b/web/src/lib/keys.ts
@@ -28,6 +28,14 @@ export function onEnter<T extends HTMLElement>(action: () => void) {
  * editor it inserts a line break, on a button or link it presses them.
  * The field-level onEnter handler fires first and sets defaultPrevented,
  * so submission never doubles.
+ *
+ * A button marked data-chip is the exception. A real mouse click focuses
+ * the clicked button, so after picking a category chip the focus sits on
+ * it and the button-skip ate the Enter that meant "save" — pressing it
+ * again just toggled the chip (#70). A chip is a selection, not an
+ * action: once it is picked, Enter means "done". preventDefault also
+ * stops the browser's own Enter-presses-the-focused-button, so the chip
+ * does not un-toggle while the dialog saves.
  */
 export function dialogKeys(submit: () => void, close: () => void) {
   return (e: globalThis.KeyboardEvent) => {
@@ -37,8 +45,10 @@ export function dialogKeys(submit: () => void, close: () => void) {
     }
     if (e.key !== 'Enter' || e.shiftKey || e.isComposing || e.defaultPrevented) return;
     const target = e.target as HTMLElement | null;
+    const isChip = target?.dataset['chip'] !== undefined;
     if (
       target &&
+      !isChip &&
       (target.tagName === 'TEXTAREA' ||
         target.tagName === 'BUTTON' ||
         target.tagName === 'A' ||


### PR DESCRIPTION
## Why

#70: type an amount, click a category, press Enter — nothing. A mouse click focuses the chip (a `<button>`), and `dialogKeys` skips Enter on any focused button, so Enter toggled the chip instead of saving. Skipping the category made Enter work, hence "intermittent".

## What

The distinction the issue asked for — action buttons vs selection chips — encoded as `data-chip`: `dialogKeys` treats marked buttons as inert for Enter (and `preventDefault` stops the browser's own Enter-presses-the-focused-button, so the chip does not un-toggle mid-save). Marked all four selection rows inside dialogs: transaction kind switcher, transaction category chips, entity-dialog palette, event participants. Footer buttons, links, and the remove-receipt cross keep the old skip — Enter on them still presses them. The quick-form chips live outside any dialog and are untouched.

## Verified live

Amount → click **Groceries** → Enter: transaction saved, dialog closed. Same flow with an empty amount: Enter surfaces `Enter an amount above zero` instead of silently toggling the chip. typecheck + lint + tests green.

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)