### PR TITLE
chore: version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump ahead of the `v1.3.0` tag: hosted mode (#137), per-family backups (#138), per-family activity counters (#139), and the brand tails (#140, #141, #142).

No new migrations in this release — the schema is unchanged since 1.2.0; hosted mode's registry and stats live in their own databases outside the app schema, on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)