### PR TITLE
docs: write down how a release is cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The hub comes up on `http://localhost:8787` and is reachable from other devices 
 Tagged releases publish a prebuilt multi-arch image (amd64 + arm64, so Raspberry Pi works) to GitHub Container Registry — point `image:` in the compose file at it to skip building:
 
 ```bash
-docker pull ghcr.io/burtsdenis/family-hub:latest
+docker pull ghcr.io/burtsdenis/family-hub:latest   # or a pinned release: :1.1.0
 ```
 
 For development:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,4 +94,15 @@ Settings → About and the foot of the sidebar name the version and the commit t
 
 Both are visible only behind the sign-in screen. `/api/health` withholds the version from the public internet deliberately, and a line under the login box would have handed it to every scanner instead.
 
-Two things follow for whoever cuts a release: bump the version in all three `package.json` files along with the tag, or the interface will keep announcing the previous one — and keep `--build-arg BUILD_SHA=…` on any hand-rolled `docker build`, or the commit line simply disappears.
+A hand-rolled `docker build` should pass `--build-arg BUILD_SHA=…`; without it the commit line simply disappears.
+
+### Cutting a release
+
+1. Everything merged and the docs caught up — both are written in the same pull requests as the code, not gathered up afterwards.
+2. Bump the version in all three `package.json` files in that day's last pull request, before tagging. Settings → About and the sidebar read it, so a manifest left behind announces the wrong release.
+3. `git tag vX.Y.Z && git push origin vX.Y.Z`.
+4. The tag starts `release.yml`: a multi-arch image (amd64 + arm64) to GHCR, 6–9 minutes, most of it arm64 under emulation.
+5. Write the release page by hand — [v1.0.0](https://github.com/burtsdenis/family-hub/releases/tag/v1.0.0) is the shape: a title that names the release, what it means in a paragraph, a section per headline feature, and an **Upgrading** block naming the migrations that will run and the exact image to pull. Generated notes do not do that job.
+6. Close the milestone, if one is open.
+
+The git tag carries a `v` and the image tag does not — `v1.1.0` in the repository, `ghcr.io/burtsdenis/family-hub:1.1.0` in the registry. That is `docker/metadata-action` following registry convention (`node:22`, `postgres:16` carry no prefix), not a prefix going missing. It reads like a bug often enough to be worth writing down.


### PR DESCRIPTION
## Why

The release ritual lived in habit and in one paragraph about build identity. It is five steps and one of them is new, so it belongs on paper:

1. everything merged, docs caught up in the same PRs
2. **bump the version in all three `package.json` files** in the day's last PR, before tagging
3. `git tag vX.Y.Z && git push origin vX.Y.Z`
4. `release.yml` builds the multi-arch image (6–9 minutes, mostly arm64 under emulation)
5. **write the release page by hand** — v1.0.0 is the shape; generated notes do not do that job
6. close the milestone if one is open

Step 2 is the new one, and it is not bureaucracy: the version now shows in Settings → About and at the foot of the sidebar, so a manifest left at `1.0.0` has the interface announcing the wrong release.

It also records something that reads as a bug and is not: the git tag carries a `v`, the image tag does not — `v1.1.0` in the repository, `family-hub:1.1.0` in the registry. That is `docker/metadata-action` following registry convention (`node:22`, `postgres:16`). I took it for a lost prefix earlier today and changed it before checking; the next person deserves the sentence I did not have.

## How you know it works

Documentation only — no code, no workflow changes. The README gains the pinned form (`:1.1.0`) beside `:latest`, since that is the tag someone would actually pin.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [x] Docs updated, if behaviour changed ([docs/](../docs))

🤖 Generated with [Claude Code](https://claude.com/claude-code)