### PR TITLE
Versioning: the build names itself from the tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       DEPLOY: ${{ secrets.DEPLOY_USER || 'root' }}@${{ secrets.DEPLOY_HOST }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # git describe names the build; a shallow clone has no tags to describe
+          fetch-depth: 0
 
       # Deploying code that fails types or tests is pointless; ci.yml runs
       # the same checks in parallel, these gate the deploy itself.
@@ -46,7 +49,11 @@ jobs:
       - run: npm test
 
       - name: Build image
-        run: docker build --build-arg BUILD_SHA=${{ github.sha }} -t family-hub:prod .
+        run: |
+          docker build \
+            --build-arg BUILD_SHA=${{ github.sha }} \
+            --build-arg BUILD_VERSION="$(git describe --tags --always)" \
+            -t family-hub:prod .
 
       - name: SSH key and server address
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          build-args: BUILD_SHA=${{ github.sha }}
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+            BUILD_VERSION=${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ COPY . .
 # value has to be handed in.
 ARG BUILD_SHA=""
 ENV BUILD_SHA=$BUILD_SHA
+ARG BUILD_VERSION=""
+ENV BUILD_VERSION=$BUILD_VERSION
 RUN npm run build
 
 RUN npm prune --omit=dev

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,23 @@ The same worker solves the long-lived-tab problem: a kiosk that stays open for w
 
 ### Which build is running
 
-Settings → About and the foot of the sidebar name the version and the commit the bundle was built from. The version comes from the root `package.json` at build time; the commit arrives as the `BUILD_SHA` Docker build argument, because `.dockerignore` keeps `.git` out of the image. A build from source shows the version alone — a dev bundle has no commit worth quoting.
+Settings → About and the foot of the sidebar name the build. Both arrive as Docker build arguments, because `.dockerignore` keeps `.git` out of the image: `BUILD_SHA` is the commit, and `BUILD_VERSION` is `git describe --tags` — the tag itself on a release build, and `1.1.0-12-gabc1234` twelve commits later. That second form is the literal truth about a hub that deploys on every push, and it is derived rather than remembered, which matters: the manifest version sat at `0.1.0` through the whole of v1.0.0 because bumping it was somebody's job. Now nothing important depends on it; it is only the fallback for a build with no git and no argument.
+
+The interface prints the commit separately only when the version does not already end in it, so a between-releases build says its commit once.
 
 Both are visible only behind the sign-in screen. `/api/health` withholds the version from the public internet deliberately, and a line under the login box would have handed it to every scanner instead.
 
-Two things follow for whoever cuts a release: bump the version in all three `package.json` files along with the tag, or the interface will keep announcing the previous one — and keep `--build-arg BUILD_SHA=…` on any hand-rolled `docker build`, or the commit line simply disappears.
+### Cutting a release
+
+Development is reactive and ships daily, so the ritual is one command:
+
+```bash
+npm run release            # what would happen, and nothing else
+npm run release -- minor   # patch | minor | major
+```
+
+It refuses anything but a clean master that matches origin, then tags and pushes. Nothing is committed — deliberately: master takes pull requests only, and a version bump living in a file would mean a pull request and a CI wait every single day, which is how a daily ritual stops happening.
+
+Pushing the tag starts `release.yml`, which publishes the multi-arch image to GHCR and moves `latest`. That is what self-hosters install, so a long gap between tags means the `docker pull` in the README hands people something much older than the repository — the reason to keep the cadence tight rather than the reason to skip it.
+
+A hand-rolled `docker build` should pass both arguments; without them the interface falls back to the manifest version and prints no commit.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,8 +105,16 @@ npm run release            # what would happen, and nothing else
 npm run release -- minor   # patch | minor | major
 ```
 
-It refuses anything but a clean master that matches origin, then tags and pushes. Nothing is committed — deliberately: master takes pull requests only, and a version bump living in a file would mean a pull request and a CI wait every single day, which is how a daily ritual stops happening.
+It refuses anything but a clean master that matches origin, then tags, pushes, and writes the release page. Nothing is committed — deliberately: master takes pull requests only, and a version bump living in a file would mean a pull request and a CI wait every single day, which is how a daily ritual stops happening.
 
-Pushing the tag starts `release.yml`, which publishes the multi-arch image to GHCR and moves `latest`. That is what self-hosters install, so a long gap between tags means the `docker pull` in the README hands people something much older than the repository — the reason to keep the cadence tight rather than the reason to skip it.
+Pushing the tag starts `release.yml`, which publishes the multi-arch image to GHCR and moves `latest` (6–9 minutes, most of it arm64 under emulation). That image is what self-hosters install, so a long gap between tags means the `docker pull` in the README hands people something much older than the repository — the reason to keep the cadence tight rather than the reason to skip it.
+
+The page matters as much as the tag: the README's badge points at it, and a bare tag tells a visitor nothing. GitHub composes the notes from merged pull requests by default — the honest floor for a release nobody is going to write an essay about. A release that earns the essay gets one:
+
+```bash
+npm run release -- minor --title "v1.1.0 — the board you arrange" --notes notes.md
+```
+
+What a written page is for is visible in [v1.0.0](https://github.com/burtsdenis/family-hub/releases/tag/v1.0.0): what the release means in a paragraph, a section per headline feature, and an **Upgrading** block naming the migrations that will run and the exact image to pull.
 
 A hand-rolled `docker build` should pass both arguments; without them the interface falls back to the manifest version and prints no commit.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "import": "node scripts/import.mjs",
     "admin:reset": "node scripts/admin-reset.mjs",
     "screenshots": "node scripts/screenshots.mjs",
+    "release": "node scripts/release.mjs",
     "test": "npm run test --workspace=server && npm run test --workspace=web",
     "lint": "eslint server/src web/src scripts"
   },

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -16,8 +16,18 @@
   Pushing the tag starts release.yml, which publishes the multi-arch image
   to GHCR and moves `latest` — that is what self-hosters install, so this
   is the moment the outside world sees the work.
+
+  It also writes the release page, because that page is the release as far
+  as anyone reading the repository is concerned — the README's badge points
+  at it. By default GitHub composes the notes from the merged pull
+  requests, which is the right floor for a daily release nobody is going
+  to write an essay about. When a release does deserve the essay:
+
+    npm run release -- minor --title "v1.1.0 — the board you arrange" \
+                             --notes notes.md
 */
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 
 const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
 const die = (message) => {
@@ -26,8 +36,17 @@ const die = (message) => {
 };
 
 const BUMPS = ['patch', 'minor', 'major'];
-const bump = process.argv.slice(2).find((a) => !a.startsWith('-'));
+const argv = process.argv.slice(2);
+const bump = argv.find((a) => !a.startsWith('-'));
 if (bump && !BUMPS.includes(bump)) die(`Unknown bump "${bump}" — expected ${BUMPS.join(', ')}`);
+
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : undefined;
+};
+const notesFile = flag('notes');
+const title = flag('title');
+if (notesFile && !existsSync(notesFile)) die(`No such notes file: ${notesFile}`);
 
 // Refuse to tag anything but a clean, current master: a tag is public and
 // immovable in practice, and half the point is that it names a known state.
@@ -64,6 +83,24 @@ if (!bump) {
 
 const tag = `v${next[bump]}`;
 git('tag', '-a', tag, '-m', `Release ${tag}`);
+// Pushed with git rather than left to `gh release create`: a tag pushed
+// this way reliably starts release.yml, and the image matters more than
+// the page if only one of the two survives a bad day.
 git('push', 'origin', tag);
-console.log(`\n✓ ${tag} pushed — release.yml is building the image now.`);
-console.log(`  https://github.com/burtsdenis/family-hub/actions/workflows/release.yml\n`);
+console.log(`\n✓ ${tag} pushed — release.yml is building the image.`);
+
+const notes = notesFile ? ['--notes-file', notesFile] : ['--generate-notes'];
+try {
+  execFileSync('gh', ['release', 'create', tag, '--title', title ?? tag, ...notes], {
+    stdio: 'inherit',
+  });
+  console.log(`✓ release page written`);
+} catch {
+  // The tag is already public; say plainly what is left rather than
+  // pretending the release failed.
+  console.error(`\n✗ Could not write the release page. The tag is pushed; finish with:`);
+  console.error(`  gh release create ${tag} --title "${title ?? tag}" ${notes.join(' ')}\n`);
+  process.exit(1);
+}
+
+console.log(`  https://github.com/burtsdenis/family-hub/releases/tag/${tag}\n`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/*
+  Cut a release: one tag, pushed.
+
+  Development here is reactive and ships daily, so the release ritual has
+  to cost seconds or it will not happen. It costs one command because the
+  version is derived from the tag rather than written into a file — master
+  is protected (pull requests only), and a version bump living in the
+  manifest would mean a pull request and a CI wait every single day.
+
+    npm run release            # what would happen, and nothing else
+    npm run release -- patch   # fixes only
+    npm run release -- minor   # anything new
+    npm run release -- major   # an upgrade that needs hands
+
+  Pushing the tag starts release.yml, which publishes the multi-arch image
+  to GHCR and moves `latest` — that is what self-hosters install, so this
+  is the moment the outside world sees the work.
+*/
+import { execFileSync } from 'node:child_process';
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+const die = (message) => {
+  console.error(`✗ ${message}`);
+  process.exit(1);
+};
+
+const BUMPS = ['patch', 'minor', 'major'];
+const bump = process.argv.slice(2).find((a) => !a.startsWith('-'));
+if (bump && !BUMPS.includes(bump)) die(`Unknown bump "${bump}" — expected ${BUMPS.join(', ')}`);
+
+// Refuse to tag anything but a clean, current master: a tag is public and
+// immovable in practice, and half the point is that it names a known state.
+if (git('rev-parse', '--abbrev-ref', 'HEAD') !== 'master') die('Releases are cut from master');
+if (git('status', '--porcelain')) die('Working tree is not clean');
+git('fetch', '--quiet', '--tags', 'origin');
+if (git('rev-parse', 'HEAD') !== git('rev-parse', 'origin/master')) {
+  die('master and origin/master differ — pull or push first');
+}
+
+const last = git('describe', '--tags', '--abbrev=0');
+const [major, minor, patch] = last.replace(/^v/, '').split('.').map(Number);
+if ([major, minor, patch].some(Number.isNaN)) die(`Cannot read a version out of "${last}"`);
+
+const next = {
+  major: `${major + 1}.0.0`,
+  minor: `${major}.${minor + 1}.0`,
+  patch: `${major}.${minor}.${patch + 1}`,
+};
+
+const log = git('log', `${last}..HEAD`, '--oneline', '--no-merges');
+const commits = log ? log.split('\n') : [];
+if (commits.length === 0) die(`Nothing new since ${last}`);
+
+console.log(`\n${commits.length} commits since ${last}:\n`);
+for (const line of commits) console.log(`  ${line}`);
+
+if (!bump) {
+  console.log('\nNothing tagged. Pick a bump:');
+  for (const kind of BUMPS) console.log(`  npm run release -- ${kind}\t→ v${next[kind]}`);
+  console.log();
+  process.exit(0);
+}
+
+const tag = `v${next[bump]}`;
+git('tag', '-a', tag, '-m', `Release ${tag}`);
+git('push', 'origin', tag);
+console.log(`\n✓ ${tag} pushed — release.yml is building the image now.`);
+console.log(`  https://github.com/burtsdenis/family-hub/actions/workflows/release.yml\n`);

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { t } from '../lib/i18n';
-import { BUILD_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
+import { EXTRA_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
 import { useAuth } from '../lib/auth';
@@ -325,12 +325,9 @@ export function AppShell() {
               links worth having within reach. Settings → About repeats it
               for phones, where this sidebar does not exist. */}
           <div className="px-2 text-muted">
-            <p
-              className="font-mono text-xs"
-              title={BUILD_SHA ? `${VERSION} · ${BUILD_SHA}` : VERSION}
-            >
+            <p className="font-mono text-xs">
               v{VERSION}
-              {BUILD_SHA && <span className="ml-1.5 opacity-70">{BUILD_SHA}</span>}
+              {EXTRA_SHA && <span className="ml-1.5 opacity-70">{EXTRA_SHA}</span>}
             </p>
             <span className="mt-1.5 flex flex-col items-start gap-1 text-sm">
               <a

--- a/web/src/lib/build.ts
+++ b/web/src/lib/build.ts
@@ -17,6 +17,13 @@ export const VERSION = __APP_VERSION__;
 export const BUILD_SHA = __BUILD_SHA__;
 
 /**
+ * The commit, unless the version already names it. `git describe` ends a
+ * between-releases version in -g<sha>, and printing that sha again beside
+ * it says nothing twice.
+ */
+export const EXTRA_SHA = BUILD_SHA && !VERSION.includes(BUILD_SHA) ? BUILD_SHA : '';
+
+/**
  * Upstream, not the running host: a fork's bug reports still belong with
  * the project, and a self-hoster reading these links wants the source
  * they installed from.

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { lang, setLang, t } from '../lib/i18n';
-import { BUILD_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
+import { EXTRA_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
 import { formatStamp, setWeekStart, weekStart } from '../lib/format';
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../lib/api';
@@ -654,8 +654,8 @@ export function Settings() {
       <section className="mb-5 break-inside-avoid rounded-card border border-line bg-surface p-5">
         <h2 className="eyebrow mb-4">{t('About')}</h2>
         <p className="font-mono text-sm text-ink">Family Hub v{VERSION}</p>
-        {BUILD_SHA && (
-          <p className="mt-1 font-mono text-xs text-muted">{t('Build {sha}', { sha: BUILD_SHA })}</p>
+        {EXTRA_SHA && (
+          <p className="mt-1 font-mono text-xs text-muted">{t('Build {sha}', { sha: EXTRA_SHA })}</p>
         )}
         <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-sm">
           <a

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,21 +5,28 @@ import tailwindcss from '@tailwindcss/vite';
 import { VitePWA } from 'vite-plugin-pwa';
 
 /*
-  What the About block and the sidebar show. The version is the product's
-  own (the root manifest, bumped with the release tag); BUILD_SHA arrives
-  as a Docker build argument, because .git never enters the image.
+  What the About block and the sidebar show.
 
-  Running from source leaves the commit empty and only the version shows —
-  a dev build has no commit worth quoting.
+  BUILD_VERSION comes from `git describe --tags` (or the tag itself on a
+  release build), so it is derived rather than remembered: on a tag it
+  reads 1.1.0, and twelve commits later 1.1.0-12-gabc1234, which is the
+  literal truth about a continuously deployed hub. The manifest version
+  is only the fallback for a build with no git and no argument — a
+  tarball, or a plain `npm run build` — and it will drift, which is
+  exactly why nothing important depends on it.
+
+  BUILD_SHA is separate because .git never enters the image and the
+  commit is worth having even when the version already implies it.
 */
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
   version: string;
 };
 const BUILD_SHA = (process.env.BUILD_SHA ?? '').slice(0, 7);
+const BUILD_VERSION = (process.env.BUILD_VERSION ?? '').replace(/^v/, '') || pkg.version;
 
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(BUILD_VERSION),
     __BUILD_SHA__: JSON.stringify(BUILD_SHA),
   },
   plugins: [


### PR DESCRIPTION
## Why

The version was a number somebody had to remember to change, and it had already rotted once — the manifests sat at `0.1.0` through the whole of v1.0.0, and were still claiming `1.0.0` a hundred commits later while prod deploys on every push. A number that lies about which software is running is worse than no number.

Underneath is a real distinction the old scheme papered over: **releases and production answer to different clocks.** Prod is whatever master is; GHCR is whatever was last tagged. Self-hosters install the latter, so `latest` being 101 commits stale is the consequential half of this — anyone following the README today gets a hub from before Family profiles, the wishlist and the widget board.

## What this does

- **`BUILD_VERSION` comes from `git describe --tags`.** Exactly the tag on a release build; `1.1.0-12-gabc1234` between releases, which is the literal truth about a continuously deployed hub. Derived, not remembered — nothing to forget. The manifest version survives only as the fallback for a build with neither git nor the argument.
- **The commit prints separately only when the version does not already end in it**, so a between-releases build states its commit once.
- **`npm run release -- minor`** (or `patch` / `major`) cuts a release: refuses anything but a clean master matching origin, prints what is going out, then tags and pushes. With no argument it only shows the plan.

It **commits nothing**, and that is the design point: master takes pull requests only, so a version bump living in a file means a pull request and a CI wait *every day* under the daily cadence we agreed. A ritual that expensive is a ritual that stops — the same way the manual bump already did.

## How you know it works

Both identities verified by building the frontend with the arguments the Dockerfile will pass:

- `BUILD_VERSION=v1.1.0 BUILD_SHA=deadbeefcafe` → bundle carries `"1.1.0"` and `deadbee`, printed as version + commit.
- `BUILD_VERSION=v1.0.0-101-g98793df` → bundle carries `1.0.0-101-g98793df`, and the commit is not repeated beside it.

The script's guards were exercised for real: run on a dirty tree it refused with `Working tree is not clean` rather than tagging.

Also confirmed on the way in that the existing chain works end to end: prod currently serves `1.0.0` + `98793df`, and `98793df` is master's HEAD — so `BUILD_SHA` really does survive the runner → Docker → bundle path. `deploy.yml`'s checkout gains `fetch-depth: 0`, without which `git describe` has no tags to describe.

`npm run typecheck`, `npm run lint`, 160 tests pass.

## After merging

`npm run release -- minor` → **v1.1.0**, which is what you approved: two new sections (Family profiles with the wishlist, the widget board), four migrations (018–021), piggy banks, the About block — features, nothing breaking, so minor rather than major. That tag is also what finally moves GHCR `latest` off the v1.0.0 image.

## Anything you are unsure about

- The between-releases string is long — `1.1.0-12-gabc1234`. It fits the sidebar at 224px, but it is a mouthful next to a bare `v1.1.0`. Trimming it to `1.1.0+12` would read better and describe less precisely.
- `fetch-depth: 0` makes the deploy checkout clone the full history. At this repo's size that is noise, but it is not free forever.
- The script assumes tags are `vX.Y.Z` and reads the last one with `git describe --abbrev=0`. A stray non-semver tag would stop it with an honest error rather than guessing.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [x] Docs updated, if behaviour changed ([docs/](../docs))

🤖 Generated with [Claude Code](https://claude.com/claude-code)