### PR TITLE
The published image keeps the v it was tagged with

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
+            # v-prefixed on purpose: the image tag should read the same as
+            # the git tag it was cut from. metadata-action strips the v by
+            # default, which quietly made v1.0.0 ship as 1.0.0.
+            type=semver,pattern=v{{version}}
             type=raw,value=latest
       - uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The hub comes up on `http://localhost:8787` and is reachable from other devices 
 Tagged releases publish a prebuilt multi-arch image (amd64 + arm64, so Raspberry Pi works) to GitHub Container Registry — point `image:` in the compose file at it to skip building:
 
 ```bash
-docker pull ghcr.io/burtsdenis/family-hub:latest
+docker pull ghcr.io/burtsdenis/family-hub:latest   # or a pinned release: :v1.1.0
 ```
 
 For development:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,4 +94,13 @@ Settings → About and the foot of the sidebar name the version and the commit t
 
 Both are visible only behind the sign-in screen. `/api/health` withholds the version from the public internet deliberately, and a line under the login box would have handed it to every scanner instead.
 
-Two things follow for whoever cuts a release: bump the version in all three `package.json` files along with the tag, or the interface will keep announcing the previous one — and keep `--build-arg BUILD_SHA=…` on any hand-rolled `docker build`, or the commit line simply disappears.
+A hand-rolled `docker build` should pass `--build-arg BUILD_SHA=…`; without it the commit line simply disappears.
+
+### Cutting a release
+
+1. Everything merged and the docs caught up — both are written in the same pull requests as the code, not gathered up afterwards.
+2. Bump the version in all three `package.json` files in that day's last pull request, before tagging. Settings → About and the sidebar read it, so a manifest left behind announces the wrong release.
+3. `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. The tag starts `release.yml`: a multi-arch image (amd64 + arm64) to GHCR, 6–9 minutes, most of it arm64 under emulation. The image carries the same `vX.Y.Z` as the git tag.
+5. Write the release page by hand — [v1.0.0](https://github.com/burtsdenis/family-hub/releases/tag/v1.0.0) is the shape: a title that names the release, what it means in a paragraph, a section per headline feature, and an **Upgrading** block naming the migrations that will run and the exact image to pull. Generated notes do not do that job.
+6. Close the milestone, if one is open.


### PR DESCRIPTION
## Why

`docker/metadata-action` strips the `v` prefix by default, so **v1.0.0 shipped to GHCR as `1.0.0`** — the git tag and the image tag disagreed, and nobody chose that. `type=semver,pattern=v{{version}}` makes them read the same.

No compatibility to preserve: the README only ever documented `:latest`, and the bare `1.0.0` appears solely in the v1.0.0 release page, which stays valid — that image is not going anywhere. The README now spells out the pinned form as well, since that is the tag people will actually pin.

## Also here

The release ritual is written down in [architecture.md](docs/architecture.md) — it lived only in habit and in one paragraph about build identity:

1. everything merged, docs caught up in the same PRs
2. **bump the version in all three `package.json` files** in the day's last PR, before tagging
3. `git tag vX.Y.Z && git push origin vX.Y.Z`
4. `release.yml` builds the multi-arch image (6–9 minutes, mostly arm64 under emulation), now tagged `vX.Y.Z`
5. **write the release page by hand** — v1.0.0 is the shape; generated notes do not do that job
6. close the milestone if one is open

Step 2 is the new one, and it is not bureaucracy: the version is now on screen in Settings → About and at the foot of the sidebar, so a manifest left at `1.0.0` would have the interface announcing the wrong release. That instruction already existed in a paragraph about build identity; it belongs in the checklist.

## How you know it works

Nothing to run — this is workflow configuration. The proof arrives with the next release: the image should appear as `ghcr.io/burtsdenis/family-hub:v1.1.0` alongside `latest`. If it comes out bare again, the pattern is wrong and it is a one-line fix.

## Anything you are unsure about

Registry convention is usually the *other* way — `node:22`, `postgres:16` carry no `v`, which is why the action strips it by default. Matching our own git tag is the more useful consistency here, but it is a deliberate step away from the ecosystem norm rather than an oversight.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [x] Docs updated, if behaviour changed ([docs/](../docs))

🤖 Generated with [Claude Code](https://claude.com/claude-code)