### PR TITLE
feat: add 'rename your home' setting (#136)

### DIFF
--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -104,6 +104,7 @@ export function clearSessionCookie(reply: FastifyReply): void {
 
 const PUBLIC_PATHS = new Set([
   '/api/health',
+  '/api/home-name',
   '/api/auth/login',
   // The TOTP step of sign-in: the session does not exist yet, the
   // short-lived ticket from /login is the authorization

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -104,6 +104,8 @@ export function clearSessionCookie(reply: FastifyReply): void {
 
 const PUBLIC_PATHS = new Set([
   '/api/health',
+  // Home name for the sign-in screen; hosted mode answers the brand
+  // only — see routes/index.ts
   '/api/home-name',
   '/api/auth/login',
   // The TOTP step of sign-in: the session does not exist yet, the

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -18,6 +18,15 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
     }
   });
 
+  // ── Home name (public — the login page needs it without a session) ────
+
+  app.get('/api/home-name', () => {
+    const row = db
+      .prepare("SELECT value FROM settings WHERE key = 'home.name'")
+      .get() as { value: string } | undefined;
+    return { name: row?.value?.trim() || 'Neiliro' };
+  });
+
   // ── Settings (dashboard widgets included) ──────────────────────────────
 
   app.get('/api/settings', () => {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { db, now, today as localToday } from '../db/index.js';
+import { env } from '../env.js';
 import { listOccurrences, remindersFor } from './calendar.js';
 
 export async function registerRoutes(app: FastifyInstance): Promise<void> {
@@ -21,6 +22,12 @@ export async function registerRoutes(app: FastifyInstance): Promise<void> {
   // ── Home name (public — the login page needs it without a session) ────
 
   app.get('/api/home-name', () => {
+    // Hosted: the public answer is always the brand. A family-chosen name
+    // is private data, and a renamed family must stay indistinguishable
+    // from the ghost (lib/tenants.ts). Inside the app the name arrives
+    // through /api/settings, behind the session.
+    if (env.hostedMode) return { name: 'Neiliro' };
+
     const row = db
       .prepare("SELECT value FROM settings WHERE key = 'home.name'")
       .get() as { value: string } | undefined;

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,7 +1,9 @@
 import { t } from '../lib/i18n';
 import { BUILD_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
+import { homeName } from '../lib/home-name';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
+import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { applyUpdate, setupPwa } from '../lib/pwa';
 import { clearFailure, useFailure } from '../lib/failures';
@@ -267,7 +269,21 @@ export function AppShell() {
   // and there is no sidebar there at all.
   const [searchOpen, setSearchOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [settings, setSettings] = useState<Record<string, string>>({});
   const sidebarNav = [...NAV, ...SECONDARY];
+
+  useEffect(() => {
+    void api
+      .get<Record<string, string>>('/settings')
+      .then(setSettings)
+      .catch(() => {});
+  }, []);
+
+  // The brand defaults to "Neiliro"; a family-chosen name wins verbatim.
+  const displayName = homeName(settings);
+  useEffect(() => {
+    document.title = displayName;
+  }, [displayName]);
 
   return (
     <div className="min-h-dvh md:flex">
@@ -278,7 +294,7 @@ export function AppShell() {
         {/* The theme toggle lives in the header: next to Sign out a missed
             click cost a whole session — a price out of scale for the button */}
         <div className="mb-8 flex items-center justify-between px-2">
-          <span className="font-display text-lg font-bold tracking-tight text-ink">Neiliro</span>
+          <span className="font-display text-lg font-bold tracking-tight text-ink">{displayName}</span>
           <ThemeToggle />
         </div>
 

--- a/web/src/lib/home-name.ts
+++ b/web/src/lib/home-name.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { api } from './api';
+
+const BRAND = 'Neiliro';
+
+/**
+ * Display name for the hub. Follows the calendarName / projectTitle
+ * pattern: the default is product branding rendered in place; a name
+ * set by the family is data and wins verbatim. (#136)
+ */
+export function homeName(settings: Record<string, string>): string {
+  return settings['home.name']?.trim() || BRAND;
+}
+
+/**
+ * Fetch the home name from the public endpoint — used by the login
+ * page, which sits outside the auth gate and cannot read /api/settings.
+ */
+export function useHomeName(): string | null {
+  const [name, setName] = useState<string | null>(null);
+  useEffect(() => {
+    void api
+      .get<{ name: string }>('/home-name')
+      .then((r) => setName(r.name))
+      .catch(() => setName(BRAND));
+  }, []);
+  return name;
+}

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -252,7 +252,7 @@ export const ru: Record<string, string> = {
   'Goal name': 'Название цели',
   'Goal settings': 'Настройки цели',
   'Home name': 'Название дома',
-  'A local label for your hub — shows in the sidebar, the sign-in screen and the browser tab. Leave blank for the default.': 'Местная метка вашего хаба — отображается на боковой панели, экране входа и во вкладке браузера. Оставьте пустым для значения по умолчанию.',
+  'A local label for your hub — shows in the sidebar, the sign-in screen and the browser tab. Leave blank for the default.': 'Своё название дома — видно в боковом меню, на экране входа и во вкладке браузера. Пусто — останется Neiliro.',
   'in {unit}': 'через {unit}',
   'Left': 'Останется',
   'Overdue counts from this date': 'Просрочка считается от этой даты',

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -251,6 +251,8 @@ export const ru: Record<string, string> = {
   'Goal currency': 'Валюта цели',
   'Goal name': 'Название цели',
   'Goal settings': 'Настройки цели',
+  'Home name': 'Название дома',
+  'A local label for your hub — shows in the sidebar, the sign-in screen and the browser tab. Leave blank for the default.': 'Местная метка вашего хаба — отображается на боковой панели, экране входа и во вкладке браузера. Оставьте пустым для значения по умолчанию.',
   'in {unit}': 'через {unit}',
   'Left': 'Останется',
   'Overdue counts from this date': 'Просрочка считается от этой даты',

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { lang, setLang, t } from '../lib/i18n';
 import { ISSUES_URL, REPO_URL } from '../lib/build';
+import { useHomeName } from '../lib/home-name';
 import { useEffect, useState, type FormEvent } from 'react';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
@@ -20,15 +21,20 @@ function Frame({
   note?: React.ReactNode;
   children: React.ReactNode;
 }) {
+  const displayName = useHomeName();
+
+  useEffect(() => {
+    if (displayName) document.title = displayName;
+  }, [displayName]);
+
   return (
     <div className="flex min-h-dvh items-center justify-center bg-surface-2 px-5">
       <div className="w-full max-w-sm">
         <div className="mb-7 text-center">
           {/* The brand is a proper noun, not a UI string: the same word in
-              both languages, so it never goes through t(). Every caller
-              used to pass it a second time as a subtitle under a
-              localized "Home" — one brand, one line. (#136) */}
-          <p className="font-display text-2xl font-bold tracking-tight text-ink">Neiliro</p>
+              both languages, so it never goes through t(). A family-chosen
+              name wins verbatim over the default. (#136) */}
+          <p className="font-display text-2xl font-bold tracking-tight text-ink">{displayName ?? 'Neiliro'}</p>
         </div>
         <div className="rounded-card border border-line bg-surface p-6">
           <h1 className="eyebrow mb-5">{title}</h1>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -518,6 +518,7 @@ export function Settings() {
             onChange={(e) => setValues({ ...values, 'home.name': e.target.value })}
             onKeyDown={onEnter(() => void save())}
             placeholder="Neiliro"
+            maxLength={60}
             className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent"
           />
           <span className="mt-1 block text-xs text-muted">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -510,6 +510,21 @@ export function Settings() {
           mx-auto centers the capped block like every other page. */}
       <div className="mx-auto max-w-md columns-1 gap-5 lg:max-w-4xl lg:columns-2 3xl:max-w-[86rem] 3xl:columns-3 4xl:max-w-[114rem] 4xl:columns-4">
       <div className="mb-5 break-inside-avoid space-y-5 rounded-card border border-line bg-surface p-5">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-ink">{t('Home name')}</span>
+          <input
+            type="text"
+            value={values['home.name'] ?? ''}
+            onChange={(e) => setValues({ ...values, 'home.name': e.target.value })}
+            onKeyDown={onEnter(() => void save())}
+            placeholder="Neiliro"
+            className="w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+          />
+          <span className="mt-1 block text-xs text-muted">
+            {t('A local label for your hub — shows in the sidebar, the sign-in screen and the browser tab. Leave blank for the default.')}
+          </span>
+        </label>
+
         {FIELDS.map((f) => (
           <label key={f.key} className="block">
             <span className="mb-1.5 block text-sm font-medium text-ink">{f.label}</span>


### PR DESCRIPTION
Families can now set a custom display name for their hub. The name shows in the sidebar header, the sign-in screen, and the browser tab. Defaults to 'Neiliro' when unset.

Server:
- Add GET /api/home-name (public, no session required) so the login page can fetch the name without authentication
- Add /api/home-name to PUBLIC_PATHS

Frontend:
- Add web/src/lib/home-name.ts: homeName() helper (reads from settings) and useHomeName() hook (fetches from the public endpoint)
- AppShell: fetch settings on mount, display dynamic home name in sidebar header, update document.title reactively
- Login: Frame component uses useHomeName() hook, displays dynamic name in the sign-in header, updates document.title
- Settings: add 'Home name' input field at the top of the settings card
- i18n.ru.ts: add Russian translations for new strings