### PR TITLE
feat: agenda rows tell tasks from events, width buys a second column

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -222,8 +222,10 @@ The **agenda** is the week in one card — overdue, then today (events
 with times and tasks together), then only the days ahead that actually
 hold something. An empty day is silence, not an empty panel. A task
 wears a checkbox — tickable right on the board — an event its
-calendar-coloured dot. At full row width the card splits in two: the
-now (overdue and today) beside the week ahead. The **mini
+calendar-coloured dot. At full row width the card splits in two — the
+now (overdue and today) beside the week ahead — and the rows grow
+detail: the project or calendar, a line of the description, who a task
+is on. The **mini
 month** marks days with dots in calendar colours; a day click opens the
 calendar there. The **balance** answers the question the accounts screen
 answers badly — not how much is there, but how much of it is already

--- a/docs/features.md
+++ b/docs/features.md
@@ -220,7 +220,10 @@ target the widget is simply not there.
 
 The **agenda** is the week in one card — overdue, then today (events
 with times and tasks together), then only the days ahead that actually
-hold something. An empty day is silence, not an empty panel. The **mini
+hold something. An empty day is silence, not an empty panel. A task
+wears a checkbox — tickable right on the board — an event its
+calendar-coloured dot. At full row width the card splits in two: the
+now (overdue and today) beside the week ahead. The **mini
 month** marks days with dots in calendar colours; a day click opens the
 calendar there. The **balance** answers the question the accounts screen
 answers badly — not how much is there, but how much of it is already

--- a/docs/features.md
+++ b/docs/features.md
@@ -223,9 +223,9 @@ with times and tasks together), then only the days ahead that actually
 hold something. An empty day is silence, not an empty panel. A task
 wears a checkbox — tickable right on the board — an event its
 calendar-coloured dot. At full row width the card splits in two — the
-now (overdue and today) beside the week ahead — and the rows grow
-detail: the project or calendar, a line of the description, who a task
-is on. The **mini
+now (overdue and today) beside the week ahead. Today's rows unfold
+there: the description in full, the project or calendar, who a task is
+on. The week ahead stays terse — a whole week of detail is noise. The **mini
 month** marks days with dots in calendar colours; a day click opens the
 calendar there. The **balance** answers the question the accounts screen
 answers badly — not how much is there, but how much of it is already

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -93,14 +93,16 @@ export async function seedDemo(): Promise<void> {
     ).run(home, alex, trip, alex);
 
     const paint = id();
+    // Descriptions on the dated ones: the wide agenda shows a line of
+    // the description, and it should have something to show
     db.prepare(
-      `INSERT INTO tasks (id, project_id, level, title, status, priority, due_date, assignee_id, position, created_by) VALUES
-       (?, ?, 0, 'Repaint the hallway', 'in_progress', 'normal', ?, ?, 1, ?),
-       (?, ?, 1, 'Pick the colour together', 'done', 'normal', NULL, ?, 2, ?),
-       (?, ?, 1, 'Buy paint and tape', 'todo', 'high', ?, ?, 3, ?),
-       (?, ?, 0, 'Fix the dripping tap', 'todo', 'urgent', ?, ?, 4, ?),
-       (?, ?, 0, 'Book the ferry', 'todo', 'high', ?, ?, 5, ?),
-       (?, ?, 0, 'Renew passports', 'backlog', 'normal', NULL, NULL, 6, ?)`,
+      `INSERT INTO tasks (id, project_id, level, title, description, status, priority, due_date, assignee_id, position, created_by) VALUES
+       (?, ?, 0, 'Repaint the hallway', NULL, 'in_progress', 'normal', ?, ?, 1, ?),
+       (?, ?, 1, 'Pick the colour together', NULL, 'done', 'normal', NULL, ?, 2, ?),
+       (?, ?, 1, 'Buy paint and tape', 'Two cans of Misty Sage and the wide tape', 'todo', 'high', ?, ?, 3, ?),
+       (?, ?, 0, 'Fix the dripping tap', 'The kitchen one — the washer kit is in the garage', 'todo', 'urgent', ?, ?, 4, ?),
+       (?, ?, 0, 'Book the ferry', 'The evening crossing, the cabin with a window', 'todo', 'high', ?, ?, 5, ?),
+       (?, ?, 0, 'Renew passports', NULL, 'backlog', 'normal', NULL, NULL, 6, ?)`,
     ).run(
       paint, home, day(5), alex, alex,
       id(), home, sam, alex,
@@ -139,10 +141,10 @@ export async function seedDemo(): Promise<void> {
     const dentist = id();
     const birthday = id();
     db.prepare(
-      `INSERT INTO events (id, calendar_id, title, location, starts_at, ends_at, all_day, recurrence_rule, remind_days_before, created_by) VALUES
-       (?, ?, 'Gym', 'Iron Temple', ?, ?, 0, 'FREQ=WEEKLY;INTERVAL=1', NULL, ?),
-       (?, ?, 'Dentist', 'Dr. Molar', ?, ?, 0, NULL, 1, ?),
-       (?, ?, 'Grandma''s birthday', NULL, ?, ?, 1, 'FREQ=YEARLY;INTERVAL=1', 7, ?)`,
+      `INSERT INTO events (id, calendar_id, title, description, location, starts_at, ends_at, all_day, recurrence_rule, remind_days_before, created_by) VALUES
+       (?, ?, 'Gym', 'Legs and the sauna after', 'Iron Temple', ?, ?, 0, 'FREQ=WEEKLY;INTERVAL=1', NULL, ?),
+       (?, ?, 'Dentist', 'The crown on the left, ask about a night guard', 'Dr. Molar', ?, ?, 0, NULL, 1, ?),
+       (?, ?, 'Grandma''s birthday', NULL, NULL, ?, ?, 1, 'FREQ=YEARLY;INTERVAL=1', 7, ?)`,
     ).run(
       gym, shared, `${day(1)}T18:30`, `${day(1)}T20:00`, alex,
       dentist, shared, `${day(3)}T11:00`, `${day(3)}T11:45`, sam,

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -140,19 +140,25 @@ export async function seedDemo(): Promise<void> {
     const gym = id();
     const dentist = id();
     const birthday = id();
+    const movie = id();
+    // The movie lands on "today": the wide agenda unfolds today's rows
+    // (description, calendar), and the template must always have one
+    // event there to unfold
     db.prepare(
       `INSERT INTO events (id, calendar_id, title, description, location, starts_at, ends_at, all_day, recurrence_rule, remind_days_before, created_by) VALUES
+       (?, ?, 'Movie night', 'The new Miyazaki — tickets are in the mail', 'Odeon', ?, ?, 0, NULL, NULL, ?),
        (?, ?, 'Gym', 'Legs and the sauna after', 'Iron Temple', ?, ?, 0, 'FREQ=WEEKLY;INTERVAL=1', NULL, ?),
        (?, ?, 'Dentist', 'The crown on the left, ask about a night guard', 'Dr. Molar', ?, ?, 0, NULL, 1, ?),
        (?, ?, 'Grandma''s birthday', NULL, NULL, ?, ?, 1, 'FREQ=YEARLY;INTERVAL=1', 7, ?)`,
     ).run(
+      movie, shared, `${day(0)}T20:00`, `${day(0)}T22:30`, sam,
       gym, shared, `${day(1)}T18:30`, `${day(1)}T20:00`, alex,
       dentist, shared, `${day(3)}T11:00`, `${day(3)}T11:45`, sam,
       birthday, shared, day(9), day(9), alex,
     );
     db.prepare(
-      `INSERT INTO event_participants (event_id, user_id) VALUES (?, ?), (?, ?), (?, ?)`,
-    ).run(gym, alex, gym, sam, dentist, sam);
+      `INSERT INTO event_participants (event_id, user_id) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)`,
+    ).run(gym, alex, gym, sam, dentist, sam, movie, alex, movie, sam);
 
     // ── Family mail ──
     // A believable paperwork inbox; one message is already a task, so

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -249,8 +249,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     */
     const dueToday = db
       .prepare(
-        `SELECT t.*, p.title AS project_title, p.color AS project_color
+        `SELECT t.*, p.title AS project_title, p.color AS project_color,
+                u.name AS assignee_name, u.color AS assignee_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
+           LEFT JOIN users u ON u.id = t.assignee_id
           WHERE coalesce(t.expected_date, t.due_date) = ?
             AND t.status NOT IN ('done','cancelled')
           ORDER BY t.priority DESC`,
@@ -259,8 +261,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
 
     const overdue = db
       .prepare(
-        `SELECT t.*, p.title AS project_title, p.color AS project_color
+        `SELECT t.*, p.title AS project_title, p.color AS project_color,
+                u.name AS assignee_name, u.color AS assignee_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
+           LEFT JOIN users u ON u.id = t.assignee_id
           WHERE coalesce(t.expected_date, t.due_date) < ?
             AND t.status NOT IN ('done','cancelled')
           ORDER BY coalesce(t.expected_date, t.due_date)`,
@@ -269,8 +273,10 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
 
     const upcoming = db
       .prepare(
-        `SELECT t.*, p.title AS project_title, p.color AS project_color
+        `SELECT t.*, p.title AS project_title, p.color AS project_color,
+                u.name AS assignee_name, u.color AS assignee_color
            FROM tasks t JOIN projects p ON p.id = t.project_id
+           LEFT JOIN users u ON u.id = t.assignee_id
           WHERE coalesce(t.expected_date, t.due_date) > ?
             AND coalesce(t.expected_date, t.due_date) <= date(?, '+7 days')
             AND t.status NOT IN ('done','cancelled')

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -68,11 +68,14 @@ function TaskRow({
   task,
   showDate,
   overdue,
+  detailed,
   onChanged,
 }: {
   task: Task;
   showDate?: boolean;
   overdue?: boolean;
+  /** Width permitting, unfold description/project/assignee under the title. */
+  detailed?: boolean;
   onChanged: () => void;
 }) {
   const [busy, setBusy] = useState(false);
@@ -92,106 +95,124 @@ function TaskRow({
   }
 
   return (
-    <li className="flex items-center border-b border-line last:border-0">
+    <li className="flex items-start border-b border-line last:border-0">
       <input
         type="checkbox"
         checked={busy}
         disabled={busy}
         onChange={() => void toggle()}
         aria-label={t('Mark as done')}
-        className="ml-4 size-4 shrink-0 accent-[var(--c-done)]"
+        className="mt-3 ml-4 size-4 shrink-0 accent-[var(--c-done)]"
       />
       <Link
         to={`/tasks?open=${task.id}`}
-        className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 transition-colors hover:bg-surface-2">
-      <span className="min-w-0 flex-1 truncate text-sm text-ink">{task.title}</span>
-      {/* Width permitting (the card's own width — the agenda is a
-          container), the row grows what the task page would show:
-          the project, a line of the description, who it is on. */}
-      <span className="hidden shrink-0 items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted @4xl:inline-flex">
-        <span
-          className="size-1.5 rounded-full"
-          style={{ backgroundColor: task.project_color ?? 'var(--c-accent)' }}
-          aria-hidden
-        />
-        {projectTitle(task.project_id, task.project_title ?? '')}
-      </span>
-      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted @4xl:block">
-        {task.description}
-      </span>
-      {task.assignee_name && (
-        <span
-          className="hidden size-5 shrink-0 place-items-center rounded-full text-[0.625rem] font-medium text-white @4xl:grid"
-          style={{ backgroundColor: task.assignee_color ?? 'var(--c-accent)' }}
-          title={task.assignee_name}
-        >
-          {task.assignee_name.slice(0, 1)}
-        </span>
-      )}
-      {task.priority === 'urgent' && (
-        <span className="shrink-0 rounded-full border border-urgent/40 bg-urgent/10 px-2 py-0.5 font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
-          {PRIORITY_LABEL.urgent}
-        </span>
-      )}
+        className="min-w-0 flex-1 px-3 py-2.5 transition-colors hover:bg-surface-2">
+      <span className="flex items-center gap-3">
+        <span className="min-w-0 flex-1 truncate text-sm text-ink">{task.title}</span>
+        {task.priority === 'urgent' && (
+          <span className="shrink-0 rounded-full border border-urgent/40 bg-urgent/10 px-2 py-0.5 font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
+            {PRIORITY_LABEL.urgent}
+          </span>
+        )}
         {showDate && effectiveDate(task) && (
-          <span className={`font-mono text-xs ${overdue ? 'text-urgent' : 'text-muted'}`}>
+          <span className={`shrink-0 font-mono text-xs ${overdue ? 'text-urgent' : 'text-muted'}`}>
             {formatDate(effectiveDate(task)!)}
           </span>
         )}
+      </span>
+      {/* The now column of a wide card has room to breathe, so the
+          detail goes under the title, unhurried: the description in
+          full, then the project and who the task is on. The week-ahead
+          rows stay terse everywhere — a whole week of detail is noise. */}
+      {detailed && (
+        <span className="mt-1 hidden @4xl:block">
+          {task.description && (
+            <span className="block text-xs leading-relaxed text-muted">{task.description}</span>
+          )}
+          <span className="mt-1.5 flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted">
+              <span
+                className="size-1.5 rounded-full"
+                style={{ backgroundColor: task.project_color ?? 'var(--c-accent)' }}
+                aria-hidden
+              />
+              {projectTitle(task.project_id, task.project_title ?? '')}
+            </span>
+            {task.assignee_name && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted">
+                <span
+                  className="grid size-4 place-items-center rounded-full text-[0.5625rem] font-medium text-white"
+                  style={{ backgroundColor: task.assignee_color ?? 'var(--c-accent)' }}
+                >
+                  {task.assignee_name.slice(0, 1)}
+                </span>
+                {task.assignee_name}
+              </span>
+            )}
+          </span>
+        </span>
+      )}
       </Link>
     </li>
   );
 }
 
-function EventRow({ occurrence }: { occurrence: Occurrence }) {
+function EventRow({ occurrence, detailed }: { occurrence: Occurrence; detailed?: boolean }) {
   const time = timeOf(occurrence.starts_at);
   return (
     <li className="border-b border-line last:border-0">
       <Link
         to={`/calendar?date=${occurrence.date}`}
-        className="flex items-center gap-3 px-4 py-2.5 transition-colors hover:bg-surface-2">
-      <span
-        className="size-2 shrink-0 rounded-full"
-        style={{ backgroundColor: occurrence.calendar_color }}
-        aria-hidden
-      />
-      <span className="min-w-0 flex-1 truncate text-sm text-ink">
-        {occurrence.title}
-        {occurrence.age !== null && <span className="ml-2 text-muted">{occurrence.age}</span>}
-      </span>
-      {/* Same rule as the task row: a wide card earns the calendar's
-          name and a line of the description. */}
-      <span className="hidden shrink-0 items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted @4xl:inline-flex">
+        className="block px-4 py-2.5 transition-colors hover:bg-surface-2">
+      <span className="flex items-center gap-3">
         <span
-          className="size-1.5 rounded-full"
+          className="size-2 shrink-0 rounded-full"
           style={{ backgroundColor: occurrence.calendar_color }}
           aria-hidden
         />
-        {calendarName(occurrence.calendar_id, occurrence.calendar_name)}
+        <span className="min-w-0 flex-1 truncate text-sm text-ink">
+          {occurrence.title}
+          {occurrence.age !== null && <span className="ml-2 text-muted">{occurrence.age}</span>}
+        </span>
+        {occurrence.participants.length > 0 && (
+          <span
+            className="flex shrink-0 -space-x-1"
+            title={occurrence.participants.map((p) => p.name).join(', ')}
+          >
+            {occurrence.participants.slice(0, 3).map((p) => (
+              <span
+                key={p.id}
+                className="grid size-5 place-items-center rounded-full text-[0.625rem] font-medium text-white ring-1 ring-surface"
+                style={{ backgroundColor: p.color }}
+              >
+                {p.name.slice(0, 1)}
+              </span>
+            ))}
+          </span>
+        )}
+        {occurrence.location && (
+          <span className="hidden truncate text-xs text-muted sm:inline">{occurrence.location}</span>
+        )}
+        <span className="shrink-0 font-mono text-xs text-muted">{time || t('all day')}</span>
       </span>
-      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted @4xl:block">
-        {occurrence.description}
-      </span>
-      {occurrence.participants.length > 0 && (
-        <span
-          className="flex shrink-0 -space-x-1"
-          title={occurrence.participants.map((p) => p.name).join(', ')}
-        >
-          {occurrence.participants.slice(0, 3).map((p) => (
-            <span
-              key={p.id}
-              className="grid size-5 place-items-center rounded-full text-[0.625rem] font-medium text-white ring-1 ring-surface"
-              style={{ backgroundColor: p.color }}
-            >
-              {p.name.slice(0, 1)}
+      {/* Same rule as the task row: today's rows on a wide card unfold. */}
+      {detailed && (
+        <span className="mt-1 hidden pl-5 @4xl:block">
+          {occurrence.description && (
+            <span className="block text-xs leading-relaxed text-muted">
+              {occurrence.description}
             </span>
-          ))}
+          )}
+          <span className="mt-1.5 inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted">
+            <span
+              className="size-1.5 rounded-full"
+              style={{ backgroundColor: occurrence.calendar_color }}
+              aria-hidden
+            />
+            {calendarName(occurrence.calendar_id, occurrence.calendar_name)}
+          </span>
         </span>
       )}
-      {occurrence.location && (
-        <span className="hidden truncate text-xs text-muted sm:inline">{occurrence.location}</span>
-      )}
-        <span className="font-mono text-xs text-muted">{time || t('all day')}</span>
       </Link>
     </li>
   );
@@ -301,7 +322,7 @@ function Agenda({
           <GroupHeader label={t('Overdue')} count={data.overdue.length} alarm />
           <ul>
             {data.overdue.map((task) => (
-              <TaskRow key={task.id} task={task} showDate overdue onChanged={onChanged} />
+              <TaskRow key={task.id} task={task} showDate overdue detailed onChanged={onChanged} />
             ))}
           </ul>
         </>
@@ -319,10 +340,10 @@ function Agenda({
       ) : (
         <ul>
           {data.todayEvents.map((o) => (
-            <EventRow key={o.id} occurrence={o} />
+            <EventRow key={o.id} occurrence={o} detailed />
           ))}
           {data.dueToday.map((task) => (
-            <TaskRow key={task.id} task={task} onChanged={onChanged} />
+            <TaskRow key={task.id} task={task} detailed onChanged={onChanged} />
           ))}
         </ul>
       )}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -57,19 +57,53 @@ const PRIORITY_LABEL: Record<Task['priority'], string> = {
   Every dashboard row leads to where something can be done about it.
   A task opens its card, an event the calendar at the right date, a note
   the note itself. Showing a list with nowhere to go is a dead end.
+
+  A task wears the hub's own task marker — a checkbox, tickable right
+  here — while an event keeps its calendar-coloured dot. The two used to
+  share the dot and were indistinguishable at a glance (the colours mean
+  project vs calendar, which nobody remembers).
 */
 // showDate: whether a date renders at all; overdue: whether it's alarming.
-function TaskRow({ task, showDate, overdue }: { task: Task; showDate?: boolean; overdue?: boolean }) {
+function TaskRow({
+  task,
+  showDate,
+  overdue,
+  onChanged,
+}: {
+  task: Task;
+  showDate?: boolean;
+  overdue?: boolean;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  // The row disappears on reload rather than flipping to a "done" state:
+  // the agenda lists only open work. `checked` follows busy so the tick
+  // is visible for the moment the save takes.
+  async function toggle() {
+    setBusy(true);
+    try {
+      await api.patch(`/tasks/${task.id}`, { status: 'done' });
+      onChanged();
+    } catch (err) {
+      reportFailure(err instanceof Error ? err.message : t('Could not save'));
+      setBusy(false);
+    }
+  }
+
   return (
-    <li className="border-b border-line last:border-0">
+    <li className="flex items-center border-b border-line last:border-0">
+      <input
+        type="checkbox"
+        checked={busy}
+        disabled={busy}
+        onChange={() => void toggle()}
+        aria-label={t('Mark as done')}
+        className="ml-4 size-4 shrink-0 accent-[var(--c-done)]"
+      />
       <Link
         to={`/tasks?open=${task.id}`}
-        className="flex items-center gap-3 px-4 py-2.5 transition-colors hover:bg-surface-2">
-      <span
-        className="size-2 shrink-0 rounded-full"
-        style={{ backgroundColor: task.project_color ?? 'var(--c-accent)' }}
-        aria-hidden
-      />
+        className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 transition-colors hover:bg-surface-2">
       <span className="min-w-0 flex-1 truncate text-sm text-ink">{task.title}</span>
       {task.priority === 'urgent' && (
         <span className="shrink-0 rounded-full border border-urgent/40 bg-urgent/10 px-2 py-0.5 font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
@@ -209,10 +243,12 @@ function Agenda({
   data,
   monthEvents,
   today: t0,
+  onChanged,
 }: {
   data: DashboardData;
   monthEvents: Occurrence[];
   today: string;
+  onChanged: () => void;
 }) {
   const days = Array.from({ length: 7 }, (_, i) => addDays(t0, i + 1)).map((date) => ({
     date,
@@ -222,14 +258,14 @@ function Agenda({
   const busyDays = days.filter((d) => d.events.length + d.tasks.length > 0);
   const nothingToday = data.dueToday.length === 0 && data.todayEvents.length === 0;
 
-  return (
-    <section className="overflow-hidden rounded-card border border-line bg-surface">
+  const now = (
+    <div>
       {data.overdue.length > 0 && (
         <>
           <GroupHeader label={t('Overdue')} count={data.overdue.length} alarm />
           <ul>
             {data.overdue.map((task) => (
-              <TaskRow key={task.id} task={task} showDate overdue />
+              <TaskRow key={task.id} task={task} showDate overdue onChanged={onChanged} />
             ))}
           </ul>
         </>
@@ -250,11 +286,15 @@ function Agenda({
             <EventRow key={o.id} occurrence={o} />
           ))}
           {data.dueToday.map((task) => (
-            <TaskRow key={task.id} task={task} />
+            <TaskRow key={task.id} task={task} onChanged={onChanged} />
           ))}
         </ul>
       )}
+    </div>
+  );
 
+  const ahead = (
+    <div>
       {busyDays.map((d, i) => (
         <div key={d.date}>
           <GroupHeader
@@ -270,7 +310,7 @@ function Agenda({
               <EventRow key={o.id} occurrence={o} />
             ))}
             {d.tasks.map((task) => (
-              <TaskRow key={task.id} task={task} />
+              <TaskRow key={task.id} task={task} onChanged={onChanged} />
             ))}
           </ul>
         </div>
@@ -278,6 +318,19 @@ function Agenda({
       {busyDays.length === 0 && (
         <p className="px-4 py-3 text-sm text-muted">{t('The week ahead is clear.')}</p>
       )}
+    </div>
+  );
+
+  return (
+    <section className="@container overflow-hidden rounded-card border border-line bg-surface">
+      {/* Width buys structure, not just wider rows: once the card itself
+          is wide enough (the full row of a big screen), the now and the
+          week ahead sit side by side. A container query, not a viewport
+          one — the same widget can be a half-row on the same screen. */}
+      <div className="@4xl:grid @4xl:grid-cols-2 @4xl:divide-x @4xl:divide-line">
+        {now}
+        {ahead}
+      </div>
     </section>
   );
 }
@@ -706,6 +759,12 @@ export function Dashboard() {
     setAdding(false);
   }
 
+  // Ticking a task off the agenda changes every bucket at once (overdue,
+  // today, the week). Bumping the tick re-runs the loading effect — one
+  // refetch, and the interval restarts with it.
+  const [tick, setTick] = useState(0);
+  const refresh = useCallback(() => setTick((n) => n + 1), []);
+
   useEffect(() => {
     let alive = true;
     const load = () => {
@@ -753,7 +812,7 @@ export function Dashboard() {
       alive = false;
       clearInterval(timer);
     };
-  }, []);
+  }, [tick]);
 
   if (error && !data) {
     return (
@@ -786,7 +845,7 @@ export function Dashboard() {
         }
       />
     ) : null,
-    agenda: <Agenda data={data} monthEvents={monthEvents} today={data.today} />,
+    agenda: <Agenda data={data} monthEvents={monthEvents} today={data.today} onChanged={refresh} />,
     month: <MiniMonth today={data.today} occurrences={monthEvents} />,
     balance:
       outlook && outlook.currencies.length > 0 ? (

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/core';
 import { api, ApiError, type Dashboard as DashboardData, type Task } from '../lib/api';
-import type { Occurrence } from '../lib/calendar';
+import { calendarName, type Occurrence } from '../lib/calendar';
 import { loadLocal, saveLocal } from '../lib/storage';
 import { reportFailure } from '../lib/failures';
 import {
@@ -41,7 +41,7 @@ import {
   weekdayIndex,
 } from '../lib/format';
 import { formatMoney, monthBounds, type Category, type Outlook, type Summary } from '../lib/money';
-import { effectiveDate, today } from '../lib/tasks';
+import { effectiveDate, projectTitle, today } from '../lib/tasks';
 import { GoalBoard, hasGoal } from '../components/GoalBoard';
 import { BalancePanel } from '../components/BalancePanel';
 import { Page } from '../components/Page';
@@ -105,6 +105,29 @@ function TaskRow({
         to={`/tasks?open=${task.id}`}
         className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 transition-colors hover:bg-surface-2">
       <span className="min-w-0 flex-1 truncate text-sm text-ink">{task.title}</span>
+      {/* Width permitting (the card's own width — the agenda is a
+          container), the row grows what the task page would show:
+          the project, a line of the description, who it is on. */}
+      <span className="hidden shrink-0 items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted @4xl:inline-flex">
+        <span
+          className="size-1.5 rounded-full"
+          style={{ backgroundColor: task.project_color ?? 'var(--c-accent)' }}
+          aria-hidden
+        />
+        {projectTitle(task.project_id, task.project_title ?? '')}
+      </span>
+      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted @4xl:block">
+        {task.description}
+      </span>
+      {task.assignee_name && (
+        <span
+          className="hidden size-5 shrink-0 place-items-center rounded-full text-[0.625rem] font-medium text-white @4xl:grid"
+          style={{ backgroundColor: task.assignee_color ?? 'var(--c-accent)' }}
+          title={task.assignee_name}
+        >
+          {task.assignee_name.slice(0, 1)}
+        </span>
+      )}
       {task.priority === 'urgent' && (
         <span className="shrink-0 rounded-full border border-urgent/40 bg-urgent/10 px-2 py-0.5 font-mono text-[0.625rem] tracking-wide text-urgent uppercase">
           {PRIORITY_LABEL.urgent}
@@ -135,6 +158,19 @@ function EventRow({ occurrence }: { occurrence: Occurrence }) {
       <span className="min-w-0 flex-1 truncate text-sm text-ink">
         {occurrence.title}
         {occurrence.age !== null && <span className="ml-2 text-muted">{occurrence.age}</span>}
+      </span>
+      {/* Same rule as the task row: a wide card earns the calendar's
+          name and a line of the description. */}
+      <span className="hidden shrink-0 items-center gap-1.5 rounded-full border border-line bg-surface-2 px-2 py-0.5 text-xs text-muted @4xl:inline-flex">
+        <span
+          className="size-1.5 rounded-full"
+          style={{ backgroundColor: occurrence.calendar_color }}
+          aria-hidden
+        />
+        {calendarName(occurrence.calendar_id, occurrence.calendar_name)}
+      </span>
+      <span className="hidden min-w-0 flex-1 truncate text-xs text-muted @4xl:block">
+        {occurrence.description}
       </span>
       {occurrence.participants.length > 0 && (
         <span

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -165,11 +165,14 @@ function EventRow({ occurrence, detailed }: { occurrence: Occurrence; detailed?:
         to={`/calendar?date=${occurrence.date}`}
         className="block px-4 py-2.5 transition-colors hover:bg-surface-2">
       <span className="flex items-center gap-3">
-        <span
-          className="size-2 shrink-0 rounded-full"
-          style={{ backgroundColor: occurrence.calendar_color }}
-          aria-hidden
-        />
+        {/* The dot sits in a checkbox-sized box: mixed lists put events
+            and tasks under each other, and the titles must share a column */}
+        <span className="grid size-4 shrink-0 place-items-center" aria-hidden>
+          <span
+            className="size-2 rounded-full"
+            style={{ backgroundColor: occurrence.calendar_color }}
+          />
+        </span>
         <span className="min-w-0 flex-1 truncate text-sm text-ink">
           {occurrence.title}
           {occurrence.age !== null && <span className="ml-2 text-muted">{occurrence.age}</span>}
@@ -197,7 +200,7 @@ function EventRow({ occurrence, detailed }: { occurrence: Occurrence; detailed?:
       </span>
       {/* Same rule as the task row: today's rows on a wide card unfold. */}
       {detailed && (
-        <span className="mt-1 hidden pl-5 @4xl:block">
+        <span className="mt-1 hidden pl-7 @4xl:block">
           {occurrence.description && (
             <span className="block text-xs leading-relaxed text-muted">
               {occurrence.description}


### PR DESCRIPTION
Two complaints about the agenda, one PR.

**A task and an event were indistinguishable.** Both wore a coloured dot, and the colours could not tell them apart either — one means a project, the other a calendar, which nobody remembers. A task now wears the hub's own task marker: a checkbox. A working one — ticking it closes the task right on the board, exactly the way the task list does it (same PATCH, same `reportFailure` toast on error). The row disappears on refresh rather than flipping to a crossed-out state: the agenda lists only open work, same as the balance widget's bills. Closing the most frequent action in the app used to require leaving the dashboard; now it doesn't.

**Size 8 only made the lines longer.** Now width buys structure: once the card itself is wide enough (`@4xl`), the now — overdue and today — and the week ahead sit side by side as two columns. A container query, not a viewport one, same as the goal board: the identical card is a half-row on the same screen and must stay a single column there.

Ticking a task refetches the whole dashboard payload — one closed task can touch every bucket at once (overdue, today, the week) — and restarts the kiosk's 60-second interval with it.

### Checks

`typecheck`, `lint`, 167 tests. Verified live in the sandbox: checkbox ticks a task and the agenda refreshes ("Всё на сегодня закрыто"), two columns at size 8, single column at size 4 (`grid-template-columns: none` confirmed at 750px), mobile viewport single column with checkboxes and dots clearly apart.