### PR TITLE
feat: per-family backups on a hosted server

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Nightly backup: database snapshot, notes export to markdown, encryption, git push.
 # Goes into cron at 03:00. Attachments are not included — Time Machine covers them.
+# On a hosted server (a families/ directory in DATA_DIR) the shape changes:
+# one encrypted archive per family, attachments included — see below.
 set -euo pipefail
 
 DATA_DIR="${DATA_DIR:-$HOME/.family-hub}"
@@ -22,6 +24,67 @@ report() {
 trap 'status=$?; if [ "$status" -eq 0 ]; then report ""; else report "/fail"; fi' EXIT
 
 mkdir -p "$BACKUP_DIR"
+
+# ── Hosted: one server, many families ───────────────────────────────────────
+# family = subdomain = one SQLite file in families/<id>/ (see
+# docs/architecture.md, "Hosted mode"). Each family becomes its own
+# encrypted archive: database snapshot PLUS attachments — unlike the
+# single-family install below, there is no Time Machine behind a hosted
+# server, and the attachments are other people's data. The registry
+# (slug → id mapping) is snapshotted alongside, so any archive can be
+# matched to its family even after renames. Notes are not exported to
+# markdown here: that insurance is for reading one's own data without
+# the app, and hosted families get the in-app export for that.
+if [ -d "$DATA_DIR/families" ]; then
+  if [ -z "$AGE_RECIPIENT" ]; then
+    echo "AGE_RECIPIENT is not set — refusing to write other people's data unencrypted." >&2
+    exit 1
+  fi
+
+  DAY_DIR="$BACKUP_DIR/$STAMP"
+  mkdir -p "$DAY_DIR"
+
+  sqlite3 "$DATA_DIR/registry.db" ".backup '$DAY_DIR/registry.db'"
+
+  count=0
+  for family_dir in "$DATA_DIR/families"/*/; do
+    [ -f "$family_dir/hub.db" ] || continue
+    family_id=$(basename "$family_dir")
+
+    # The slug in the filename is ops convenience (which archive is whose);
+    # the id is the stable truth — restores match by id.
+    slug=$(sqlite3 "$DAY_DIR/registry.db" \
+      "SELECT slug FROM families WHERE id = '$family_id';" 2>/dev/null || true)
+    name="${slug:-unknown}.$family_id"
+
+    snap_dir="$DAY_DIR/$family_id.snap"
+    mkdir -p "$snap_dir"
+    sqlite3 "$family_dir/hub.db" ".backup '$snap_dir/hub.db'"
+
+    if [ -d "$family_dir/attachments" ]; then
+      tar -czf "$DAY_DIR/$name.tar.gz" -C "$snap_dir" hub.db -C "$family_dir" attachments
+    else
+      tar -czf "$DAY_DIR/$name.tar.gz" -C "$snap_dir" hub.db
+    fi
+    rm -rf "$snap_dir"
+
+    age -r "$AGE_RECIPIENT" -o "$DAY_DIR/$name.tar.gz.age" "$DAY_DIR/$name.tar.gz"
+    rm -f "$DAY_DIR/$name.tar.gz"
+    count=$((count + 1))
+  done
+
+  age -r "$AGE_RECIPIENT" -o "$DAY_DIR/registry.db.age" "$DAY_DIR/registry.db"
+  # The slug SELECTs above open the snapshot and, since WAL mode is
+  # persisted in the file, leave empty -wal/-shm companions — sweep them
+  # together with the plaintext snapshot.
+  rm -f "$DAY_DIR/registry.db" "$DAY_DIR/registry.db-wal" "$DAY_DIR/registry.db-shm"
+
+  # Keep two weeks of daily directories, like the single-family path
+  find "$BACKUP_DIR" -maxdepth 1 -type d -name '20*' -mtime +14 -exec rm -rf {} + 2>/dev/null || true
+
+  echo "Hosted backup $STAMP is ready: $count families."
+  exit 0
+fi
 
 # 1. Consistent database snapshot (safe while the app is running)
 sqlite3 "$DATA_DIR/hub.db" ".backup '$BACKUP_DIR/hub-$STAMP.db'"


### PR DESCRIPTION
Milestone B6 of the hosted roadmap. `backup.sh` grows a hosted branch, detected by the `families/` directory in `DATA_DIR` — no flags, no new scripts, the same cron line as always.

**Hosted shape** (`backups/<date>/`):
- `<slug>.<id>.tar.gz.age` per family — a consistent `.backup` snapshot of the database **plus `attachments/`**. The single-family install skips attachments because Time Machine covers them; behind a hosted server nothing does, and the attachments are other people's data.
- `registry.db.age` — the slug→id mapping, so any archive matches its family even after renames.
- 14 daily sets kept, same dead-man ping (`BACKUP_PING_URL`) around the whole run.

Deliberate choices:
- **Refuses to run without `AGE_RECIPIENT`** — other people's data never hits disk unencrypted (the single-family path only warns).
- Suspended families are still backed up — retention is the point of suspension.
- No markdown notes export in hosted mode: that insurance is for reading *your own* data without the app; hosted families have the in-app export.

**Single-family path is unchanged** and re-verified (snapshot + notes export + encrypt + retention).

Verified live against a 3-family layout: per-family archives with correct names, decrypt shows `hub.db` + `attachments/receipt.jpg`, registry snapshot encrypted, plaintext and WAL companions swept.

Ops procedures (cron line, off-site rsync, per-family restore) land in the private cloud repo's runbook alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)