### PR TITLE
fix: footer text at a size you can actually read

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -324,12 +324,15 @@ export function AppShell() {
               and this is the cheapest way to tell those apart — and the two
               links worth having within reach. Settings → About repeats it
               for phones, where this sidebar does not exist. */}
-          <div className="px-2 font-mono text-[0.625rem] text-muted">
-            <p title={BUILD_SHA ? `${VERSION} · ${BUILD_SHA}` : VERSION}>
+          <div className="px-2 text-muted">
+            <p
+              className="font-mono text-xs"
+              title={BUILD_SHA ? `${VERSION} · ${BUILD_SHA}` : VERSION}
+            >
               v{VERSION}
               {BUILD_SHA && <span className="ml-1.5 opacity-70">{BUILD_SHA}</span>}
             </p>
-            <span className="mt-1 flex flex-col items-start gap-0.5">
+            <span className="mt-1.5 flex flex-col items-start gap-1 text-sm">
               <a
                 href={REPO_URL}
                 target="_blank"


### PR DESCRIPTION
## Why

Reported from a real browser right after #121 landed: the sidebar footer was 10px, which is too small to read comfortably — and a footer nobody can read is only marginally better than the dead end it replaced.

The links now match the **Sign out** button sitting directly above them: 14px, same face, so the bottom of the sidebar reads as one group rather than a control plus some fine print. The version drops from 10px to 12px mono — a step quieter than the links on purpose, because it is a stamp you check, not something you act on.

| | before | after |
|---|---|---|
| Source code / Report a bug | 10px mono | **14px**, matching Sign out |
| v1.0.0 | 10px mono | 12px mono |

## How you know it works

Computed sizes read back from the running app: Sign out `14px`, both links `14px`, version `12px`. Checked in both themes.

## Anything you are unsure about

The links keep their quiet underline rather than borrowing Sign out's pill-on-hover treatment — that styling is deliberately urgent-toned for the one destructive-ish action in the shell, and two ordinary links should not wear it.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [ ] Docs updated, if behaviour changed — typography only, nothing to describe

🤖 Generated with [Claude Code](https://claude.com/claude-code)