### PR TITLE
feat: keep piggy banks out of the spendable total

### DIFF
--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -455,6 +455,7 @@ export const ru: Record<string, string> = {
   'Search notes': 'Поиск по заметкам',
   'Search tasks, notes, events and files': 'Искать по задачам, заметкам, событиям и файлам',
   'Server unavailable': 'Сервер недоступен',
+  'set aside': 'отложено',
   'Settings': 'Настройки',
   'Settings must be pairs of strings': 'Настройки должны быть парами строк',
   'Shared': 'Общий',

--- a/web/src/lib/money.test.ts
+++ b/web/src/lib/money.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   describeRule,
   formatAmountInput,
+  groupByCurrency,
   normalizeRule,
   orderCategories,
   parseAmount,
+  type Account,
   type Category,
 } from './money';
 
@@ -116,5 +118,40 @@ describe('orderCategories', () => {
       'expense',
     );
     expect(ordered.map((o) => o.category.id)).toEqual(['car', 'fuel']);
+  });
+});
+
+describe('groupByCurrency', () => {
+  const acc = (over: Partial<Account>): Account =>
+    ({
+      id: 'x',
+      name: 'x',
+      kind: 'card',
+      currency: 'EUR',
+      color: '#000000',
+      shared: 1,
+      balance: 0,
+      checked_balance: null,
+      last_checked_on: null,
+      last_actual: null,
+      ...over,
+    }) as Account;
+
+  it('keeps savings out of the spendable total but visible as saved (#69)', () => {
+    const groups = groupByCurrency([
+      acc({ id: 'a', kind: 'card', balance: 245_990 }),
+      acc({ id: 'b', kind: 'cash', balance: 18_110 }),
+      acc({ id: 'c', kind: 'savings', balance: 125_000 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.total).toBe(264_100);
+    expect(groups[0]!.saved).toBe(125_000);
+    // The account itself stays in the list — only the headline changes
+    expect(groups[0]!.items).toHaveLength(3);
+  });
+
+  it('a currency holding only savings shows zero available, not nothing', () => {
+    const groups = groupByCurrency([acc({ kind: 'savings', currency: 'RSD', balance: 500_000 })]);
+    expect(groups[0]).toMatchObject({ currency: 'RSD', total: 0, saved: 500_000 });
   });
 });

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -203,8 +203,20 @@ export function monthBounds(anchor: string): { from: string; to: string } {
   return { from, to: last.toISOString().slice(0, 10) };
 }
 
-/** Accounts grouped by currency: no grand total without an exchange rate. */
-export function groupByCurrency(accounts: Account[]): { currency: string; total: number; items: Account[] }[] {
+/**
+ * Accounts grouped by currency: no grand total without an exchange rate.
+ *
+ * The headline total is what the family can actually spend, so a piggy
+ * bank does not count towards it (#69): money set aside is not money
+ * available, and adding it in overstated the number at the top of the
+ * Money page. The set-aside sum is returned separately rather than
+ * hidden — savings should stay visible, just not spendable. A savings
+ * account itself keeps behaving like any account: balance, transfers,
+ * reconciliation are untouched.
+ */
+export function groupByCurrency(
+  accounts: Account[],
+): { currency: string; total: number; saved: number; items: Account[] }[] {
   const map = new Map<string, Account[]>();
   for (const a of accounts) {
     const list = map.get(a.currency) ?? [];
@@ -214,7 +226,8 @@ export function groupByCurrency(accounts: Account[]): { currency: string; total:
   return [...map.entries()]
     .map(([currency, items]) => ({
       currency,
-      total: items.reduce((sum, a) => sum + a.balance, 0),
+      total: items.filter((a) => a.kind !== 'savings').reduce((sum, a) => sum + a.balance, 0),
+      saved: items.filter((a) => a.kind === 'savings').reduce((sum, a) => sum + a.balance, 0),
       items,
     }))
     .sort((a, b) => b.total - a.total);

--- a/web/src/pages/Money.tsx
+++ b/web/src/pages/Money.tsx
@@ -305,8 +305,17 @@ export function Money() {
               <section key={group.currency}>
                 <div className="mb-2 flex items-baseline justify-between">
                   <h2 className="eyebrow">{group.currency}</h2>
-                  <span className="font-display text-lg font-semibold text-ink">
-                    {formatMoney(group.total, group.currency)}
+                  <span className="flex items-baseline gap-3">
+                    {/* Set-aside money stays visible but out of the headline:
+                        the big number is what can actually be spent (#69) */}
+                    {group.saved > 0 && (
+                      <span className="text-xs text-muted">
+                        {formatMoney(group.saved, group.currency)} {t('set aside')}
+                      </span>
+                    )}
+                    <span className="font-display text-lg font-semibold text-ink">
+                      {formatMoney(group.total, group.currency)}
+                    </span>
                   </span>
                 </div>
 


### PR DESCRIPTION
## Why

#69: the per-currency headline summed every account, savings included — the number at the top of the Money page overstated what the family can actually spend.

## What

Option A from the issue (the kind already exists and already means this):

- `groupByCurrency` returns `total` (non-savings) and `saved` (savings) separately;
- the currency header shows `€1,250 set aside · €2,628.66` — set-aside money stays visible, just out of the headline;
- a savings account itself is untouched: card, balance, transfers, reconciliation all as before. Month summary was already transfer-free; budgets are per category — both confirmed unaffected.

## Tests / verified

Two new unit tests (split correctness; savings-only currency shows `0` available rather than looking broken). Verified live on the demo: created a `Piggy bank` account, header renders `EUR | €1,250 set aside | €2,628.66`. typecheck + lint + tests green.

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)