### PR TITLE
chore: rebrand the demo family's addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The hub comes up on `http://localhost:8787` and is reachable from other devices 
 Tagged releases publish a prebuilt multi-arch image (amd64 + arm64, so Raspberry Pi works) to GitHub Container Registry — point `image:` in the compose file at it to skip building:
 
 ```bash
-docker pull ghcr.io/neiliro/neiliro:latest   # or a pinned release: :1.1.0
+docker pull ghcr.io/neiliro/neiliro:latest   # or a pinned release: :1.2.0
 ```
 
 For development:

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -79,8 +79,8 @@ export async function seedDemo(): Promise<void> {
     // ── Family ──
     db.prepare(
       `INSERT INTO users (id, email, name, role, password_hash, color, created_at) VALUES
-       (?, 'alex@family.hub', 'Alex', 'admin', ?, '#2E6F8E', ?),
-       (?, 'sam@family.hub', 'Sam', 'member', ?, '#B4654A', ?)`,
+       (?, 'alex@neiliro.example', 'Alex', 'admin', ?, '#2E6F8E', ?),
+       (?, 'sam@neiliro.example', 'Sam', 'member', ?, '#B4654A', ?)`,
     ).run(alex, passwordHash, now(), sam, passwordHash, now());
 
     // ── Projects and tasks ──
@@ -167,12 +167,12 @@ export async function seedDemo(): Promise<void> {
     db.prepare(
       `INSERT INTO mail_messages (id, kind, from_address, from_name, to_address, subject,
                                   body_text, sent_at, received_at, read_at) VALUES
-       (?, 'in', 'office@riverside-school.example', 'Riverside School', 'family@hub.example',
+       (?, 'in', 'office@riverside-school.example', 'Riverside School', 'family@neiliro.example',
         'Parent-teacher evening on Thursday',
         'Dear parents,' || char(10) || char(10) ||
         'We look forward to seeing you this Thursday at 17:30 in the main hall. Please confirm your attendance by replying to this email.' || char(10) || char(10) ||
         'Riverside School office', ?, ?, NULL),
-       (?, 'in', 'no-reply@citypower.example', 'City Power & Light', 'family@hub.example',
+       (?, 'in', 'no-reply@citypower.example', 'City Power & Light', 'family@neiliro.example',
         'Your electricity bill for July',
         'Your bill for July is ready: 64.20 EUR, due by the 25th.' || char(10) ||
         'The detailed statement is attached as a PDF in the original message.', ?, ?, ?)`,

--- a/server/src/lib/mail.test.ts
+++ b/server/src/lib/mail.test.ts
@@ -8,7 +8,7 @@ const PDF_BASE64 = Buffer.from('%PDF-1.4 fake').toString('base64');
 const RAW_WITH_ATTACHMENT = [
   'Message-ID: <trip-42@school.example>',
   'From: "Riverside School" <office@school.example>',
-  'To: family@hub.example',
+  'To: family@neiliro.example',
   'Subject: Trip consent form',
   'Date: Thu, 14 Aug 2026 09:00:00 +0200',
   'MIME-Version: 1.0',
@@ -31,7 +31,7 @@ const RAW_WITH_ATTACHMENT = [
 const RAW_HTML_ONLY = [
   'Message-ID: <bill-7@power.example>',
   'From: no-reply@power.example',
-  'To: family@hub.example',
+  'To: family@neiliro.example',
   'Subject: Your bill',
   'MIME-Version: 1.0',
   'Content-Type: text/html; charset=utf-8',


### PR DESCRIPTION
The last brand tail from the Neiliro rename (milestone A of the hosted roadmap).

The seeded demo family still logged in as `alex@family.hub` / `sam@family.hub`, and the two sample letters in the Mail section arrived at `family@hub.example`. The demo is the shop window the landing page links to, so those addresses are on display in People, Settings and Mail. Now `neiliro.example` — the `.example` TLD is reserved by RFC 2606 and can never resolve, so it reads as the placeholder it is without promising an address that doesn't exist yet (addresses-from-slug are milestone C).

Deliberately **not** touched: `hub.example.com` throughout `docs/deploy-vps.md` and `env.ts` — that placeholder stands for a *self-hoster's own* domain, and rebranding it would be wrong.

Test fixtures in `mail.test.ts` follow along so the codebase has one placeholder domain rather than two. README's pinned-release example goes from `:1.1.0` to the current `:1.2.0`.

Verified: 118 tests green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)