### PR TITLE
feat: per-family activity counters in hosted mode

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -257,6 +257,22 @@ export async function buildApp(): Promise<FastifyInstance> {
 
   app.addHook('preHandler', authenticate);
 
+  /*
+    Hosted activity counters (lib/hosted-stats.ts). Registered after
+    authenticate on purpose: the user id is part of the count (distinct
+    active users per day), and requests authenticate rejects never get
+    here — unauthenticated probing is not engagement.
+  */
+  if (env.hostedMode) {
+    const { trackFamilyRequest } = await import('./lib/hosted-stats.js');
+    const { currentTenant } = await import('./db/index.js');
+    app.addHook('preHandler', (req, _reply, done) => {
+      const { familyId } = currentTenant();
+      if (familyId) trackFamilyRequest(familyId, req.method, req.url, req.user?.id);
+      done();
+    });
+  }
+
   await registerAuthRoutes(app);
   await registerGoogleRoutes(app);
   await registerSetupRoutes(app);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -103,6 +103,9 @@ export interface Tenant {
   db: Database.Database;
   attachmentsDir: string;
   backupsDir: string;
+  /** Registry id of the hosted family; absent for the single-family
+   *  default, demo sandboxes and the ghost. See lib/tenants.ts */
+  familyId?: string;
   /** Only the hosted decoy behind unknown subdomains. See lib/tenants.ts */
   ghost?: boolean;
 }

--- a/server/src/lib/hosted-stats.test.ts
+++ b/server/src/lib/hosted-stats.test.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { afterAll, describe, expect, it } from 'vitest';
+import { env } from '../env.js';
+import {
+  flushHostedStats,
+  initHostedStats,
+  shutdownHostedStats,
+  trackFamilyRequest,
+} from './hosted-stats.js';
+
+/*
+  The merge semantics carry the privacy promise: additive counters plus
+  a max() on active_users mean a restart mid-day can only undercount,
+  never double-count — and user ids themselves never reach the disk
+  (nothing here ever hands them to the database).
+*/
+describe('hosted stats', () => {
+  afterAll(() => shutdownHostedStats());
+
+  it('accumulates counters and merges a mid-day restart with max()', () => {
+    initHostedStats();
+
+    trackFamilyRequest('fam-1', 'GET', '/api/tasks', 'user-a');
+    trackFamilyRequest('fam-1', 'POST', '/api/tasks', 'user-a');
+    trackFamilyRequest('fam-1', 'GET', '/api/money', 'user-b');
+    // auth and health are not engagement — must not count
+    trackFamilyRequest('fam-1', 'GET', '/api/auth/me', 'user-a');
+    flushHostedStats();
+
+    // A restart: accumulators (and the day's user set) start empty
+    shutdownHostedStats();
+    initHostedStats();
+    trackFamilyRequest('fam-1', 'GET', '/api/tasks', 'user-b');
+    flushHostedStats();
+
+    const db = new Database(join(env.dataDir, 'hosted-stats.db'), { readonly: true });
+    const row = db.prepare('SELECT * FROM family_days WHERE family_id = ?').get('fam-1') as {
+      requests: number;
+      writes: number;
+      active_users: number;
+      modules: string;
+    };
+    db.close();
+
+    expect(row.requests).toBe(4);
+    expect(row.writes).toBe(1);
+    // 2 before the restart, 1 after — max keeps the better estimate
+    expect(row.active_users).toBe(2);
+    expect(JSON.parse(row.modules)).toEqual({ tasks: 3, money: 1 });
+  });
+});

--- a/server/src/lib/hosted-stats.ts
+++ b/server/src/lib/hosted-stats.ts
@@ -1,0 +1,172 @@
+import type Database from 'better-sqlite3';
+import { join } from 'node:path';
+import { openDatabase, today } from '../db/index.js';
+import { env } from '../env.js';
+import { apiModule } from './demo-stats.js';
+import { log } from './log.js';
+
+/*
+  Activity statistics for hosted mode — the demo-stats idea grown up:
+  one row per FAMILY per DAY, counters only. The numbers answer the
+  operator's questions (is a family alive, do both adults use it, which
+  modules matter) without ever reading family content — the same privacy
+  stance as the demo: counters, not data.
+
+  The rows live in their own database (hosted-stats.db) next to the
+  registry. Not in the app schema: migrations describe family data, and
+  these rows describe the service. Deleting a family leaves its history
+  here — the history is the operator's, not the family's.
+
+  User identifiers never touch the disk: the per-day set of active users
+  lives in memory and only its SIZE is stored. The cost is a soft
+  undercount when the process restarts mid-day (the set starts empty and
+  the flush merges with max()) — accepted: deploys are occasional, and
+  an undercount can only delay a "both adults active" verdict, never
+  fake one.
+
+  Everything here is best-effort: a stats failure must never break a
+  family's request, so writes swallow their errors into warn lines.
+*/
+
+interface DayAccumulator {
+  day: string;
+  /** Deltas since the last flush — flushed additively, then reset. */
+  requests: number;
+  writes: number;
+  modules: Map<string, number>;
+  /** Cumulative for the whole day — flushed via max(), never reset. */
+  users: Set<string>;
+}
+
+let statsDb: Database.Database | null = null;
+const accumulators = new Map<string, DayAccumulator>();
+
+const FLUSH_MS = 10 * 60_000;
+
+export function initHostedStats(): void {
+  try {
+    statsDb = openDatabase(join(env.dataDir, 'hosted-stats.db'));
+    statsDb.exec(`
+      CREATE TABLE IF NOT EXISTS family_days (
+        family_id    TEXT NOT NULL,
+        day          TEXT NOT NULL,
+        requests     INTEGER NOT NULL DEFAULT 0,
+        writes       INTEGER NOT NULL DEFAULT 0,
+        active_users INTEGER NOT NULL DEFAULT 0,
+        modules      TEXT NOT NULL DEFAULT '{}',
+        PRIMARY KEY (family_id, day)
+      )
+    `);
+    setInterval(flushHostedStats, FLUSH_MS).unref();
+  } catch (err) {
+    statsDb = null;
+    log.warn('hosted stats: disabled, the database failed to open', err);
+  }
+}
+
+/**
+ * Counts one request against its family's current day. Called after
+ * auth (the user id is part of the count) and only for module requests —
+ * apiModule() filters out auth, health and static noise, so "active"
+ * means "touched the product", the same bar the demo sets.
+ */
+export function trackFamilyRequest(
+  familyId: string,
+  method: string,
+  url: string,
+  userId: string | undefined,
+): void {
+  if (!statsDb) return;
+  const module = apiModule(url);
+  if (!module) return;
+
+  const day = today();
+  let acc = accumulators.get(familyId);
+  if (acc && acc.day !== day) {
+    // Midnight passed: close yesterday's row, start fresh (users reset —
+    // "active today" starts over)
+    flushFamily(familyId, acc);
+    accumulators.delete(familyId);
+    acc = undefined;
+  }
+  if (!acc) {
+    acc = { day, requests: 0, writes: 0, modules: new Map(), users: new Set() };
+    accumulators.set(familyId, acc);
+  }
+
+  acc.requests += 1;
+  if (method !== 'GET' && method !== 'HEAD') acc.writes += 1;
+  acc.modules.set(module, (acc.modules.get(module) ?? 0) + 1);
+  if (userId) acc.users.add(userId);
+}
+
+function flushFamily(familyId: string, acc: DayAccumulator): void {
+  if (!statsDb || acc.requests === 0) return;
+  try {
+    const existing = statsDb
+      .prepare(
+        'SELECT requests, writes, active_users, modules FROM family_days WHERE family_id = ? AND day = ?',
+      )
+      .get(familyId, acc.day) as
+      | { requests: number; writes: number; active_users: number; modules: string }
+      | undefined;
+
+    if (existing) {
+      const modules = JSON.parse(existing.modules) as Record<string, number>;
+      for (const [name, count] of acc.modules) {
+        modules[name] = (modules[name] ?? 0) + count;
+      }
+      statsDb
+        .prepare(
+          `UPDATE family_days
+              SET requests = ?, writes = ?, active_users = ?, modules = ?
+            WHERE family_id = ? AND day = ?`,
+        )
+        .run(
+          existing.requests + acc.requests,
+          existing.writes + acc.writes,
+          Math.max(existing.active_users, acc.users.size),
+          JSON.stringify(modules),
+          familyId,
+          acc.day,
+        );
+    } else {
+      statsDb
+        .prepare(
+          `INSERT INTO family_days (family_id, day, requests, writes, active_users, modules)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          familyId,
+          acc.day,
+          acc.requests,
+          acc.writes,
+          acc.users.size,
+          JSON.stringify(Object.fromEntries(acc.modules)),
+        );
+    }
+
+    acc.requests = 0;
+    acc.writes = 0;
+    acc.modules.clear();
+    // acc.users stays: it is the day's cumulative set behind the max()
+  } catch (err) {
+    log.warn('hosted stats: flush failed', err);
+  }
+}
+
+export function flushHostedStats(): void {
+  for (const [familyId, acc] of accumulators) flushFamily(familyId, acc);
+}
+
+/** Final flush and close — the WAL folds into the file for clean copies. */
+export function shutdownHostedStats(): void {
+  flushHostedStats();
+  try {
+    statsDb?.close();
+  } catch (err) {
+    log.warn('hosted stats: database failed to close', err);
+  }
+  statsDb = null;
+  accumulators.clear();
+}

--- a/server/src/lib/tenants.ts
+++ b/server/src/lib/tenants.ts
@@ -4,6 +4,7 @@ import type Database from 'better-sqlite3';
 import { id, now, openDatabase, runWithDb, runWithTenant, type Tenant } from '../db/index.js';
 import { migrate } from '../db/migrate.js';
 import { env } from '../env.js';
+import { initHostedStats, shutdownHostedStats } from './hosted-stats.js';
 import { log } from './log.js';
 
 /*
@@ -67,6 +68,7 @@ export function initHosted(): void {
   }
   log.notice(`hosted mode: ${migrated} families on *.${env.hostedDomain}`);
 
+  initHostedStats();
   setInterval(closeIdle, IDLE_SWEEP_MS).unref();
 }
 
@@ -154,7 +156,12 @@ function tenantFor(familyId: string): Tenant {
   mkdirSync(attachmentsDir, { recursive: true });
   mkdirSync(backupsDir, { recursive: true });
 
-  const tenant: Tenant = { db: openDatabase(join(dir, 'hub.db')), attachmentsDir, backupsDir };
+  const tenant: Tenant = {
+    db: openDatabase(join(dir, 'hub.db')),
+    attachmentsDir,
+    backupsDir,
+    familyId,
+  };
   openTenants.set(familyId, { tenant, lastUsed: Date.now() });
   return tenant;
 }
@@ -235,6 +242,7 @@ export async function forEachFamily(fn: () => unknown): Promise<void> {
 
 /** Checkpoint and close everything on the way out. */
 export function shutdownHosted(): void {
+  shutdownHostedStats();
   for (const familyId of [...openTenants.keys()]) closeTenant(familyId);
   try {
     ghost?.db.close();

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -58,10 +58,11 @@ describe('createFamily', () => {
 
 describe('host routing', () => {
   let app: FastifyInstance;
+  let smithsId: string;
 
   beforeAll(async () => {
     tenants.initHosted();
-    tenants.createFamily('smiths-a1b2');
+    smithsId = tenants.createFamily('smiths-a1b2').familyId;
     tenants.createFamily('jones-c3d4');
     app = await buildApp();
   });
@@ -127,6 +128,42 @@ describe('host routing', () => {
       payload: { name: 'Eve', email: 'eve@evil.test', password: 'longenoughpass' },
     });
     expect(setup.statusCode).toBe(403);
+  });
+
+  it('counts module requests into per-family day stats, never the ghost', async () => {
+    const login = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: onHost('smiths-a1b2.neiliro.test'),
+      payload: { email: 'sam@smiths.test', password: 'correct horse battery' },
+    });
+    const session = login.cookies.find((c) => c.name === 'hub_session')!;
+
+    const tasks = await app.inject({
+      url: '/api/tasks',
+      headers: { ...onHost('smiths-a1b2.neiliro.test'), cookie: `hub_session=${session.value}` },
+    });
+    expect(tasks.statusCode).toBe(200);
+
+    const stats = await import('../lib/hosted-stats.js');
+    stats.flushHostedStats();
+    const { default: Database } = await import('better-sqlite3');
+    const { join } = await import('node:path');
+    const { env } = await import('../env.js');
+    const db = new Database(join(env.dataDir, 'hosted-stats.db'), { readonly: true });
+    const rows = db.prepare('SELECT family_id, requests, active_users FROM family_days').all() as {
+      family_id: string;
+      requests: number;
+      active_users: number;
+    }[];
+    db.close();
+
+    // Exactly one family has activity — and it is a real one, not the
+    // ghost: probes at unknown subdomains must leave no trace here
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.family_id).toBe(smithsId);
+    expect(rows[0]!.requests).toBeGreaterThanOrEqual(1);
+    expect(rows[0]!.active_users).toBe(1);
   });
 
   it('runs background jobs once per family, each inside its own database', async () => {


### PR DESCRIPTION
Milestone B7 of the hosted roadmap — the demo-stats idea applied to permanent families.

**What is stored** (`hosted-stats.db` next to the registry; own database, not app migrations — these rows describe the service, not family data): one row per **family per day**: `requests`, `writes`, `active_users` (distinct), `modules` (per-module request counts as JSON).

**Privacy stance, same as demo-stats but stricter**: family content is never read, and user identifiers never touch the disk — the per-day user set lives in memory, only its **size** is stored. A mid-day restart therefore merges via `max()` and can only undercount, never double-count (unit-tested).

**Where counting happens**: a `preHandler` registered after `authenticate` — rejected requests aren't engagement, and the user id is needed for the distinct count (the beta exit criterion is "≥5 families active ≥4 weeks *including second adults*"). `apiModule()` is reused from demo-stats: auth/health/static don't count, "active" means "touched the product" in both systems. The ghost has no `familyId`, so probes at unknown subdomains leave no trace — asserted in the e2e test.

**Flush**: every 10 minutes, on day rollover (local wall clock, per project convention), and on shutdown via `shutdownHosted` — the WAL folds into the file for clean backups.

The operator report (`stats.mjs`: per-family week streaks, top modules, and a ready beta-exit-criterion score) lands in the private cloud repo alongside this.

Verified: 118 tests green (2 new: merge semantics incl. restart max(), e2e through real HTTP with session cookie), typecheck, lint; report exercised live against seeded multi-week data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)