### PR TITLE
chore: version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "family-hub",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

The manifest bump that precedes the `v1.1.0` tag, per the ritual just written into [architecture.md](docs/architecture.md). The interface reads this number — Settings → About and the foot of the sidebar — so shipping the tag without it would have the hub announcing `1.0.0` for a release that adds two whole sections.

This is the step that did not exist for v0.2.0 or v1.0.0, which is exactly how the manifests came to sit at `0.1.0` through an entire major release.

## How you know it works

`npm run typecheck` and 160 tests pass; nothing but three version strings changed. The number becomes visible after the next deploy, and the tag follows immediately.

---

- [x] `npm run typecheck`, `npm run lint` and `npm test` pass locally
- [x] Branched from `master`
- [ ] Docs updated — no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)