### PR TITLE
feat: the app calls itself Neiliro, not "Home"

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -278,7 +278,7 @@ export function AppShell() {
         {/* The theme toggle lives in the header: next to Sign out a missed
             click cost a whole session — a price out of scale for the button */}
         <div className="mb-8 flex items-center justify-between px-2">
-          <span className="font-display text-lg font-bold tracking-tight text-ink">{t('Home')}</span>
+          <span className="font-display text-lg font-bold tracking-tight text-ink">Neiliro</span>
           <ThemeToggle />
         </div>
 

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -318,7 +318,6 @@ export const ru: Record<string, string> = {
   'Highlight': 'Выделение',
   'History': 'История',
   'History is empty — the note has not been edited since creation.': 'История пуста — заметку ещё не правили после создания.',
-  'Home': 'Дом',
   'I': 'К',
   'In progress': 'В работе',
   'Inbox': 'Входящие',

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -13,12 +13,10 @@ import { onEnter } from '../lib/keys';
 */
 function Frame({
   title,
-  hint,
   note,
   children,
 }: {
   title: string;
-  hint: string;
   note?: React.ReactNode;
   children: React.ReactNode;
 }) {
@@ -26,8 +24,11 @@ function Frame({
     <div className="flex min-h-dvh items-center justify-center bg-surface-2 px-5">
       <div className="w-full max-w-sm">
         <div className="mb-7 text-center">
-          <p className="font-display text-2xl font-bold tracking-tight text-ink">{t('Home')}</p>
-          <p className="mt-1.5 text-sm text-muted">{hint}</p>
+          {/* The brand is a proper noun, not a UI string: the same word in
+              both languages, so it never goes through t(). Every caller
+              used to pass it a second time as a subtitle under a
+              localized "Home" — one brand, one line. (#136) */}
+          <p className="font-display text-2xl font-bold tracking-tight text-ink">Neiliro</p>
         </div>
         <div className="rounded-card border border-line bg-surface p-6">
           <h1 className="eyebrow mb-5">{title}</h1>
@@ -168,7 +169,6 @@ export function Login() {
     return (
       <Frame
       title={t('Demo')}
-      hint="Neiliro"
       note={
         <p>
           {t('Run your own: one Docker container, the data stays at home.')}{' '}
@@ -196,7 +196,7 @@ export function Login() {
 
   return (
     mfaToken ? (
-    <Frame title={t('Enter the code')} hint="Neiliro">
+    <Frame title={t('Enter the code')}>
       <form onSubmit={submitMfa} className="space-y-4">
         <p className="text-sm text-muted">
           {t('The six-digit code from your authenticator app.')}
@@ -232,7 +232,7 @@ export function Login() {
       </form>
     </Frame>
     ) : (
-    <Frame title={t('Sign in')} hint="Neiliro">
+    <Frame title={t('Sign in')}>
       <form onSubmit={submit} className="space-y-4">
         <label className="block">
           <span className="mb-1.5 block text-sm font-medium text-ink">{t('Login')}</span>
@@ -332,7 +332,7 @@ function Setup() {
   }
 
   return (
-    <Frame title={t('First run')} hint="Neiliro">
+    <Frame title={t('First run')}>
       <p className="mb-5 text-sm text-muted">
         {t('Create the first account — it becomes the administrator: it can invite family members and reset passwords.')}
       </p>
@@ -403,7 +403,7 @@ function Join() {
   if (valid === null) return null;
   if (!valid) {
     return (
-      <Frame title={t('Invitation')} hint="Neiliro">
+      <Frame title={t('Invitation')}>
         <p className="text-sm text-muted">
           {t('This link is no longer valid: it has expired or was already used. Ask the person who runs the hub for a new one.')}
         </p>
@@ -412,7 +412,7 @@ function Join() {
   }
 
   return (
-    <Frame title={t('Invitation')} hint="Neiliro">
+    <Frame title={t('Invitation')}>
       <p className="mb-5 text-sm text-muted">{t('You have been invited to Neiliro. Set up your account:')}</p>
       <form onSubmit={(e) => void submit(e)} className="space-y-4">
         <label className="block">
@@ -472,7 +472,7 @@ export function ChangePassword() {
 
   if (done) {
     return (
-      <Frame title={t('Password changed')} hint="Neiliro">
+      <Frame title={t('Password changed')}>
         <p className="mb-5 text-sm text-muted">
           {t('Password updated. All devices were signed out — sign in again with the new password.')}
         </p>
@@ -484,7 +484,7 @@ export function ChangePassword() {
   }
 
   return (
-    <Frame title={t('Change password')} hint="Neiliro">
+    <Frame title={t('Change password')}>
       <p className="mb-5 text-sm text-muted">
         {t('The issued password was shown once. Set your own before continuing.')}
       </p>


### PR DESCRIPTION
Part 1 of #136 — and the last visible tail of the Neiliro rebrand (milestone A of the hosted roadmap).

The rebrand took the tab title and the PWA manifest, but the two most prominent in-app spots still rendered the pre-rebrand `t('Home')` — «Дом» in Russian:

- the sidebar header (`AppShell.tsx`)
- the login header (`Login.tsx`)

**The brand stops being a translatable string.** It is a proper noun — the same word in both languages — so it no longer goes through `t()`, and the `'Home': 'Дом'` dictionary entry is deleted.

**It also removes a duplication the rebrand introduced.** Every `<Frame>` on the login screen passed `hint="Neiliro"`, rendered as a muted subtitle *underneath* the localized "Home" — so the brand appeared twice, once wrong (before the rebrand that subtitle was the descriptor `t('Family hub')`). The `hint` prop existed for nothing else, so it is gone along with its 8 call sites: one brand, one line.

Part 2 of #136 — a family renaming their home — deliberately stays in the backlog for self-serve. It will put the family's own name in this same slot via the `calendarName`/`projectTitle` pattern, which is exactly why the default now lives in one place per surface. **The issue stays open** for that half.

## Verified

Production build, driven in the browser in both languages: login shows a single "Neiliro", the sidebar header shows "Neiliro", nothing renders «Дом». 176 tests green (the i18n coverage scan included — it is what would have caught a stale key), typecheck and lint clean.

## Follow-up for the landing page

The screenshots on neiliro.com were shot from the live demo and still show "Home" in the sidebar. They need a reshoot (`scripts/shoot.mjs` in the www repo) **after** this merges and the demo redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)