### PR TITLE
feat: seed family profiles into the demo

### DIFF
--- a/server/src/lib/demo-seed.test.ts
+++ b/server/src/lib/demo-seed.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { openDatabase, runWithDb } from '../db/index.js';
+import { migrate } from '../db/migrate.js';
+import { seedDemo } from './demo.js';
+
+/*
+  The demo seeder runs at sandbox-template build, which means a broken
+  INSERT crashes the whole demo server at startup — and that is exactly
+  how a missing NULL in a multi-row VALUES list was actually found. The
+  seeder must be exercised where CI can see it, not on the live stand.
+*/
+describe('seedDemo', () => {
+  it('seeds an empty database without crashing, profiles included', async () => {
+    const db = openDatabase(':memory:');
+    runWithDb(db, () => migrate());
+    await runWithDb(db, () => seedDemo());
+
+    const n = (q: string) => (db.prepare(q).get() as { n: number }).n;
+    expect(n('SELECT count(*) AS n FROM users')).toBeGreaterThan(0);
+    expect(n('SELECT count(*) AS n FROM profiles')).toBe(2);
+    expect(n(`SELECT count(*) AS n FROM profile_entries WHERE kind = 'allergy'`)).toBe(1);
+    expect(n('SELECT count(*) AS n FROM wishes')).toBe(4);
+    // One wish arrives pre-claimed by a guest, to showcase the public link
+    expect(n('SELECT count(*) AS n FROM wishes WHERE claimed_by_name IS NOT NULL')).toBe(1);
+    // The derived birthday events carry the back-reference the routes use
+    expect(n('SELECT count(*) AS n FROM events WHERE profile_user_id IS NOT NULL')).toBe(2);
+
+    // Idempotence: a second run on a non-empty database is a no-op
+    await runWithDb(db, () => seedDemo());
+    expect(n('SELECT count(*) AS n FROM profiles')).toBe(2);
+    db.close();
+  });
+});

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -45,6 +45,15 @@ function id(): string {
 }
 
 /** ISO date offset from today, local time — as everywhere in the hub. */
+/**
+ * A birthdate for the seeds: a past year wearing day(offset)'s month and
+ * day, so the template database (rebuilt daily) always has a birthday
+ * coming up and the age math stays honest.
+ */
+function birthdate(offset: number, year: number): string {
+  return `${year}${day(offset).slice(4)}`;
+}
+
 function day(offset: number): string {
   const base = new Date(`${today()}T00:00:00`);
   base.setDate(base.getDate() + offset);
@@ -167,6 +176,53 @@ export async function seedDemo(): Promise<void> {
        VALUES (?, '00000000-0000-4000-8000-000000000001', 0, 'Confirm parent-teacher evening', 'Reply to the school before Thursday', 'todo', 'normal', ?, ?, 8, ?)`,
     ).run(schoolTask, day(1), sam, alex);
     db.prepare('UPDATE mail_messages SET task_id = ? WHERE id = ?').run(schoolTask, school);
+
+    // ── Family profiles ──
+    // The visitor signs in as Alex, so the seeds are arranged to show
+    // both sides of the wishlist rule at once: Sam's list demonstrates
+    // reserving (one wish already taken by a guest through the public
+    // link — claimed_by_name with no account), while Alex's own list
+    // shows the owner's view, where the server hides every claim.
+    const alexBirthday = birthdate(6, 1988);
+    const samBirthday = birthdate(45, 1990);
+    db.prepare(
+      `INSERT INTO profiles (user_id, birthday, family_role) VALUES
+       (?, ?, 'father'),
+       (?, ?, 'mother')`,
+    ).run(alex, alexBirthday, sam, samBirthday);
+    // The derived birthday events, exactly as PATCH /api/profiles writes
+    // them (profiles.ts syncBirthdayEvent): profile_user_id is how the
+    // route finds them again when a visitor edits the date
+    db.prepare(
+      `INSERT INTO events (id, calendar_id, title, starts_at, ends_at, all_day,
+                           recurrence_rule, birth_year, profile_user_id, created_at, updated_at)
+       VALUES (?, ?, 'Alex', ?, ?, 1, 'FREQ=YEARLY', ?, ?, ?, ?),
+              (?, ?, 'Sam', ?, ?, 1, 'FREQ=YEARLY', ?, ?, ?, ?)`,
+    ).run(
+      id(), shared, alexBirthday, alexBirthday, 1988, alex, now(), now(),
+      id(), shared, samBirthday, samBirthday, 1990, sam, now(), now(),
+    );
+    db.prepare(
+      `INSERT INTO profile_entries (id, user_id, kind, label, value, position) VALUES
+       (?, ?, 'preference', 'Shoes', '44', 1),
+       (?, ?, 'preference', 'Coffee', 'flat white, no sugar', 2),
+       (?, ?, 'preference', 'Shoes', '38', 1),
+       (?, ?, 'preference', 'Tea', 'Earl Grey', 2),
+       (?, ?, 'preference', 'Flowers', 'tulips, never lilies', 3),
+       (?, ?, 'allergy', 'peanuts', NULL, 4)`,
+    ).run(id(), alex, id(), alex, id(), sam, id(), sam, id(), sam, id(), sam);
+    db.prepare(
+      `INSERT INTO wishes (id, user_id, title, url, claimed_by, claimed_by_name, claimed_at, position, created_at) VALUES
+       (?, ?, 'A proper espresso tamper', NULL, NULL, NULL, NULL, 1, ?),
+       (?, ?, 'Wool hiking socks', NULL, NULL, NULL, NULL, 2, ?),
+       (?, ?, 'Weekend at a spa', NULL, NULL, 'Grandma Vera', ?, 1, ?),
+       (?, ?, 'A very sharp kitchen knife', NULL, NULL, NULL, NULL, 2, ?)`,
+    ).run(
+      id(), alex, now(),
+      id(), alex, now(),
+      id(), sam, now(), now(),
+      id(), sam, now(),
+    );
 
     // ── Money ──
     const card = id();


### PR DESCRIPTION
## Why

Follow-up to #114: the Family section opened empty in the demo — the one place strangers evaluate the hub.

## What

Seeds arranged around the visitor signing in **as Alex**, so both sides of the wishlist rule show at once:

- **Sam** (mother, birthday +45 days, allergy `peanuts` → the urgent line on the family card): two wishes — *Weekend at a spa* already reserved by **"Grandma Vera"** via the guest-link mechanics (`claimed_by_name`, no account), *A very sharp kitchen knife* free to reserve.
- **Alex** (father, birthday +6 days): two wishes, shown ownerside — no claim info, with the "reservations are hidden" caption doing the explaining.
- Preferences on both (label–value rows); birthdays are **relative to the template build date** (a past year wearing a nearby month-day), so the calendar always has one coming up with a computed age.
- The derived birthday events are written exactly as `PATCH /api/profiles` writes them (`profile_user_id` included), so a visitor editing a date in the sandbox exercises the real route against seeded rows.

## The test this earned the hard way

The seeder runs at sandbox-template build — a broken INSERT **crashes the demo server at startup**, which is exactly how a missing `NULL` in a multi-row VALUES list announced itself on the live stand during this change. New `demo-seed.test.ts` runs `seedDemo()` against `:memory:` in CI: seeds apply, profile/wish/allergy counts hold, second run is a no-op.

## Verified live

Fresh sandbox: family cards render (Папа · 37, Мама · 35 with the peanuts line), Sam's profile shows «Забронировано: Grandma Vera» + a live «Забронировать», Alex's own list is claim-blind. Share-link creation in the demo stays blocked as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)