### PR TITLE
fix: split the donut centre label at the currency, not the first space

### DIFF
--- a/web/src/components/DonutChart.test.ts
+++ b/web/src/components/DonutChart.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { splitCenterLabel } from './DonutChart';
+
+/*
+  The centre label against real Intl output. The fixtures are the exact
+  strings formatMoney produces (NBSP thousands separators included) —
+  the production regression was "378 264,09 RSD" splitting at the first
+  NBSP into "378" over "264,09 RSD".
+*/
+const NBSP = ' ';
+
+describe('splitCenterLabel', () => {
+  it('code-first locales split after the code (en-GB RSD)', () => {
+    expect(splitCenterLabel(`RSD${NBSP}378,264.09`)).toEqual({
+      unit: 'RSD',
+      amount: '378,264.09',
+    });
+  });
+
+  it('code-last locales split before the code, thousands NBSPs intact (ru-RU RSD)', () => {
+    expect(splitCenterLabel(`378${NBSP}264,09${NBSP}RSD`)).toEqual({
+      unit: 'RSD',
+      amount: `378${NBSP}264,09`,
+    });
+  });
+
+  it('trailing symbol with spaced thousands (ru-RU EUR)', () => {
+    expect(splitCenterLabel(`2${NBSP}641,00${NBSP}€`)).toEqual({
+      unit: '€',
+      amount: `2${NBSP}641,00`,
+    });
+  });
+
+  it('small ru amount — one separator, still the right cut', () => {
+    expect(splitCenterLabel(`127,40${NBSP}RSD`)).toEqual({ unit: 'RSD', amount: '127,40' });
+  });
+
+  it('spaceless labels stay on one line (en-GB EUR)', () => {
+    expect(splitCenterLabel('€2,641.00')).toBeNull();
+  });
+
+  it('a bare number with separators is left alone rather than guessed at', () => {
+    expect(splitCenterLabel(`1${NBSP}234,56`)).toBeNull();
+  });
+});

--- a/web/src/components/DonutChart.tsx
+++ b/web/src/components/DonutChart.tsx
@@ -20,6 +20,36 @@ interface Props {
   size?: number;
 }
 
+/**
+ * Splits a formatted money string into the currency unit and the number,
+ * for the two-line centre label. Null means "one line, do not split".
+ *
+ * The trap this guards (a production regression): the split used to cut
+ * at the FIRST whitespace, which is the currency boundary only in
+ * code-first locales ("RSD 378,264.09"). Russian formats the code LAST
+ * and separates thousands with the very same non-breaking space —
+ * "378\u00a0264,09\u00a0RSD" — so the first-space cut produced "378" over
+ * "264,09 RSD". The boundary cannot be told apart by the character; it
+ * can by the content: the unit is the non-numeric token, and it sits at
+ * whichever end the locale put it.
+ */
+export function splitCenterLabel(label: string): { unit: string; amount: string } | null {
+  const first = label.search(/\s/);
+  if (first === -1) return null;
+  const startsWithUnit = /^[^\d]/.test(label);
+  const endsWithUnit = /[^\d.,]$/.test(label);
+  if (startsWithUnit && !endsWithUnit) {
+    return { unit: label.slice(0, first), amount: label.slice(first + 1) };
+  }
+  if (endsWithUnit && !startsWithUnit) {
+    const last = label.length - 1 - [...label].reverse().join('').search(/\s/);
+    return { unit: label.slice(last + 1), amount: label.slice(0, last) };
+  }
+  // No unit to peel off (or one at both ends — nothing sane to do):
+  // keep the single line rather than guess
+  return null;
+}
+
 export function DonutChart({ segments, centerLabel, size = 132 }: Props) {
   const total = segments.reduce((sum, s) => sum + s.value, 0);
   if (total <= 0) return null;
@@ -77,10 +107,8 @@ export function DonutChart({ segments, centerLabel, size = 132 }: Props) {
           const hole = size - 2 * stroke;
           const fitted = (text: string, base: number) =>
             Math.min(base, (hole * 0.92) / (Math.max(text.length, 1) * 0.62));
-          // formatMoney separates code and amount with a non-breaking
-          // space — match any whitespace, not the plain one
-          const space = centerLabel.search(/\s/);
-          if (space === -1) {
+          const parts = splitCenterLabel(centerLabel);
+          if (!parts) {
             return (
               <text
                 x="50%"
@@ -94,8 +122,7 @@ export function DonutChart({ segments, centerLabel, size = 132 }: Props) {
               </text>
             );
           }
-          const unit = centerLabel.slice(0, space);
-          const amount = centerLabel.slice(space + 1);
+          const { unit, amount } = parts;
           const amountSize = fitted(amount, size * 0.095);
           return (
             <>


### PR DESCRIPTION
## Why

Production screenshot: the "By category" donut for RSD showed `378` on one line and `264,09 RSD` on the other. The centre-label split cut at the **first** whitespace — correct only for code-first locales (`RSD 378,264.09`). Russian puts the code **last** and separates thousands with the very same `U+00A0` (verified against Intl output: `378 264,09 RSD`), so any six-digit amount split inside the number.

## What

`splitCenterLabel()` — extracted and testable — finds the non-numeric unit at whichever end the locale put it:

- code-first (`RSD 378,264.09`) → split after the first space, as before;
- code/symbol-last (`378 264,09 RSD`, `2 641,00 €`) → split before the **last** space, thousands NBSPs staying inside the amount line;
- spaceless (`€2,641.00`) → one line, unchanged;
- no unit at all (`1 234,56`) → left alone rather than guessed at.

## Tests / verified

Six unit tests against the **exact** strings `formatMoney` produces, NBSPs included (en/ru × RSD/EUR × large/small). Live repro of the screenshot: seeded the same `378 264,09 RSD` month in Russian — the centre now renders `RSD` over the intact `378 264,09` (asserted from the SVG's two `<text>` nodes). 145 tests green, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)