### PR TITLE
feat: hosted mode — one server, many families, routed by subdomain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,11 @@ TZ=UTC
 
 # Where the throwaway demo data lives.
 #DEMO_DATA_DIR=/srv/family-hub/demo-data
+
+# ── Hosted mode (multi-family, one server) ──────────────────────────────────
+
+# Many families on one server, one database file each, routed by subdomain.
+# Not needed for self-hosting a single family — leave both unset.
+# See docs/architecture.md, "Hosted mode".
+#HOSTED_MODE=true
+#HOSTED_DOMAIN=example.com

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,16 @@ Visitors can create, edit and delete anything — nobody else will ever see it, 
 
 Deploying a public demo next to a production hub: [deploy-vps.md](deploy-vps.md), "Public demo".
 
+## Hosted mode
+
+`HOSTED_MODE=true` (plus `HOSTED_DOMAIN`) turns one server into many hubs: **family = subdomain = one SQLite file**, routed by the `Host` header through the same `AsyncLocalStorage` context the demo proved out. Route code is identical in all modes — a request is wrapped in its tenant (database *and* its attachments/backups directories) before any handler runs, and background chores (mail polling, session pruning, recurring transactions) iterate the families instead of running once.
+
+Families live in `families/<internal-id>/` under the data directory and are listed in `registry.db` next to them — the slug is registry cosmetics, renames never move files. Provisioning is one command (`node server/dist/cli/create-family.js <slug>`); the family's first visit gets the ordinary first-run screen and creates its own admin.
+
+A subdomain that doesn't exist is deliberately indistinguishable from one that does: unknown hosts resolve to a ghost — an empty in-memory database that claims to be set up, rejects sign-ins exactly like a real family rejecting a wrong password (timing included: the dummy-scrypt path already existed), and refuses first-run setup. Probing names tells an outsider nothing.
+
+None of this concerns self-hosting: without the flag the hub runs exactly as before, one family per server.
+
 ## Offline and updates
 
 The frontend is a PWA: a service worker precaches the app shell and answers GET API reads NetworkFirst — fresh when online, the last snapshot when not. Nothing external is involved (the strict CSP allows no third-party scripts); workbox is bundled and self-hosted. Auth is uncached except the single `auth/me` read, without which an offline reload would strand the person on the sign-in screen; signing out — or any 401 — deletes the offline caches, so cached family data never outlives a session.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -138,6 +138,21 @@ export async function buildApp(): Promise<FastifyInstance> {
       done();
     });
   }
+
+  /*
+    Hosted: route the request to its family by the Host header — the same
+    contract as the demo hook above, with a permanent family instead of a
+    throwaway sandbox (lib/tenants.ts). Every request gets a tenant:
+    unknown subdomains get the ghost, which answers like a family
+    rejecting a wrong password — so names cannot be enumerated.
+  */
+  if (env.hostedMode) {
+    const { resolveTenant } = await import('./lib/tenants.js');
+    const { runWithTenant } = await import('./db/index.js');
+    app.addHook('onRequest', (req, _reply, done) => {
+      return runWithTenant(resolveTenant(req.headers.host), done);
+    });
+  }
   await app.register(fastifyMultipart, {
     limits: { fileSize: MAX_FILE_BYTES, files: 10 },
   });

--- a/server/src/cli/create-family.ts
+++ b/server/src/cli/create-family.ts
@@ -1,0 +1,39 @@
+import { env } from '../env.js';
+import { createFamily, initHosted } from '../lib/tenants.js';
+
+/*
+  Provision one family on a hosted server. Run inside the app container:
+
+    docker compose exec app node server/dist/cli/create-family.js <slug>
+
+  Needs HOSTED_MODE/HOSTED_DOMAIN in the environment (the container
+  already has them). The printed URL is the whole onboarding: the first
+  person to open it gets the ordinary first-run screen and becomes the
+  family's admin — hand the link to the family, nothing else to do.
+
+  Slugs by convention: <family name in latin>-<4 random chars>, e.g.
+  "petrovs-x7k2". The suffix designs collisions out; vanity renames are a
+  later, self-serve feature.
+*/
+
+if (!env.hostedMode) {
+  console.error('This is a hosted-mode tool: set HOSTED_MODE=true and HOSTED_DOMAIN first.');
+  process.exit(1);
+}
+
+const slug = process.argv[2];
+if (!slug || process.argv.length > 3) {
+  console.error('Usage: create-family.js <slug>');
+  process.exit(1);
+}
+
+try {
+  initHosted();
+  const { familyId, url } = createFamily(slug.toLowerCase());
+  console.log(`Family created: ${url}`);
+  console.log(`  id: ${familyId}`);
+  console.log('  The first visit shows the first-run screen and creates the admin.');
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -83,29 +83,58 @@ export function openDatabase(file: string): Database.Database {
 const mainDb = openDatabase(paths.db);
 
 /*
-  Which database serves the current request.
+  Which family serves the current request.
 
-  In normal mode there is one database and the context is always empty —
-  mainDb does the work. In demo mode every visitor lives in their own
-  sandbox: the hook in index.ts puts its database into AsyncLocalStorage
-  for the duration of the request, and all code below — routes, auth,
-  migrations, seeding — transparently works with it through the exported
-  Proxy. No route knows about sandboxes.
+  A tenant is a database plus the directories that belong to it: routing
+  the database alone is not enough — attachments and backups are files
+  on disk, and they must switch together with the data or one family's
+  photos would land in another family's folder. Demo dodged this by
+  blocking uploads in sandboxes; hosted mode cannot.
 
-  This is a deliberate prototype of the future hosted "database per
-  family" mode: the layer can already route a request to its database,
-  only the mapping source needs replacing (sandbox cookie → permanent
-  family).
+  In normal mode the context is always empty and the default tenant
+  (the single family) does the work. In demo mode every visitor lives in
+  their own sandbox; in hosted mode every family lives on its own
+  subdomain (lib/tenants.ts). Either way a hook wraps the request in its
+  tenant, and all code below — routes, auth, migrations, seeding —
+  transparently works with it through the exported Proxy. No route knows
+  about tenants.
 */
-const dbContext = new AsyncLocalStorage<Database.Database>();
-
-export function currentDb(): Database.Database {
-  return dbContext.getStore() ?? mainDb;
+export interface Tenant {
+  db: Database.Database;
+  attachmentsDir: string;
+  backupsDir: string;
+  /** Only the hosted decoy behind unknown subdomains. See lib/tenants.ts */
+  ghost?: boolean;
 }
 
-/** Run fn (async included) so that all code inside sees database d. */
+const defaultTenant: Tenant = {
+  db: mainDb,
+  attachmentsDir: paths.attachments,
+  backupsDir: paths.backups,
+};
+
+const dbContext = new AsyncLocalStorage<Tenant>();
+
+export function currentTenant(): Tenant {
+  return dbContext.getStore() ?? defaultTenant;
+}
+
+export function currentDb(): Database.Database {
+  return currentTenant().db;
+}
+
+/** Run fn (async included) so that all code inside sees this tenant. */
+export function runWithTenant<T>(tenant: Tenant, fn: () => T): T {
+  return dbContext.run(tenant, fn);
+}
+
+/**
+ * Database-only override: the file directories stay the default ones.
+ * Enough for demo sandboxes and tests, where uploads are blocked or
+ * irrelevant; hosted tenants must use runWithTenant.
+ */
 export function runWithDb<T>(d: Database.Database, fn: () => T): T {
-  return dbContext.run(d, fn);
+  return dbContext.run({ ...defaultTenant, db: d }, fn);
 }
 
 /*

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -66,10 +66,24 @@ export const env = {
   // Public sandbox: a throwaway database per visitor.
   // See server/src/lib/sandbox.ts and lib/demo.ts
   demoMode: boolFrom('DEMO_MODE'),
+  // Hosted mode: many families on one server, one database file each,
+  // routed by the Host header. See server/src/lib/tenants.ts
+  hostedMode: boolFrom('HOSTED_MODE'),
+  // The apex all family subdomains hang off (e.g. neiliro.com):
+  // a request to <slug>.<domain> is routed to that family's database.
+  hostedDomain: (process.env.HOSTED_DOMAIN ?? '').trim().toLowerCase(),
   // debug | info | warn | error | silent. Default warn:
   // in normal operation only warnings and errors are interesting.
   logLevel: process.env.LOG_LEVEL ?? 'warn',
 } as const;
+
+// A typo'd combination must stop startup, not surface as odd routing later.
+if (env.hostedMode && env.demoMode) {
+  throw new Error('HOSTED_MODE and DEMO_MODE are mutually exclusive — run the demo as its own process');
+}
+if (env.hostedMode && !/^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/.test(env.hostedDomain)) {
+  throw new Error('HOSTED_MODE=true requires HOSTED_DOMAIN (the apex domain, e.g. example.com)');
+}
 
 export const paths = {
   db: resolve(env.dataDir, 'hub.db'),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,15 +12,35 @@ import { log, logLevel } from './lib/log.js';
   that tests can build the same app and drive it through inject().
 */
 
-migrate();
-pruneSessions();
+/*
+  In hosted mode every per-database chore below — migrations, session
+  pruning, recurring transactions, mail polling — runs once per family
+  instead of once. eachFamily is that difference in one place: the
+  single-family fallback just runs the job as before.
+*/
+const eachFamily: (fn: () => unknown) => Promise<void> = env.hostedMode
+  ? (await import('./lib/tenants.js')).forEachFamily
+  : async (fn) => {
+      await fn();
+    };
+
+if (env.hostedMode) {
+  // Opens the registry and migrates every family; migrate() below would
+  // only touch the unused default database.
+  const { initHosted } = await import('./lib/tenants.js');
+  initHosted();
+} else {
+  migrate();
+}
+
+await eachFamily(pruneSessions);
 // Boot-only pruning was enough while every deploy restarted the process,
 // but a home server can stay up for months — repeat daily so expiry and
 // the 30-day idle rule actually retire rows from the Devices list.
 // Nothing leaks either way (userForToken enforces expiry); this is about
 // the table and the list not growing stale. Same pattern as the attempt
 // and MFA sweeps in routes/auth.ts.
-setInterval(pruneSessions, 24 * 60 * 60_000).unref();
+setInterval(() => void eachFamily(pruneSessions), 24 * 60 * 60_000).unref();
 
 // Production without Secure cookies is almost certainly a forgotten flag,
 // not intent: the session cookie would then travel over plaintext too
@@ -30,7 +50,10 @@ if (env.isProd && !env.secureCookies && !env.demoMode) {
 if (env.demoMode) {
   const { initDemo } = await import('./lib/sandbox.js');
   await initDemo();
-} else {
+} else if (!env.hostedMode) {
+  // Hosted families onboard through the same first-run screen, but on
+  // their own subdomain — announcing a setup link for the unused default
+  // database would only mislead.
   announceSetupIfEmpty();
 }
 
@@ -38,8 +61,18 @@ const app = await buildApp();
 
 // Recurring payments marked "create automatically" catch up at startup:
 // the Mac may have been asleep, and a couple of dates may have passed us by
-const createdOnBoot = runAutoCreate();
-if (createdOnBoot > 0) log.info(`recurring transactions: created ${createdOnBoot}`);
+await eachFamily(() => {
+  const created = runAutoCreate();
+  if (created > 0) log.info(`recurring transactions: created ${created}`);
+});
+// ...and once a day from then on. Catch-up used to be boot-only, which a
+// server that never restarts (hosted, a long-lived home box) never hits:
+// auto-created payments silently stopped between deploys. runAutoCreate
+// is idempotent — a repeat run creates nothing extra.
+setInterval(
+  () => void eachFamily(runAutoCreate),
+  24 * 60 * 60_000,
+).unref();
 
 try {
   await app.listen({ port: env.port, host: env.host });
@@ -53,7 +86,7 @@ try {
 // mailbox, and the sample messages are seeded, not fetched.
 if (!env.demoMode) {
   const { startMailPoller } = await import('./lib/mail.js');
-  startMailPoller();
+  startMailPoller(eachFamily);
 }
 
 // An unhandled crash must be visible at any log level
@@ -71,6 +104,12 @@ for (const signal of ['SIGINT', 'SIGTERM'] as const) {
     if (env.demoMode) {
       const { shutdownDemo } = await import('./lib/sandbox.js');
       shutdownDemo();
+    }
+    // Same courtesy for hosted: closing checkpoints each family's WAL,
+    // so every hub.db stays a single copy-friendly file on disk
+    if (env.hostedMode) {
+      const { shutdownHosted } = await import('./lib/tenants.js');
+      shutdownHosted();
     }
     // An explicit close runs a WAL checkpoint: the database stays a single
     // file, no -wal/-shm next to it — safer to copy and move around

--- a/server/src/lib/mail.ts
+++ b/server/src/lib/mail.ts
@@ -171,11 +171,19 @@ export async function pollMail(): Promise<{ fetched: number } | { error: string 
 
 const POLL_MS = 3 * 60_000;
 
-/** Background polling. A hub with no mailbox configured idles for free. */
-export function startMailPoller(): void {
+/**
+ * Background polling. A hub with no mailbox configured idles for free.
+ *
+ * The caller supplies the iteration context: a single-family install
+ * passes a run-once wrapper, hosted mode passes forEachFamily — this
+ * module stays ignorant of tenants, the same way routes are.
+ */
+export function startMailPoller(each: (fn: () => unknown) => Promise<void>): void {
   setInterval(() => {
-    if (!getMailAccount()) return;
-    void pollMail();
+    void each(async () => {
+      if (!getMailAccount()) return;
+      await pollMail();
+    });
   }, POLL_MS).unref();
 }
 

--- a/server/src/lib/tenants.ts
+++ b/server/src/lib/tenants.ts
@@ -1,0 +1,290 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
+import { id, now, openDatabase, runWithDb, runWithTenant, type Tenant } from '../db/index.js';
+import { migrate } from '../db/migrate.js';
+import { env } from '../env.js';
+import { log } from './log.js';
+
+/*
+  Hosted mode: many families on one server, routed by the Host header.
+
+  family = subdomain = one SQLite file. The demo sandboxes proved the
+  mechanism (a request wrapped in its own database via AsyncLocalStorage);
+  this module replaces the mapping source: sandbox cookie → permanent
+  family looked up by subdomain slug.
+
+  The registry (registry.db next to the family folders) maps slug → family.
+  A family's folder is named by its internal id, never the slug: renaming
+  a slug is a registry update, the files don't move. Like demo-stats.db,
+  the registry is not part of the app schema and has no migrations — it
+  belongs to operating the service, not to the product.
+
+  Unknown subdomains resolve to the ghost: an empty migrated in-memory
+  database. Its login path answers exactly like a real family rejecting a
+  wrong password (auth already runs a dummy scrypt for missing users, so
+  even the timing matches), and /api/auth/state claims the hub is set up.
+  From outside, a subdomain that doesn't exist is indistinguishable from
+  one that does — nobody can enumerate families by probing names.
+*/
+
+const familiesDir = join(env.dataDir, 'families');
+
+let registry: Database.Database | null = null;
+
+interface FamilyRow {
+  id: string;
+  slug: string;
+  status: string;
+}
+
+/** Open (or create) the registry. Idempotent — the CLI calls it too. */
+export function initHosted(): void {
+  if (registry) return;
+  mkdirSync(familiesDir, { recursive: true });
+  registry = openDatabase(join(env.dataDir, 'registry.db'));
+  registry.exec(`
+    CREATE TABLE IF NOT EXISTS families (
+      id         TEXT PRIMARY KEY,
+      slug       TEXT NOT NULL UNIQUE,
+      status     TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL
+    )
+  `);
+
+  // Every family catches up on schema at startup, exactly like a
+  // single-family install does. A family that fails to migrate is logged
+  // and skipped, not fatal: one broken database must not hold the other
+  // families' breakfast hostage.
+  let migrated = 0;
+  for (const family of allFamilies()) {
+    try {
+      runWithTenant(tenantFor(family.id), migrate);
+      migrated += 1;
+    } catch (err) {
+      log.error(`family ${family.slug}: migration failed — skipped`, err);
+    }
+  }
+  log.notice(`hosted mode: ${migrated} families on *.${env.hostedDomain}`);
+
+  setInterval(closeIdle, IDLE_SWEEP_MS).unref();
+}
+
+function allFamilies(): FamilyRow[] {
+  return registry!.prepare('SELECT id, slug, status FROM families').all() as FamilyRow[];
+}
+
+// ── Slug → family ─────────────────────────────────────────────────────────
+
+/**
+ * The slug is the first DNS label under the hosted apex. Anything that
+ * isn't exactly <one-label>.<apex> — the apex itself, a nested label, a
+ * foreign host — resolves to nothing and ends up at the ghost.
+ */
+export function slugFromHost(host: string | undefined): string | null {
+  if (!host) return null;
+  const bare = host.split(':')[0]!.toLowerCase();
+  const suffix = `.${env.hostedDomain}`;
+  if (!bare.endsWith(suffix)) return null;
+  const slug = bare.slice(0, -suffix.length);
+  return /^[a-z0-9-]{1,63}$/.test(slug) ? slug : null;
+}
+
+/*
+  Slug lookups are cached briefly. A registry read is microseconds, but
+  this also bounds how often a suspended family keeps answering: within
+  the TTL after a status flip, requests may still land in the old state —
+  accepted, suspension is an operator action, not a security boundary.
+*/
+const SLUG_TTL_MS = 30_000;
+const slugCache = new Map<string, { familyId: string | null; at: number }>();
+
+function familyIdBySlug(slug: string): string | null {
+  const cached = slugCache.get(slug);
+  if (cached && Date.now() - cached.at < SLUG_TTL_MS) return cached.familyId;
+
+  const row = registry!
+    .prepare("SELECT id FROM families WHERE slug = ? AND status = 'active'")
+    .get(slug) as { id: string } | undefined;
+  const familyId = row?.id ?? null;
+
+  // Negative entries are capped: unknown slugs arrive from the whole
+  // internet and must not grow the cache without bound.
+  if (familyId !== null || slugCache.size < 1000) {
+    slugCache.set(slug, { familyId, at: Date.now() });
+  }
+  return familyId;
+}
+
+// ── Open tenants (LRU) ────────────────────────────────────────────────────
+
+/*
+  Open database handles are pooled and closed when idle. A handle is a
+  few megabytes of page cache — fine for dozens of families, not for
+  keeping every family ever seen open forever.
+
+  Closing can in principle race a slow in-flight request (multipart
+  upload, mail send): the eviction targets are least-recently-used and
+  idle-for-half-an-hour handles, and lastUsed is stamped on every
+  request, so a handle in flight is never the one chosen.
+*/
+const MAX_OPEN = 50;
+const IDLE_CLOSE_MS = 30 * 60_000;
+const IDLE_SWEEP_MS = 5 * 60_000;
+
+interface OpenTenant {
+  tenant: Tenant;
+  lastUsed: number;
+}
+
+const openTenants = new Map<string, OpenTenant>();
+
+function tenantFor(familyId: string): Tenant {
+  const entry = openTenants.get(familyId);
+  if (entry) {
+    entry.lastUsed = Date.now();
+    return entry.tenant;
+  }
+
+  if (openTenants.size >= MAX_OPEN) evictOldest();
+
+  const dir = join(familiesDir, familyId);
+  const attachmentsDir = join(dir, 'attachments');
+  const backupsDir = join(dir, 'backups');
+  mkdirSync(attachmentsDir, { recursive: true });
+  mkdirSync(backupsDir, { recursive: true });
+
+  const tenant: Tenant = { db: openDatabase(join(dir, 'hub.db')), attachmentsDir, backupsDir };
+  openTenants.set(familyId, { tenant, lastUsed: Date.now() });
+  return tenant;
+}
+
+function closeTenant(familyId: string): void {
+  const entry = openTenants.get(familyId);
+  if (!entry) return;
+  openTenants.delete(familyId);
+  try {
+    // close() checkpoints the WAL — the family stays a single file on disk
+    entry.tenant.db.close();
+  } catch (err) {
+    log.warn(`family ${familyId}: database failed to close`, err);
+  }
+}
+
+function evictOldest(): void {
+  let oldest: string | null = null;
+  let oldestAt = Infinity;
+  for (const [familyId, entry] of openTenants) {
+    if (entry.lastUsed < oldestAt) {
+      oldest = familyId;
+      oldestAt = entry.lastUsed;
+    }
+  }
+  if (oldest) closeTenant(oldest);
+}
+
+function closeIdle(): void {
+  const cutoff = Date.now() - IDLE_CLOSE_MS;
+  for (const [familyId, entry] of [...openTenants]) {
+    if (entry.lastUsed < cutoff) closeTenant(familyId);
+  }
+}
+
+// ── The ghost ─────────────────────────────────────────────────────────────
+
+let ghost: Tenant | null = null;
+
+function ghostTenant(): Tenant {
+  if (!ghost) {
+    const ghostDb = openDatabase(':memory:');
+    runWithDb(ghostDb, migrate);
+    // The ghost never stores a file (uploads sit behind auth, and the
+    // ghost has no users), but its paths must still be real: code that
+    // only reads them — the storage budget, for one — must not trip.
+    const dir = join(familiesDir, '.ghost');
+    mkdirSync(dir, { recursive: true });
+    ghost = { db: ghostDb, attachmentsDir: dir, backupsDir: dir, ghost: true };
+  }
+  return ghost;
+}
+
+// ── Entry points ──────────────────────────────────────────────────────────
+
+/** The tenant behind a Host header. Never null: unknown hosts get the ghost. */
+export function resolveTenant(host: string | undefined): Tenant {
+  const slug = slugFromHost(host);
+  const familyId = slug === null ? null : familyIdBySlug(slug);
+  return familyId === null ? ghostTenant() : tenantFor(familyId);
+}
+
+/**
+ * Run a background job once per active family, sequentially — pollers
+ * and sweeps written for one family work unchanged inside. One family's
+ * failure is logged and does not stop the round.
+ */
+export async function forEachFamily(fn: () => unknown): Promise<void> {
+  for (const family of allFamilies()) {
+    if (family.status !== 'active') continue;
+    try {
+      await runWithTenant(tenantFor(family.id), async () => fn());
+    } catch (err) {
+      log.error(`family ${family.slug}: background job failed`, err);
+    }
+  }
+}
+
+/** Checkpoint and close everything on the way out. */
+export function shutdownHosted(): void {
+  for (const familyId of [...openTenants.keys()]) closeTenant(familyId);
+  try {
+    ghost?.db.close();
+    registry?.close();
+  } catch {
+    // Already closed — not an error on exit
+  }
+}
+
+// ── Provisioning (the CLI and, later, the control plane) ─────────────────
+
+/**
+ * Default slugs are <family name>-<4 random chars>, so collisions are
+ * designed out; vanity renames come later and pass the same gate.
+ * The reserved list keeps service names out of family hands: a family
+ * called "mail" or "api" would collide with infrastructure sooner or
+ * later, and "admin" or "billing" is a phishing costume.
+ */
+const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{1,28})[a-z0-9]$/;
+const RESERVED_SLUGS = new Set([
+  'www', 'app', 'api', 'demo', 'mail', 'in', 'mx', 'smtp', 'imap', 'pop',
+  'admin', 'billing', 'pay', 'account', 'accounts', 'login', 'auth',
+  'help', 'support', 'docs', 'blog', 'status', 'static', 'cdn', 'assets',
+  'dev', 'staging', 'test', 'ns1', 'ns2', 'ftp', 'vpn', 'webmail',
+]);
+
+export function createFamily(slug: string): { familyId: string; url: string } {
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(`Bad slug "${slug}": 3–30 chars of [a-z0-9-], letters or digits at the edges`);
+  }
+  if (RESERVED_SLUGS.has(slug)) {
+    throw new Error(`Slug "${slug}" is reserved for the service itself`);
+  }
+
+  const familyId = id();
+  try {
+    registry!
+      .prepare('INSERT INTO families (id, slug, created_at) VALUES (?, ?, ?)')
+      .run(familyId, slug, now());
+  } catch (err) {
+    if ((err as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      throw new Error(`Slug "${slug}" is already taken`);
+    }
+    throw err;
+  }
+
+  // Migrating right away turns "row in the registry" into "working hub":
+  // the family's first visit gets the ordinary first-run screen and
+  // creates its own admin — the same onboarding as a fresh install.
+  runWithTenant(tenantFor(familyId), migrate);
+  log.notice(`family created: ${slug} (${familyId})`);
+  return { familyId, url: `https://${slug}.${env.hostedDomain}/` };
+}

--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -5,8 +5,7 @@ import { pipeline } from 'node:stream/promises';
 import { createWriteStream } from 'node:fs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { db, id, now, today } from '../db/index.js';
-import { paths } from '../env.js';
+import { currentTenant, db, id, now, today } from '../db/index.js';
 
 /** The per-file ceiling. Beyond it this is no longer a note but file storage. */
 export const MAX_FILE_BYTES = 50 * 1024 * 1024;
@@ -102,7 +101,7 @@ export async function saveMailAttachment(
 
   const storageName = storageNameFor(file.filename);
   const month = today().slice(0, 7);
-  const folder = join(paths.attachments, month);
+  const folder = join(currentTenant().attachmentsDir, month);
   await mkdir(folder, { recursive: true });
   await writeFile(join(folder, storageName), file.content);
 
@@ -160,7 +159,7 @@ async function receiveFiles(
     const storageName = storageNameFor(part.filename);
     // The month folder — by the local clock, like everything else in the app
     const month = today().slice(0, 7);
-    const folder = join(paths.attachments, month);
+    const folder = join(currentTenant().attachmentsDir, month);
     await mkdir(folder, { recursive: true });
     const fullPath = join(folder, storageName);
 
@@ -267,9 +266,9 @@ export async function registerAttachmentRoutes(app: FastifyInstance): Promise<vo
     const attachment = loadVisible(attachmentId, req.user?.id ?? '');
     if (!attachment) return reply.code(404).send({ error: 'File not found' });
 
-    const fullPath = resolve(paths.attachments, attachment.storage_path);
+    const fullPath = resolve(currentTenant().attachmentsDir, attachment.storage_path);
     // Insurance against escaping the attachments directory
-    if (!fullPath.startsWith(resolve(paths.attachments))) {
+    if (!fullPath.startsWith(resolve(currentTenant().attachmentsDir))) {
       return reply.code(400).send({ error: 'Invalid path' });
     }
 
@@ -296,7 +295,7 @@ export async function registerAttachmentRoutes(app: FastifyInstance): Promise<vo
 
     db.prepare('DELETE FROM attachments WHERE id = ?').run(attachmentId);
     // The record is deleted either way; a file missing from disk is no reason to crash
-    await unlink(resolve(paths.attachments, attachment.storage_path)).catch(() => {});
+    await unlink(resolve(currentTenant().attachmentsDir, attachment.storage_path)).catch(() => {});
 
     return { ok: true };
   });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { log } from '../lib/log.js';
 import { z } from 'zod';
-import { db, now } from '../db/index.js';
+import { currentTenant, db, now } from '../db/index.js';
 import { hashPassword, verifyPassword } from '../lib/password.js';
 import { env } from '../env.js';
 import {
@@ -74,7 +74,12 @@ const loginInput = z.object({
   simply means signing in again. The attempt counter caps guessing at
   5 codes per successful password entry.
 */
-const pendingMfa = new Map<string, { userId: string; until: number; attempts: number }>();
+// host pins the ticket to the family it was issued on: in hosted mode a
+// ticket must not be redeemable against another family's database.
+const pendingMfa = new Map<
+  string,
+  { userId: string; host: string; until: number; attempts: number }
+>();
 const MFA_TTL_MS = 5 * 60_000;
 
 setInterval(() => {
@@ -96,6 +101,10 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     // happens in sandboxes), but the initial setup screen must not be
     // shown, and there is one way in — the "Try the demo" button.
     if (env.demoMode) return { initialized: true, google: false, demo: true };
+    // A hosted subdomain that doesn't exist claims to be set up: showing
+    // the first-run screen only on real families would let anyone map
+    // which names exist by probing. See lib/tenants.ts, the ghost.
+    if (currentTenant().ghost) return { initialized: true, google: false, demo: false };
     const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
     return {
       initialized: n > 0,
@@ -123,7 +132,14 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     }
     const email = parsed.data.email.trim().toLowerCase();
 
-    if (throttled(email, MAX_ATTEMPTS_LOGIN) || throttled(`ip:${req.ip}`, MAX_ATTEMPTS_IP)) {
+    // The per-login key carries the host: in hosted mode the same email
+    // can belong to different people in different families, and one
+    // family's typos must not lock the other's door. The per-IP key stays
+    // global on purpose — a dictionary sweep hopping subdomains is still
+    // one sweep from one address.
+    const loginKey = `${req.headers.host ?? ''}|${email}`;
+
+    if (throttled(loginKey, MAX_ATTEMPTS_LOGIN) || throttled(`ip:${req.ip}`, MAX_ATTEMPTS_IP)) {
       log.warn(`login blocked by the brake: ${email} from ${req.ip}`);
       return reply
         .code(429)
@@ -150,7 +166,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     }
 
     if (!user || !ok) {
-      registerFailure(email);
+      registerFailure(loginKey);
       registerFailure(`ip:${req.ip}`);
       log.warn(`failed login: ${email} from ${req.ip}`);
       return reply.code(401).send({ error: 'Wrong login or password' });
@@ -162,7 +178,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     // address could interleave their own sign-ins to keep the sweep alive
     // forever. A family's honest typos ride out the 15-minute window
     // instead — the 20-per-address threshold is sized for exactly that.
-    attempts.delete(email);
+    attempts.delete(loginKey);
 
     // Second factor: the password alone opens nothing when TOTP is
     // confirmed — the client gets a short-lived ticket and owes a code
@@ -171,7 +187,12 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       .get(user.id) as { totp_secret: string | null; totp_confirmed_at: string | null };
     if (mfa.totp_confirmed_at && mfa.totp_secret) {
       const ticket = crypto.randomUUID();
-      pendingMfa.set(ticket, { userId: user.id, until: Date.now() + MFA_TTL_MS, attempts: 0 });
+      pendingMfa.set(ticket, {
+        userId: user.id,
+        host: req.headers.host ?? '',
+        until: Date.now() + MFA_TTL_MS,
+        attempts: 0,
+      });
       log.info(`login: ${email} passed the password, awaiting TOTP`);
       return { mfa_required: true, mfa_token: ticket };
     }
@@ -207,7 +228,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     if (!parsed.success) return reply.code(400).send({ error: 'Enter the code' });
 
     const pending = pendingMfa.get(parsed.data.mfa_token);
-    if (!pending || Date.now() > pending.until) {
+    if (!pending || Date.now() > pending.until || pending.host !== (req.headers.host ?? '')) {
       pendingMfa.delete(parsed.data.mfa_token);
       return reply.code(401).send({ error: 'Sign-in expired — start over' });
     }

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+/*
+  Hosted mode: family = subdomain = one database file (lib/tenants.ts).
+
+  env.ts reads the environment at import time, so the hosted flags are
+  set before any app module is pulled in — hence the dynamic imports.
+  The flags are removed in afterAll: vitest can reuse a fork for the
+  next test file, and process.env survives module isolation.
+*/
+process.env.HOSTED_MODE = 'true';
+process.env.HOSTED_DOMAIN = 'neiliro.test';
+
+const tenants = await import('../lib/tenants.js');
+const { buildApp } = await import('../app.js');
+
+afterAll(() => {
+  delete process.env.HOSTED_MODE;
+  delete process.env.HOSTED_DOMAIN;
+  tenants.shutdownHosted();
+});
+
+function onHost(host: string) {
+  return { host };
+}
+
+describe('slugFromHost', () => {
+  beforeAll(() => tenants.initHosted());
+
+  it('takes the first label under the apex, case- and port-insensitive', () => {
+    expect(tenants.slugFromHost('smiths-x7k2.neiliro.test')).toBe('smiths-x7k2');
+    expect(tenants.slugFromHost('SMITHS-X7K2.NEILIRO.TEST:443')).toBe('smiths-x7k2');
+  });
+
+  it('resolves nothing for the apex, nested labels and foreign hosts', () => {
+    expect(tenants.slugFromHost('neiliro.test')).toBeNull();
+    expect(tenants.slugFromHost('a.b.neiliro.test')).toBeNull();
+    expect(tenants.slugFromHost('evil.example.com')).toBeNull();
+    expect(tenants.slugFromHost('xneiliro.test')).toBeNull();
+    expect(tenants.slugFromHost(undefined)).toBeNull();
+  });
+});
+
+describe('createFamily', () => {
+  beforeAll(() => tenants.initHosted());
+
+  it('rejects malformed, reserved and taken slugs', () => {
+    expect(() => tenants.createFamily('ab')).toThrow(/Bad slug/);
+    expect(() => tenants.createFamily('-petrovs')).toThrow(/Bad slug/);
+    expect(() => tenants.createFamily('petrovs!')).toThrow(/Bad slug/);
+    expect(() => tenants.createFamily('mail')).toThrow(/reserved/);
+
+    tenants.createFamily('taken-q1w2');
+    expect(() => tenants.createFamily('taken-q1w2')).toThrow(/already taken/);
+  });
+});
+
+describe('host routing', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    tenants.initHosted();
+    tenants.createFamily('smiths-a1b2');
+    tenants.createFamily('jones-c3d4');
+    app = await buildApp();
+  });
+
+  it('keeps families in separate databases: setup on one leaves the other pristine', async () => {
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('smiths-a1b2.neiliro.test'),
+      payload: { name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
+    });
+    expect(created.statusCode).toBe(201);
+
+    const smiths = await app.inject({
+      url: '/api/auth/state',
+      headers: onHost('smiths-a1b2.neiliro.test'),
+    });
+    expect(smiths.json().initialized).toBe(true);
+
+    // The other family still waits for its own first run — nothing leaked
+    const jones = await app.inject({
+      url: '/api/auth/state',
+      headers: onHost('jones-c3d4.neiliro.test'),
+    });
+    expect(jones.json().initialized).toBe(false);
+  });
+
+  it('lets a family sign in on its own subdomain only', async () => {
+    const login = (host: string) =>
+      app.inject({
+        method: 'POST',
+        url: '/api/auth/login',
+        headers: onHost(host),
+        payload: { email: 'sam@smiths.test', password: 'correct horse battery' },
+      });
+
+    expect((await login('smiths-a1b2.neiliro.test')).statusCode).toBe(200);
+    expect((await login('jones-c3d4.neiliro.test')).statusCode).toBe(401);
+  });
+
+  it('shows an unknown subdomain as an already-set-up hub (anti-enumeration)', async () => {
+    const state = await app.inject({
+      url: '/api/auth/state',
+      headers: onHost('nosuch-x9y8.neiliro.test'),
+    });
+    expect(state.json()).toEqual({ initialized: true, google: false, demo: false });
+
+    // ...that rejects a sign-in exactly like a real family would
+    const login = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: onHost('nosuch-x9y8.neiliro.test'),
+      payload: { email: 'admin@example.com', password: 'whatever else' },
+    });
+    expect(login.statusCode).toBe(401);
+    expect(login.json().error).toBe('Wrong login or password');
+
+    // ...and can never be claimed through the first-run endpoint
+    const setup = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('nosuch-x9y8.neiliro.test'),
+      payload: { name: 'Eve', email: 'eve@evil.test', password: 'longenoughpass' },
+    });
+    expect(setup.statusCode).toBe(403);
+  });
+
+  it('runs background jobs once per family, each inside its own database', async () => {
+    const seen: number[] = [];
+    const { db } = await import('../db/index.js');
+    await tenants.forEachFamily(() => {
+      seen.push((db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n);
+    });
+    // Three families exist by now (taken-q1w2, smiths, jones); exactly one has a user
+    expect(seen).toHaveLength(3);
+    expect(seen.filter((n) => n === 1)).toHaveLength(1);
+  });
+});

--- a/server/src/routes/money.ts
+++ b/server/src/routes/money.ts
@@ -2,8 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { db, id, now, today } from '../db/index.js';
-import { paths } from '../env.js';
+import { currentTenant, db, id, now, today } from '../db/index.js';
 import { shiftDays } from '../lib/dates.js';
 import { dueOccurrences } from './budgets.js';
 
@@ -670,7 +669,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     db.prepare('DELETE FROM transactions WHERE id = ?').run(txId);
 
     for (const file of receipts) {
-      await unlink(resolve(paths.attachments, file.storage_path)).catch(() => {});
+      await unlink(resolve(currentTenant().attachmentsDir, file.storage_path)).catch(() => {});
     }
     return { ok: true };
   });

--- a/server/src/routes/notes.ts
+++ b/server/src/routes/notes.ts
@@ -2,8 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { db, id, now, today } from '../db/index.js';
-import { paths } from '../env.js';
+import { currentTenant, db, id, now, today } from '../db/index.js';
 
 interface NoteRow {
   id: string;
@@ -519,7 +518,7 @@ export async function registerNoteRoutes(app: FastifyInstance): Promise<void> {
     db.prepare('DELETE FROM notes WHERE id = ?').run(noteId);
 
     for (const file of files) {
-      await unlink(resolve(paths.attachments, file.storage_path)).catch(() => {});
+      await unlink(resolve(currentTenant().attachmentsDir, file.storage_path)).catch(() => {});
     }
     return { ok: true };
   });

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { db, id, now } from '../db/index.js';
+import { currentTenant, db, id, now } from '../db/index.js';
 import { createSession, setSessionCookie } from '../lib/auth.js';
 import { hashPassword } from '../lib/password.js';
 import { log } from '../lib/log.js';
@@ -73,6 +73,12 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
     insert run in one transaction.
   */
   app.post('/api/auth/setup', strictRate, async (req, reply) => {
+    // The hosted ghost (an unknown subdomain) claims to be set up, and
+    // must act it: its shared decoy database may never grow an admin —
+    // whoever "set it up" would own every nonexistent subdomain at once.
+    if (currentTenant().ghost) {
+      return reply.code(403).send({ error: 'The hub is already set up' });
+    }
     const parsed = z
       .object({ name: nameField, email: emailField, password: passwordField })
       .safeParse(req.body);


### PR DESCRIPTION
Milestone B of the hosted roadmap: the tenancy core. family = subdomain = one SQLite file, routed by the `Host` header through the same `AsyncLocalStorage` layer the demo sandboxes proved out.

## What's inside

- **Tenant context, not just a database.** The ALS store now carries `{ db, attachmentsDir, backupsDir }`. Routing the database alone was a real hole: attachments and backups were global paths, so one family's uploads would land in the shared folder. Demo never hit this (uploads are blocked in sandboxes); hosted would have on day one.
- **`lib/tenants.ts`** — the new module: `registry.db` (slug → family id; operational data like `demo-stats.db`, deliberately not in app migrations), family folders named by **internal id** (slug renames never move files), a 30s slug cache, an LRU pool of open database handles (50 open / closed after 30 min idle), `forEachFamily` for background jobs.
- **Anti-enumeration (half of B5 for free).** Unknown subdomains resolve to a *ghost*: an empty in-memory database that claims `initialized: true`, rejects logins through the exact same wrong-password path as a real family (the dummy-scrypt timing equalizer already existed in auth), and answers first-run setup with the same 403 a set-up hub gives. Probing subdomains yields nothing.
- **Background chores go per-family**: mail poller, session pruning, recurring-transaction catch-up. Catch-up also gained a **daily tick** — it was boot-only, which a server that never restarts never runs again. That was a latent bug for long-lived home servers too, not just hosted.
- **Host-scoped auth state**: login throttle keys are `host|email` (the same email may legitimately exist in two families; per-IP stays global to still catch cross-subdomain sweeps), MFA tickets are pinned to their host.
- **Provisioning CLI** (`node server/dist/cli/create-family.js <slug>`): registry row + folder + migrations, prints the family URL. Onboarding is the ordinary first-run screen on the family's own subdomain — no invite plumbing, no passwords over side channels. This is the seed of control plane v0 (next milestone task).

## Deliberately out of scope

- Google sign-in on hosted (Google doesn't allow wildcard redirect URIs — beta rides password+TOTP; needs a central-callback design later)
- Plan limits/quotas (self-serve milestone), per-family backups (B6), per-family metrics (B7), wildcard TLS (B4)

## Self-hosting unaffected

Without `HOSTED_MODE` the default tenant is the single family; all paths behave exactly as before. `.env.example` and `docs/architecture.md` document the new mode.

## Verified

- 116 tests green (7 new in `hosted.test.ts`: slug parsing, provisioning validation, cross-family isolation via real HTTP injects, ghost behavior, per-family job iteration), typecheck both workspaces, lint
- Live smoke run: two families on `*.neiliro.local`, isolation confirmed by curl, ghost indistinguishable from a real family, SIGTERM leaves each family as a single checkpointed `hub.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)