### PR TITLE
fix: one dialog shell — EventDialog joins Modal, scroll lock behind overlays

### DIFF
--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -19,6 +19,38 @@ import { clearBlankOnBlur } from '../lib/forms';
  * Plus they can't be tested automatically: the browser closes them itself.
  */
 
+/*
+  The page must not scroll behind an open overlay (#71). Nothing locked it:
+  the overlay covers the viewport but the document behind still scrolls,
+  and when the dialog itself has nothing to scroll (the common case) the
+  wheel chains straight through. Two halves, because either alone leaves
+  a case: this lock stops the document, and overscroll-contain on the
+  overlay stops a TALL dialog from chaining at its ends.
+
+  A counter rather than a boolean — a confirmation opened on top of a
+  dialog must not unlock the page when only it closes. The scrollbar-width
+  compensation keeps desktop layout from jumping when the bar disappears.
+*/
+let scrollLocks = 0;
+
+export function useScrollLock(): void {
+  useEffect(() => {
+    if (scrollLocks === 0) {
+      const scrollbar = window.innerWidth - document.documentElement.clientWidth;
+      document.body.style.overflow = 'hidden';
+      if (scrollbar > 0) document.body.style.paddingRight = `${scrollbar}px`;
+    }
+    scrollLocks += 1;
+    return () => {
+      scrollLocks -= 1;
+      if (scrollLocks === 0) {
+        document.body.style.overflow = '';
+        document.body.style.paddingRight = '';
+      }
+    };
+  }, []);
+}
+
 export function Modal({
   title,
   children,
@@ -35,6 +67,7 @@ export function Modal({
   onSubmit?: () => void;
   width?: string;
 }) {
+  useScrollLock();
   useEffect(() => {
     const onKey = dialogKeys(() => onSubmit?.(), onClose);
     window.addEventListener('keydown', onKey);
@@ -42,7 +75,9 @@ export function Modal({
   }, [onClose, onSubmit]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto px-5 py-20">
+    // The bottom padding folds in the safe area: on a notched phone the
+    // footer row otherwise sits partly under the home indicator (#83)
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto overscroll-contain px-5 pt-20 pb-[max(5rem,env(safe-area-inset-bottom))]">
       <button
         type="button"
         aria-label={t('Close')}

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -3,10 +3,10 @@ import { useEffect, useState } from 'react';
 import { api, type HouseholdMember, type Project } from '../lib/api';
 import { REMIND_OPTIONS, calendarName, type Calendar, type Occurrence } from '../lib/calendar';
 import { RECURRENCE_OPTIONS } from '../lib/tasks';
-import { dialogKeys, onEnter } from '../lib/keys';
+import { onEnter } from '../lib/keys';
 import { clearBlankOnBlur } from '../lib/forms';
 import { timeOf } from '../lib/format';
-import { useDialogs } from './Dialog';
+import { dialogGhost, Modal, useDialogs } from './Dialog';
 
 const field =
   'w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent';
@@ -75,16 +75,6 @@ export function EventDialog({
       .catch(() => {});
   }, [occurrence]);
 
-  // No dependency list: the subscription is refreshed on every render,
-  // so save always sees the current draft
-  useEffect(() => {
-    const onKey = dialogKeys(() => {
-      if (!busy) void save();
-    }, onClose);
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  });
-
   function payload() {
     return {
       calendar_id: draft.calendar_id,
@@ -145,18 +135,60 @@ export function EventDialog({
     onClose();
   }
 
+  /*
+    Through Modal, like every other dialog (#84): the hand-rolled shell
+    here is where the dialog defects kept landing — no way to close a new
+    event on a phone (#83), no scroll lock (#71). Cancel comes with the
+    footer convention; the inline onSubmit closure re-subscribes Modal's
+    key handler every render, so save always sees the current draft —
+    exactly what the old no-dependency-list effect did.
+  */
   return (
-    <div className="fixed inset-0 z-40 flex items-start justify-center overflow-y-auto px-5 py-12">
-      <button
-        type="button"
-        aria-label={t('Close')}
-        onClick={onClose}
-        className="fixed inset-0 bg-black/40"
-      />
+    <Modal
+      title={editing ? t('Event') : t('New event')}
+      width="max-w-lg"
+      onClose={onClose}
+      onSubmit={() => {
+        if (!busy) void save();
+      }}
+      footer={
+        <div className="flex w-full flex-wrap items-center gap-3">
+          {editing && occurrence.is_recurring && (
+            <button
+              type="button"
+              onClick={() => void removeOne()}
+              className="text-sm text-muted underline underline-offset-2 hover:text-ink"
+            >
+              {t('Skip this occurrence')}
+            </button>
+          )}
+          {editing && (
+            <button
+              type="button"
+              onClick={() => void removeAll()}
+              className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+            >
+              {occurrence.is_recurring ? t('Delete series') : t('Delete')}
+            </button>
+          )}
 
-      <div className="relative w-full max-w-lg rounded-card border border-line bg-surface p-5 shadow-xl">
-        <h2 className="eyebrow mb-4">{editing ? t('Event') : t('New event')}</h2>
-
+          {/* The always-present way out (#83): on a phone the backdrop
+              shrinks to slivers once the panel scrolls, and a new event
+              used to leave Save alone in this row */}
+          <button type="button" onClick={onClose} className={`ml-auto ${dialogGhost}`}>
+            {t('Cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={busy}
+            className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? t('Saving') : t('Save')}
+          </button>
+        </div>
+      }
+    >
         <div className="space-y-4">
           <label className="block">
             <span className={label}>{t('Title')}</span>
@@ -367,37 +399,6 @@ export function EventDialog({
 
           {error && <p className="text-sm text-urgent">{error}</p>}
         </div>
-
-        <div className="mt-5 flex flex-wrap items-center gap-3">
-          {editing && occurrence.is_recurring && (
-            <button
-              type="button"
-              onClick={() => void removeOne()}
-              className="text-sm text-muted underline underline-offset-2 hover:text-ink"
-            >
-              {t('Skip this occurrence')}
-            </button>
-          )}
-          {editing && (
-            <button
-              type="button"
-              onClick={() => void removeAll()}
-              className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
-            >
-              {occurrence.is_recurring ? t('Delete series') : t('Delete')}
-            </button>
-          )}
-
-          <button
-            type="button"
-            onClick={() => void save()}
-            disabled={busy}
-            className="ml-auto rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
-          >
-            {busy ? t('Saving') : t('Save')}
-          </button>
-        </div>
-      </div>
-    </div>
+    </Modal>
   );
 }

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/tasks';
 import { dialogKeys, onEnter } from '../lib/keys';
 import { clearBlankOnBlur } from '../lib/forms';
-import { useDialogs } from './Dialog';
+import { useDialogs, useScrollLock } from './Dialog';
 
 const field =
   'w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent';
@@ -94,8 +94,19 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
     onClose();
   }
 
+  useScrollLock();
+
+  /*
+    Deliberately NOT the shared Modal (#84): this is a right-hand
+    slide-over — full height, its own header with a Close, content that
+    scrolls inside the panel — not a centred titled card with a footer.
+    Teaching Modal a drawer variant for one caller would cost more than
+    the duplication it removes. What the shells really share is behaviour,
+    and that comes from the same places Modal takes it: dialogKeys above,
+    the scroll lock here.
+  */
   return (
-    <div className="fixed inset-0 z-30 flex justify-end">
+    <div className="fixed inset-0 z-30 flex justify-end overscroll-contain">
       <button
         type="button"
         aria-label={t('Close')}


### PR DESCRIPTION
## Why

#84 diagnosed it: all three dialog defects lived in the two components that bypass `Modal`. This PR takes the cluster: #83 (new event can't be closed on a phone), #71 (page scrolls behind an open dialog), #84 (the split itself).

## What

- **EventDialog → Modal.** The hand-rolled shell was near-identical (`py-12`/`z-40` vs `py-20`/`z-50`); adopting Modal brings the footer convention, and with it the fix for #83 — an always-present **Cancel** (the backdrop on a phone shrinks to two 20px slivers once the panel scrolls). The inline `onSubmit` closure re-subscribes Modal's key handler every render, preserving the old "save sees the current draft" behaviour.
- **`useScrollLock()` in Dialog.tsx** (#71): body `overflow: hidden` with scrollbar-width compensation, **counted** so a confirm on top of a dialog doesn't unlock the page. `overscroll-contain` on the overlays stops a tall dialog chaining at its ends. Used by `Modal` and `TaskDetail`.
- **TaskDetail stays a drawer** — with the reason written in a comment rather than implied, per #84's own suggestion. It shares the behaviour (keys, lock) through the shared code.
- Modal's overlay folds `env(safe-area-inset-bottom)` into its bottom padding — the footer sat partly under the home indicator on notched phones (flagged in #83).

## Verified live

New-event dialog shows Cancel; `body.overflow` flips to `hidden` while open and back on close (padding compensation released too); `overscroll-behavior: contain` present; Enter saves and the event appears in the grid. typecheck + lint + full tests green.

Closes #83, closes #84, closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)