### PR TITLE
fix: give inline actions a way to say "that did not save"

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
 import { useAuth } from '../lib/auth';
 import { applyUpdate, setupPwa } from '../lib/pwa';
+import { clearFailure, useFailure } from '../lib/failures';
 import { QuickAdd } from './QuickAdd';
 import { GlobalSearch, SearchTrigger } from './GlobalSearch';
 import { applyTheme, initialDark, persistTheme } from '../lib/theme';
@@ -159,6 +160,32 @@ function SignOutButton({ onClick }: { onClick: () => void }) {
 }
 
 /**
+ * "That did not save" — the shared surface for inline actions that have
+ * no dialog to put an error in (#85). Same visual language and position
+ * as the update toast below, urgent-toned. It stays until dismissed or
+ * replaced: an error that hides itself before it is read said nothing.
+ */
+function FailureToast() {
+  const failure = useFailure();
+  if (!failure) return null;
+  return (
+    <div className="fixed bottom-20 left-1/2 z-50 -translate-x-1/2 md:right-6 md:bottom-6 md:left-auto md:translate-x-0">
+      <div className="flex items-center gap-3 rounded-full border border-urgent/40 bg-surface py-2 pr-2 pl-4 shadow-xl">
+        <span className="text-sm text-ink">{failure.message}</span>
+        <button
+          type="button"
+          onClick={clearFailure}
+          aria-label={t('Close')}
+          className="grid size-7 place-items-center rounded-full text-muted hover:text-ink"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
  * "The hub was updated" — shown when a new service worker is waiting
  * (see lib/pwa.ts for why long-lived tabs need this at all). Sits above
  * the bottom bar on phones and in the corner on desktop.
@@ -288,6 +315,7 @@ export function AppShell() {
       </main>
 
       <QuickAdd onAdded={() => setRefreshKey((k) => k + 1)} />
+      <FailureToast />
       <UpdateToast />
 
       {/* The search modal lives at the shell root: inside the sidebar it

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -4,6 +4,7 @@ import { api } from '../lib/api';
 import { Empty } from './Page';
 import { EntityDialog } from './EntityDialog';
 import { useDialogs } from './Dialog';
+import { reportFailure } from '../lib/failures';
 
 interface ManagedUser {
   id: string;
@@ -132,7 +133,12 @@ function InvitesBlock() {
               </span>
               <button
                 type="button"
-                onClick={() => void api.delete(`/invites/${i.id}`).then(load)}
+                onClick={() =>
+                  void api
+                    .delete(`/invites/${i.id}`)
+                    .then(load)
+                    .catch((err: Error) => reportFailure(err.message || t('Could not save')))
+                }
                 className="text-xs text-muted underline decoration-line hover:text-urgent"
               >
                 {t('Revoke')}
@@ -169,14 +175,22 @@ export function PeopleSection() {
       confirmLabel: t('Reset'),
     });
     if (!ok) return;
-    const res = await api.post<{ password: string }>(`/users/${user.id}/reset-password`, {});
-    setPassword(res.password);
-    await load();
+    try {
+      const res = await api.post<{ password: string }>(`/users/${user.id}/reset-password`, {});
+      setPassword(res.password);
+      await load();
+    } catch (err) {
+      reportFailure(err instanceof Error ? err.message : t('Could not save'));
+    }
   }
 
   async function toggle(user: ManagedUser) {
-    await api.post(`/users/${user.id}/toggle`, {});
-    await load();
+    try {
+      await api.post(`/users/${user.id}/toggle`, {});
+      await load();
+    } catch (err) {
+      reportFailure(err instanceof Error ? err.message : t('Could not save'));
+    }
   }
 
   return (

--- a/web/src/components/TaskList.tsx
+++ b/web/src/components/TaskList.tsx
@@ -4,6 +4,7 @@ import { api, type Task, type TaskMutation } from '../lib/api';
 import { formatDate } from '../lib/format';
 import { PRIORITY_LABEL, effectiveDate, isClosed, isOverdue, today, type TaskNode } from '../lib/tasks';
 import { Empty } from './Page';
+import { reportFailure } from '../lib/failures';
 
 interface Props {
   nodes: TaskNode[];
@@ -43,25 +44,38 @@ function TaskItem({
   const canNest = node.level < 2;
 
   async function toggle() {
-    const res = await api.patch<TaskMutation>(`/tasks/${node.id}`, {
-      status: closed ? 'todo' : 'done',
-    });
-    onChanged(res.spawned);
+    // The checkbox is controlled by the task's status, so on failure it
+    // snaps back — without a message that reads as "the app ignored my
+    // tap" rather than "the save failed" (#85)
+    try {
+      const res = await api.patch<TaskMutation>(`/tasks/${node.id}`, {
+        status: closed ? 'todo' : 'done',
+      });
+      onChanged(res.spawned);
+    } catch (err) {
+      reportFailure(err instanceof Error ? err.message : t('Could not save'));
+    }
   }
 
   async function addChild() {
     const title = childTitle.trim();
     if (!title) return;
-    const created = await api.post<Task>('/tasks', {
-      project_id: node.project_id,
-      parent_id: node.id,
-      title,
-    });
-    setChildTitle('');
-    setAdding(false);
-    setExpanded(true);
-    onChanged();
-    onOpen(created);
+    try {
+      const created = await api.post<Task>('/tasks', {
+        project_id: node.project_id,
+        parent_id: node.id,
+        title,
+      });
+      setChildTitle('');
+      setAdding(false);
+      setExpanded(true);
+      onChanged();
+      onOpen(created);
+    } catch (err) {
+      // The typed title deliberately stays in the field — failing must not
+      // eat the person's words
+      reportFailure(err instanceof Error ? err.message : t('Could not add'));
+    }
   }
 
   return (

--- a/web/src/lib/failures.ts
+++ b/web/src/lib/failures.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from 'react';
+
+/*
+  One shared way to say "that did not save" (#85).
+
+  Dialogs surface their own errors next to their own Save button, and that
+  stays the rule. But the app also has inline actions with no dialog to
+  put a message in — ticking a task done, revoking an invite — and each of
+  them had nothing: the promise rejected into the console and the screen
+  said nothing. An inline error field is awkward exactly where those
+  actions live (a task row, a settings list), which is why they ended up
+  silent.
+
+  So: a module-scope value mirrored into React, same shape as
+  lib/experiment.ts. reportFailure() is for actions WITHOUT their own
+  error surface — a dialog must keep using its local state, where the
+  message sits next to the thing that failed.
+*/
+
+let current: { message: string; at: number } | null = null;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+/** Show the message in the failure toast (see AppShell). */
+export function reportFailure(message: string): void {
+  // `at` makes repeats distinct: failing the same action twice must
+  // restart the toast timer, and an identical object would not re-render
+  current = { message, at: Date.now() };
+  notify();
+}
+
+export function clearFailure(): void {
+  current = null;
+  notify();
+}
+
+export function useFailure(): { message: string; at: number } | null {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => current,
+    () => null,
+  );
+}


### PR DESCRIPTION
## Why

#85: five write paths had no error handling — no try/catch, no state, nothing rendered. Worst of them: ticking a task done, the most frequent action in the app, where the status-controlled checkbox snaps back on failure and reads as "the app ignored my tap".

## What

The issue named the fork; this takes its second option — **one shared way to say "that did not save"** for actions that have no dialog to put a message in:

- `lib/failures.ts` — `reportFailure(message)`, a module-scope value mirrored into React (same shape as `lib/experiment.ts`), ~40 lines;
- `FailureToast` in the shell — the update toast's visual language and position, urgent-toned border, stays until dismissed or replaced (an error that hides itself before it is read said nothing);
- all five silent paths now catch and report: `TaskList.toggle`, `TaskList.addChild` (the typed title deliberately stays in the field), `PeopleSection.reset`, `PeopleSection.toggle`, invite revoke.

**The rule stands**: dialogs keep their local error state next to their own Save button — the toast is only for actions with no such place, and the comment in `failures.ts` says so.

## Verified live

- Task deleted behind the UI's back → tick → toast **"Task not found"**, the row stays on screen (failure does not reload the list), ✕ dismisses;
- People → Disable on one's own row → toast with the server's **"You cannot disable yourself"**;
- Russian: the same flow shows **«Нельзя отключить самого себя»** — server strings translate by exact match, unchanged.
- typecheck + lint + tests (87 server / 39 web) green. Both fallback strings (`Could not save`, `Could not add`) were already in the dictionary.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)