### PR TITLE
chore: version 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "family-hub",
-  "version": "0.1.0",
+  "name": "neiliro",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "family-hub",
-      "version": "0.1.0",
+      "name": "neiliro",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -12065,7 +12065,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12090,7 +12090,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump ahead of the `v1.2.0` tag — Settings → About and the sidebar foot read it, so it lands before the tag rather than after.

Also regenerates `package-lock.json`, which still said `family-hub` at version `0.1.0`: the rebrand changed `package.json` and left the lock behind, and the bumps before it never touched the lock either. Run with `--package-lock-only`, so the diff is names and versions only — no dependency tree movement.

Checks: typecheck, 167 tests green.