### PR TITLE
feat: let a member change their own name and colour

### DIFF
--- a/server/src/routes/users.test.ts
+++ b/server/src/routes/users.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+import { id, now, runWithDb } from '../db/index.js';
+import { createSession } from '../lib/auth.js';
+
+/*
+  The self-service boundary of PATCH /api/users/:id (#64): a member owns
+  their name and colour, and nothing else — the same route on someone
+  else's id must stay administrator-only. The harness's join() creates
+  administrators, so the member here is inserted directly.
+*/
+
+let hub: Harness;
+let adminId = '';
+let memberId = '';
+let memberCookie = '';
+
+function joinMember(name: string): { userId: string; cookie: string } {
+  return runWithDb(hub.db, () => {
+    const userId = id();
+    hub.db
+      .prepare(
+        `INSERT INTO users (id, email, name, role, password_hash, color, created_at)
+         VALUES (?, ?, ?, 'member', 'x', '#C4842B', ?)`,
+      )
+      .run(userId, `${name}@hub.local`, name, now());
+    return { userId, cookie: createSession(userId, `${name}-device`) };
+  });
+}
+
+beforeAll(async () => {
+  hub = await buildTestApp();
+  adminId = hub.join('alice').userId;
+  const member = joinMember('kate');
+  memberId = member.userId;
+  memberCookie = member.cookie;
+});
+
+describe('PATCH /api/users/:id self-service', () => {
+  it('a member changes their own name and colour', async () => {
+    const res = await hub.as(memberCookie, 'PATCH', `/api/users/${memberId}`, {
+      name: 'Kate',
+      color: '#6B8F5E',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ name: string; color: string }>()).toMatchObject({
+      name: 'Kate',
+      color: '#6B8F5E',
+    });
+  });
+
+  it("a member cannot touch someone else's profile", async () => {
+    const res = await hub.as(memberCookie, 'PATCH', `/api/users/${adminId}`, {
+      name: 'Hacked',
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -23,8 +23,13 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
   // recovery, not creation.
 
   app.patch('/api/users/:id', (req, reply) => {
-    if (!requireAdmin(req, reply)) return;
     const { id: userId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    // Name and colour are personal identity, not system management: a
+    // member edits their own, the administrator can edit anyone's (a kid
+    // without a device is set up by the parent). This route accepts
+    // nothing else — role and the disable switch have their own
+    // admin-only endpoints, so self-service here widens nothing. (#64)
+    if (req.user?.id !== userId && !requireAdmin(req, reply)) return;
     const parsed = z
       .object({
         name: z.string().min(1).max(100).optional(),

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -425,6 +425,7 @@ export const ru: Record<string, string> = {
   'Recorded, hide': 'Записал, скрыть',
   'Recurrence': 'Повторение',
   'Recurrence counts from the due date — set one': 'Повтор считается от срока — задайте дату',
+  'Profile': 'Профиль',
   'Recurring': 'Регулярные',
   'Recurring transaction': 'Регулярная операция',
   'Regular': 'Обычная',

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -14,6 +14,87 @@ import { MailSection } from '../components/MailSection';
 import { TotpSection } from '../components/TotpSection';
 
 /**
+ * Own name and avatar colour, self-service (#64). Colour is the whole
+ * visual identity here — the avatar is a letter plus a colour — and
+ * asking the administrator to change your own was an odd asymmetry when
+ * password, Google, two-factor and devices are all self-service. The
+ * server allows exactly this pair on one's own account; role and the
+ * disable switch stay admin-only.
+ */
+function ProfileSection() {
+  const { user, refresh } = useAuth();
+  const [name, setName] = useState(user?.name ?? '');
+  const [color, setColor] = useState(user?.color ?? PALETTE[0]!);
+  const [status, setStatus] = useState<string | null>(null);
+
+  if (!user) return null;
+  const dirty = name.trim() !== user.name || color.toLowerCase() !== user.color.toLowerCase();
+
+  async function save() {
+    if (!user || !name.trim()) return;
+    setStatus(null);
+    try {
+      await api.patch(`/users/${user.id}`, { name: name.trim(), color });
+      await refresh();
+      setStatus(t('Saved'));
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : t('Could not save'));
+    }
+  }
+
+  return (
+    <section className="rounded-card border border-line bg-surface p-5">
+      <h2 className="eyebrow mb-3">{t('Profile')}</h2>
+
+      <label className="block">
+        <span className="mb-1.5 block text-sm font-medium text-ink">{t('Name')}</span>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={onEnter(() => void save())}
+          className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+        />
+      </label>
+
+      <div className="mt-3">
+        <span className="mb-1.5 block text-sm font-medium text-ink">{t('Colour')}</span>
+        <div className="flex flex-wrap items-center gap-2">
+          {/* The current colour joins the row even when it is not in the
+              stock palette (invited members got palette colours, but the
+              admin's default and custom picks may not be there) */}
+          {[...new Set([user.color, ...PALETTE])].map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={t('Colour {color}', { color: c })}
+              onClick={() => setColor(c)}
+              style={{ backgroundColor: c }}
+              className={`size-7 rounded-full transition-transform ${
+                color.toLowerCase() === c.toLowerCase()
+                  ? 'ring-2 ring-ink ring-offset-2 ring-offset-surface'
+                  : 'hover:scale-110'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={!dirty || !name.trim()}
+          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+        >
+          {t('Save')}
+        </button>
+        {status && <span className="text-sm text-muted">{status}</span>}
+      </div>
+    </section>
+  );
+}
+
+/**
  * The hub's custom colors on top of the stock palette. The list also grows
  * from the color pickers in entity dialogs; this is where it gets pruned.
  */
@@ -533,6 +614,10 @@ export function Settings() {
           </button>
         </div>
       </section>
+
+      <div className="mb-5 break-inside-avoid">
+        <ProfileSection />
+      </div>
 
       <div className="mb-5 break-inside-avoid">
         <PaletteSection />


### PR DESCRIPTION
## Why

#64: the only route editing name/colour opened with `requireAdmin` — an odd asymmetry when everything else personal (password, Google, 2FA, devices, language, theme) is self-service, and colour *is* the identity system here.

## What

- Server: `PATCH /api/users/:id` allows `req.user.id === params.id`; admin path unchanged. Widens nothing — the route accepts exactly `name` and `color`; `role` and the disable switch have their own admin-only endpoints. Existing validation (length, `#RRGGBB`) covers the input.
- Web: a **Profile** section at the top of Settings — name, palette row, Save. The current colour joins the palette row even when off-palette (the pre-#48 admin default would otherwise be unselectable). Refreshes the auth context on save so the avatar updates immediately.
- Demo: the whole `/api/users` surface is demo-blocked (membership is disabled there); the section surfaces the demo message. Deliberately left as is.

## Tests

`users.test.ts`: a real `member` (inserted directly — the harness's `join()` makes admins) edits their own profile → 200 with the new values; touches the admin's → 403. Full suite (75 server + 37 web) + typecheck + lint green.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)