### PR TITLE
feat: family archive export and self-deletion from settings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,8 @@ Families live in `families/<internal-id>/` under the data directory and are list
 
 A subdomain that doesn't exist is deliberately indistinguishable from one that does: unknown hosts resolve to a ghost — an empty in-memory database that claims to be set up, rejects sign-ins exactly like a real family rejecting a wrong password (timing included: the dummy-scrypt path already existed), and refuses first-run setup. Probing names tells an outsider nothing.
 
+The family's data is self-service (`routes/family.ts`, Settings → admin). **Export**: the complete archive — database via `VACUUM INTO` (WAL folded in), attachments, manifest — streamed as tar.gz in the exact layout `scripts/import.mjs` restores, so a hosted family can leave for self-hosting at any time; a round-trip test runs a settings export through the real import script. **Deletion** (hosted only): the admin proves the password, a TOTP code when enabled, and types the family's slug; the registry row flips to `deleted` (the slug is never re-issued — a stranger inheriting it would inherit bookmarks and mail), the database files and attachments are removed, and encrypted backups are left to expire on their own within 14 days. Self-hosted installs get the export but not the button: deleting the only family means erasing the instance, which belongs to the machine's owner at the filesystem.
+
 None of this concerns self-hosting: without the flag the hub runs exactly as before, one family per server.
 
 ## Offline and updates

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -33,6 +33,7 @@ import { registerCalendarRoutes } from './routes/calendar.js';
 import { registerMailRoutes } from './routes/mail.js';
 import { registerMoneyRoutes } from './routes/money.js';
 import { registerBudgetRoutes } from './routes/budgets.js';
+import { registerFamilyRoutes } from './routes/family.js';
 import { authenticate } from './lib/auth.js';
 import { log } from './lib/log.js';
 
@@ -287,6 +288,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await registerMailRoutes(app);
   await registerMoneyRoutes(app);
   await registerBudgetRoutes(app);
+  await registerFamilyRoutes(app);
 
   await registerRoutes(app);
 

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -29,6 +29,10 @@ export function demoBlocked(method: string, path: string): boolean {
   // scan QR codes for accounts that stop existing in two hours
   if (path.startsWith('/api/auth/totp')) return true;
   if (path.startsWith('/api/auth/google')) return true;
+  // The family archive and self-deletion are meaningless for a throwaway
+  // sandbox. Only the POST is caught here — GETs pass through this
+  // function, so the export route carries its own demo check.
+  if (path.startsWith('/api/family/')) return true;
   // All file uploads: note attachments and transaction receipts
   if (method === 'POST' && path.includes('/attachments')) return true;
   if (method === 'POST' && path.includes('/receipts')) return true;

--- a/server/src/lib/tenants.ts
+++ b/server/src/lib/tenants.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { id, now, openDatabase, runWithDb, runWithTenant, type Tenant } from '../db/index.js';
@@ -59,6 +59,11 @@ export function initHosted(): void {
   // families' breakfast hostage.
   let migrated = 0;
   for (const family of allFamilies()) {
+    // A deleted family's files are gone; migrating it would quietly
+    // recreate an empty hub.db in its place. Suspended families keep
+    // migrating — they may come back mid-process, and must not return
+    // to a schema the code has moved past.
+    if (family.status === 'deleted') continue;
     try {
       runWithTenant(tenantFor(family.id), migrate);
       migrated += 1;
@@ -295,4 +300,48 @@ export function createFamily(slug: string): { familyId: string; url: string } {
   runWithTenant(tenantFor(familyId), migrate);
   log.notice(`family created: ${slug} (${familyId})`);
   return { familyId, url: `https://${slug}.${env.hostedDomain}/` };
+}
+
+// ── Self-service deletion (GDPR, routes/family.ts) ───────────────────────
+
+/** The family's slug — the phrase the admin must type to confirm deletion. */
+export function familySlug(familyId: string): string | null {
+  const row = registry!.prepare('SELECT slug FROM families WHERE id = ?').get(familyId) as
+    | { slug: string }
+    | undefined;
+  return row?.slug ?? null;
+}
+
+/**
+ * Remove a family's data for good: the database (all three WAL-mode
+ * files) and the attachments directory.
+ *
+ * The order is the point. First the family becomes unroutable — registry
+ * status plus the slug cache — and only then does the handle close and
+ * the files go: reversed, a request landing between the steps would call
+ * tenantFor, which recreates directories and an empty hub.db, and the
+ * "deleted" family would resurrect as a blank hub on its old address.
+ * Requests already in flight may hit a closed handle and fail with a
+ * 500 — acceptable for an action this final.
+ *
+ * The row stays in the registry as status='deleted' rather than being
+ * removed: the slug must never be re-registered by strangers (bookmarks
+ * and mail addressed to it would land in their hands), and the control
+ * plane reads the status to finish its own bookkeeping. Backups are
+ * deliberately left alone — they are encrypted and expire within 14
+ * days on their own, exactly as the privacy policy promises.
+ */
+export function deleteFamilyData(familyId: string): void {
+  registry!.prepare(`UPDATE families SET status = 'deleted' WHERE id = ?`).run(familyId);
+  for (const [slug, entry] of slugCache) {
+    if (entry.familyId === familyId) slugCache.delete(slug);
+  }
+  closeTenant(familyId);
+
+  const dir = join(familiesDir, familyId);
+  for (const suffix of ['', '-wal', '-shm']) {
+    rmSync(join(dir, `hub.db${suffix}`), { force: true });
+  }
+  rmSync(join(dir, 'attachments'), { recursive: true, force: true });
+  log.notice(`family deleted: ${familyId}`);
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -100,17 +100,23 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     // In demo the answer is fixed: the main database is empty (life
     // happens in sandboxes), but the initial setup screen must not be
     // shown, and there is one way in — the "Try the demo" button.
-    if (env.demoMode) return { initialized: true, google: false, demo: true };
+    if (env.demoMode) return { initialized: true, google: false, demo: true, hosted: false };
     // A hosted subdomain that doesn't exist claims to be set up: showing
     // the first-run screen only on real families would let anyone map
     // which names exist by probing. See lib/tenants.ts, the ghost.
-    if (currentTenant().ghost) return { initialized: true, google: false, demo: false };
+    // `hosted` is safe to state even here — that the service is hosted
+    // is public knowledge, only which families exist is not.
+    if (currentTenant().ghost) {
+      return { initialized: true, google: false, demo: false, hosted: true };
+    }
     const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
     return {
       initialized: n > 0,
       // Whether showing the "Sign in with Google" button makes sense
       google: Boolean(env.googleClientId && env.googleClientSecret && env.publicUrl),
       demo: false,
+      // The frontend gates hosted-only settings (the family Danger zone) on it
+      hosted: env.hostedMode,
     };
   });
 

--- a/server/src/routes/family-export.test.ts
+++ b/server/src/routes/family-export.test.ts
@@ -1,0 +1,111 @@
+import Database from 'better-sqlite3';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+import { runWithDb, id, now } from '../db/index.js';
+import { createSession } from '../lib/auth.js';
+import { demoBlocked } from '../lib/demo.js';
+import { paths } from '../env.js';
+
+/*
+  The no-lock-in promise, verified end to end: an archive downloaded
+  from Settings must restore into a self-hosted hub through the real
+  scripts/import.mjs — not through a reimplementation of it in the test.
+  If either side drifts (manifest keys, layout, integrity expectations),
+  this is the test that goes red.
+*/
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+let h: Harness;
+let admin: { userId: string; cookie: string };
+
+beforeAll(async () => {
+  h = await buildTestApp();
+  admin = h.join('alex');
+});
+
+describe('family export, single-family mode', () => {
+  it('round-trips through scripts/import.mjs', async () => {
+    // Content worth checking on the far side: a note through the API and
+    // a file in the attachments directory
+    const note = await h.as(admin.cookie, 'POST', '/api/notes', {
+      title: 'Packing list',
+      body_md: 'passports, chargers',
+    });
+    expect(note.statusCode).toBe(201);
+    mkdirSync(join(paths.attachments, '2026-08'), { recursive: true });
+    writeFileSync(join(paths.attachments, '2026-08', 'receipt.bin'), 'receipt bytes');
+
+    const res = await h.as(admin.cookie, 'GET', '/api/family/export');
+    expect(res.statusCode).toBe(200);
+    const payload = (res as unknown as { rawPayload: Buffer }).rawPayload;
+    // gzip magic bytes — the response is a real archive, not JSON
+    expect(payload[0]).toBe(0x1f);
+    expect(payload[1]).toBe(0x8b);
+
+    const work = mkdtempSync(join(tmpdir(), 'hub-roundtrip-'));
+    const archive = join(work, 'neiliro-export.tar.gz');
+    writeFileSync(archive, payload);
+
+    // The real import script into a fresh DATA_DIR — the self-hosted
+    // restore path, exactly as the docs describe it
+    const restored = join(work, 'restored');
+    execFileSync('node', [join(repoRoot, 'scripts', 'import.mjs'), archive], {
+      env: { ...process.env, DATA_DIR: restored },
+      stdio: 'pipe',
+    });
+
+    const imported = new Database(join(restored, 'hub.db'), { readonly: true });
+    try {
+      expect(imported.pragma('integrity_check', { simple: true })).toBe('ok');
+      const users = imported.prepare('SELECT email FROM users').all() as { email: string }[];
+      expect(users.map((u) => u.email)).toEqual(['alex@hub.local']);
+      const notes = imported.prepare('SELECT title FROM notes').all() as { title: string }[];
+      expect(notes.map((n) => n.title)).toContain('Packing list');
+    } finally {
+      imported.close();
+    }
+    expect(existsSync(join(restored, 'attachments', '2026-08', 'receipt.bin'))).toBe(true);
+  });
+
+  it('is for the administrator only', async () => {
+    // The harness only mints admins; a member is two direct rows away
+    const member = runWithDb(h.db, () => {
+      const userId = id();
+      h.db
+        .prepare(
+          `INSERT INTO users (id, email, name, role, password_hash, created_at)
+           VALUES (?, 'kid@hub.local', 'Kim', 'member', 'x', ?)`,
+        )
+        .run(userId, now());
+      return createSession(userId, 'kid-device');
+    });
+
+    const res = await h.as(member, 'GET', '/api/family/export');
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('family deletion, single-family mode', () => {
+  it('does not exist outside the hosted service', async () => {
+    // Self-hosted: one family per server, so this button would mean
+    // "erase the instance" — that stays a host-level operation
+    const res = await h.as(admin.cookie, 'POST', '/api/family/delete', {
+      password: 'whatever',
+      confirm: 'whatever',
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toBe(
+      'Family deletion is available on the hosted service only',
+    );
+  });
+
+  it('is blocked in the demo alongside the other destructive routes', () => {
+    expect(demoBlocked('POST', '/api/family/delete')).toBe(true);
+  });
+});

--- a/server/src/routes/family-hosted.test.ts
+++ b/server/src/routes/family-hosted.test.ts
@@ -1,0 +1,233 @@
+import Database from 'better-sqlite3';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+/*
+  The GDPR pair in hosted mode: the settings export must contain exactly
+  one family's data, and self-deletion must remove one family's files
+  without touching its neighbours. Both promises are the whole point of
+  the tenant context — so both are checked against two real families
+  side by side, not against a single database where the bug could not
+  show even in principle.
+
+  Same env dance as hosted.test.ts: env.ts reads the flags at import
+  time, hence the dynamic imports and the afterAll cleanup.
+*/
+process.env.HOSTED_MODE = 'true';
+process.env.HOSTED_DOMAIN = 'neiliro.test';
+
+const tenants = await import('../lib/tenants.js');
+const { buildApp } = await import('../app.js');
+const { env } = await import('../env.js');
+
+afterAll(() => {
+  delete process.env.HOSTED_MODE;
+  delete process.env.HOSTED_DOMAIN;
+  tenants.shutdownHosted();
+});
+
+let app: FastifyInstance;
+
+interface Family {
+  slug: string;
+  familyId: string;
+  email: string;
+  cookie: string;
+}
+
+/** Create a family, run first-run setup, sign the admin in. */
+async function bringUpFamily(slug: string, name: string): Promise<Family> {
+  const { familyId } = tenants.createFamily(slug);
+  // The setup route lowercases logins; build the expectation the same way
+  const email = `${name.toLowerCase()}@${slug}.test`;
+  const setup = await app.inject({
+    method: 'POST',
+    url: '/api/auth/setup',
+    headers: { host: `${slug}.neiliro.test` },
+    payload: { name, email, password: 'correct horse battery' },
+  });
+  expect(setup.statusCode).toBe(201);
+  const login = await app.inject({
+    method: 'POST',
+    url: '/api/auth/login',
+    headers: { host: `${slug}.neiliro.test` },
+    payload: { email, password: 'correct horse battery' },
+  });
+  expect(login.statusCode).toBe(200);
+  const cookie = login.cookies.find((c) => c.name === 'hub_session')!.value;
+  return { slug, familyId, email, cookie };
+}
+
+function onFamily(f: Family) {
+  return { host: `${f.slug}.neiliro.test`, cookie: `hub_session=${f.cookie}` };
+}
+
+/** Download the family's export and unpack it into a fresh directory. */
+async function exportAndUnpack(f: Family): Promise<string> {
+  const res = await app.inject({ url: '/api/family/export', headers: onFamily(f) });
+  expect(res.statusCode).toBe(200);
+  expect(res.headers['content-type']).toBe('application/gzip');
+
+  const dir = mkdtempSync(join(tmpdir(), 'hub-export-test-'));
+  const archive = join(dir, 'export.tar.gz');
+  writeFileSync(archive, res.rawPayload);
+  execFileSync('tar', ['-xzf', archive, '-C', dir]);
+  return dir;
+}
+
+function userEmails(dbPath: string): string[] {
+  const snapshot = new Database(dbPath, { readonly: true });
+  try {
+    expect(snapshot.pragma('integrity_check', { simple: true })).toBe('ok');
+    return (snapshot.prepare('SELECT email FROM users').all() as { email: string }[]).map(
+      (r) => r.email,
+    );
+  } finally {
+    snapshot.close();
+  }
+}
+
+describe('family export in hosted mode', () => {
+  let smiths: Family;
+  let jones: Family;
+
+  beforeAll(async () => {
+    tenants.initHosted();
+    app = await buildApp();
+    smiths = await bringUpFamily('smiths-e1x1', 'Sam');
+    jones = await bringUpFamily('jones-e2x2', 'Pat');
+  });
+
+  it('contains exactly the requesting family, cross-checked both ways', async () => {
+    // A file in the attachments directory must ride along in the archive
+    const attachmentsDir = join(env.dataDir, 'families', smiths.familyId, 'attachments');
+    mkdirSync(join(attachmentsDir, '2026-08'), { recursive: true });
+    writeFileSync(join(attachmentsDir, '2026-08', 'receipt.bin'), 'smiths receipt');
+
+    const smithsDir = await exportAndUnpack(smiths);
+    expect(userEmails(join(smithsDir, 'hub.db'))).toEqual([smiths.email]);
+    expect(existsSync(join(smithsDir, 'attachments', '2026-08', 'receipt.bin'))).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(join(smithsDir, 'manifest.json'), 'utf8')) as {
+      counts: Record<string, number>;
+      migrations: string[];
+      attachments: { files: number };
+    };
+    expect(manifest.counts.users).toBe(1);
+    expect(manifest.migrations.length).toBeGreaterThan(0);
+    expect(manifest.attachments.files).toBe(1);
+
+    const jonesDir = await exportAndUnpack(jones);
+    expect(userEmails(join(jonesDir, 'hub.db'))).toEqual([jones.email]);
+    expect(existsSync(join(jonesDir, 'attachments', '2026-08', 'receipt.bin'))).toBe(false);
+  });
+});
+
+describe('family self-deletion', () => {
+  let doomed: Family;
+  let survivor: Family;
+
+  beforeAll(async () => {
+    tenants.initHosted();
+    app = app ?? (await buildApp());
+    doomed = await bringUpFamily('doomed-d1x1', 'Dana');
+    survivor = await bringUpFamily('alive-d2x2', 'Ann');
+  });
+
+  it('refuses a wrong password and a wrong confirmation phrase', async () => {
+    const wrongPassword = await app.inject({
+      method: 'POST',
+      url: '/api/family/delete',
+      headers: onFamily(doomed),
+      payload: { password: 'not the password', confirm: doomed.slug },
+    });
+    expect(wrongPassword.statusCode).toBe(400);
+    expect(wrongPassword.json().error).toBe('The current password is incorrect');
+
+    const wrongPhrase = await app.inject({
+      method: 'POST',
+      url: '/api/family/delete',
+      headers: onFamily(doomed),
+      payload: { password: 'correct horse battery', confirm: 'someone-else' },
+    });
+    expect(wrongPhrase.statusCode).toBe(400);
+    expect(wrongPhrase.json().error).toBe('The confirmation phrase does not match the family address');
+  });
+
+  it('demands a TOTP code when the admin has one', async () => {
+    // Straight into the family's database file: enabling TOTP through the
+    // API would need a live authenticator, and the route only cares that
+    // the flags are set
+    const dbPath = join(env.dataDir, 'families', doomed.familyId, 'hub.db');
+    const direct = new Database(dbPath);
+    direct
+      .prepare(`UPDATE users SET totp_secret = 'JBSWY3DPEHPK3PXP', totp_confirmed_at = '2026-08-24 00:00:00'`)
+      .run();
+    direct.close();
+
+    const withoutCode = await app.inject({
+      method: 'POST',
+      url: '/api/family/delete',
+      headers: onFamily(doomed),
+      payload: { password: 'correct horse battery', confirm: doomed.slug },
+    });
+    expect(withoutCode.statusCode).toBe(400);
+    expect(withoutCode.json().error).toBe('Enter the code');
+
+    const disarm = new Database(dbPath);
+    disarm.prepare('UPDATE users SET totp_secret = NULL, totp_confirmed_at = NULL').run();
+    disarm.close();
+  });
+
+  it('removes the family and leaves the neighbour untouched', async () => {
+    const familyDir = join(env.dataDir, 'families', doomed.familyId);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/family/delete',
+      headers: onFamily(doomed),
+      payload: { password: 'correct horse battery', confirm: doomed.slug },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+
+    // Database files (all three WAL-mode ones) and attachments are gone;
+    // backups stay — they are encrypted and expire on their own
+    for (const suffix of ['', '-wal', '-shm']) {
+      expect(existsSync(join(familyDir, `hub.db${suffix}`))).toBe(false);
+    }
+    expect(existsSync(join(familyDir, 'attachments'))).toBe(false);
+    expect(existsSync(join(familyDir, 'backups'))).toBe(true);
+
+    const registry = new Database(join(env.dataDir, 'registry.db'), { readonly: true });
+    const row = registry
+      .prepare('SELECT status FROM families WHERE id = ?')
+      .get(doomed.familyId) as { status: string };
+    registry.close();
+    expect(row.status).toBe('deleted');
+
+    // The old address now behaves like any unknown subdomain: the ghost
+    // claims to be set up and rejects sign-ins — no trace, no enumeration
+    const state = await app.inject({
+      url: '/api/auth/state',
+      headers: { host: `${doomed.slug}.neiliro.test` },
+    });
+    expect(state.json().initialized).toBe(true);
+    const login = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: { host: `${doomed.slug}.neiliro.test` },
+      payload: { email: doomed.email, password: 'correct horse battery' },
+    });
+    expect(login.statusCode).toBe(401);
+
+    // The neighbour never noticed
+    const alive = await app.inject({ url: '/api/auth/me', headers: onFamily(survivor) });
+    expect(alive.statusCode).toBe(200);
+    expect(alive.json().email).toBe(survivor.email);
+  });
+});

--- a/server/src/routes/family.ts
+++ b/server/src/routes/family.ts
@@ -1,0 +1,241 @@
+import Database from 'better-sqlite3';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { currentTenant, db } from '../db/index.js';
+import { env } from '../env.js';
+import { clearSessionCookie, consumeTotp, requireAdmin } from '../lib/auth.js';
+import { verifyPassword } from '../lib/password.js';
+import { log } from '../lib/log.js';
+
+/*
+  The family's data, self-service: the complete archive from Settings and
+  the delete-everything button behind it. Both are promises the privacy
+  policy already makes; until now they were concierge operations
+  (scripts/export.mjs by hand, family:delete in the control plane).
+
+  Everything here goes through the tenant context (db proxy,
+  currentTenant()), never the static paths.* — in hosted mode the
+  request's family is the only family this code may see.
+*/
+
+/**
+ * The manifest's table inventory — the same list scripts/export.mjs
+ * writes and scripts/import.mjs verifies row-by-row before swapping a
+ * database in. Kept in sync by the round-trip test (family-export.test.ts),
+ * which runs a settings export through the real import script.
+ */
+const EXPORT_TABLES = [
+  'users',
+  'projects',
+  'tasks',
+  'notes',
+  'note_versions',
+  'folders',
+  'calendars',
+  'events',
+  'accounts',
+  'categories',
+  'transactions',
+  'budgets',
+  'recurring_transactions',
+  'attachments',
+  'settings',
+];
+
+function countRows(snapshot: Database.Database, table: string): number | null {
+  try {
+    return (snapshot.prepare(`SELECT count(*) AS n FROM ${table}`).get() as { n: number }).n;
+  } catch {
+    return null;
+  }
+}
+
+function dirSize(dir: string): { files: number; bytes: number } {
+  if (!existsSync(dir)) return { files: 0, bytes: 0 };
+  let files = 0;
+  let bytes = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true, recursive: true })) {
+    if (!entry.isFile()) continue;
+    files += 1;
+    bytes += statSync(join(entry.parentPath, entry.name)).size;
+  }
+  return { files, bytes };
+}
+
+const deleteInput = z.object({
+  password: z.string().min(1).max(500),
+  code: z.string().min(6).max(10).optional(),
+  confirm: z.string().min(1).max(100),
+});
+
+export async function registerFamilyRoutes(app: FastifyInstance): Promise<void> {
+  /*
+    The complete archive: the database via VACUUM INTO (the WAL journal
+    is folded in — copying hub.db as a plain file would lose the freshest
+    writes), every attachment, and a manifest. The layout matches
+    scripts/export.mjs exactly, so the archive restores into a
+    self-hosted hub through scripts/import.mjs — the no-lock-in promise.
+
+    The rate limit is strict because this is the most expensive request
+    in the app: VACUUM INTO rewrites the whole database and tar reads
+    every attachment. Three per window is plenty for a human admin and
+    starves a script.
+  */
+  app.get(
+    '/api/family/export',
+    { config: { rateLimit: { max: 3, timeWindow: '15 minutes' } } },
+    async (req, reply) => {
+      if (!requireAdmin(req, reply)) return;
+      // demoBlocked passes every GET through, so the demo check lives on
+      // the route: sandboxes are throwaways, an "archive" of one misleads.
+      if (env.demoMode) {
+        return reply.code(403).send({ error: 'Disabled in the demo' });
+      }
+
+      const { attachmentsDir } = currentTenant();
+      const staging = mkdtempSync(join(tmpdir(), 'hub-export-'));
+      const discard = () => rm(staging, { recursive: true, force: true }).catch(() => {});
+
+      try {
+        const snapshotPath = join(staging, 'hub.db');
+        // Through the db proxy on purpose: in hosted mode this snapshots
+        // the requesting family's database, never the default paths.db.
+        db.exec(`VACUUM INTO '${snapshotPath.replace(/'/g, "''")}'`);
+
+        // The manifest is read off the snapshot, not the live database:
+        // the live one keeps moving, and import.mjs compares the counts
+        // against the file that is actually inside the archive.
+        const snapshot = new Database(snapshotPath, { readonly: true });
+        const manifest = {
+          exported_at: new Date().toISOString(),
+          // scripts/export.mjs writes source_data_dir here; the settings
+          // export deliberately doesn't — a hosted archive must not leak
+          // server filesystem paths. import.mjs never reads the field.
+          source: 'settings',
+          migrations: snapshot
+            .prepare('SELECT name FROM _migrations ORDER BY name')
+            .all()
+            .map((r) => (r as { name: string }).name),
+          counts: Object.fromEntries(
+            EXPORT_TABLES.map((table) => [table, countRows(snapshot, table)]),
+          ),
+          attachments: dirSize(attachmentsDir),
+        };
+        snapshot.close();
+        writeFileSync(join(staging, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+      } catch (err) {
+        await discard();
+        throw err;
+      }
+
+      /*
+        Streamed straight from tar's stdout — the archive never lands on
+        disk as a whole, only the database snapshot does. Attachments are
+        read from their live directory (basename is always 'attachments',
+        both for the single family and for hosted tenants), which gives
+        the exact top-level layout import.mjs expects: hub.db,
+        manifest.json, attachments/.
+      */
+      const tar = spawn('tar', [
+        '-czf',
+        '-',
+        '-C',
+        staging,
+        'hub.db',
+        'manifest.json',
+        '-C',
+        dirname(attachmentsDir),
+        basename(attachmentsDir),
+      ]);
+      let stderr = '';
+      tar.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      tar.on('close', (exitCode) => {
+        if (exitCode !== 0) log.error(`family export: tar exited ${exitCode}: ${stderr.trim()}`);
+        void discard();
+      });
+
+      log.info(`family export started by ${req.user!.email}`);
+      const stamp = new Date().toISOString().slice(0, 10);
+      return reply
+        .header('Content-Type', 'application/gzip')
+        .header('Content-Disposition', `attachment; filename="neiliro-${stamp}.tar.gz"`)
+        .send(tar.stdout);
+    },
+  );
+
+  /*
+    Self-deletion — hosted only. A self-hosted install has exactly one
+    family, so this button would mean "erase the whole instance"; the
+    owner of the machine does that at the filesystem, not from a web
+    form one misclick away from the only copy of the data. The GDPR
+    promise this implements ("deleting your family removes its database
+    and files") is about the hosted service.
+
+    Three proofs are required, all server-side: the admin's password, a
+    current TOTP code when the account has one, and the family's slug
+    typed by hand. The rate limit is login-strength — a stolen session
+    must not get free password guesses here.
+  */
+  app.post(
+    '/api/family/delete',
+    { config: { rateLimit: { max: 5, timeWindow: '15 minutes' } } },
+    async (req, reply) => {
+      if (!env.hostedMode) {
+        return reply.code(403).send({ error: 'Family deletion is available on the hosted service only' });
+      }
+      if (!requireAdmin(req, reply)) return;
+      const { familyId } = currentTenant();
+      if (!familyId) {
+        // The ghost and anything else without a registry id has nothing
+        // to delete; a real family always carries one.
+        return reply.code(403).send({ error: 'Family deletion is available on the hosted service only' });
+      }
+
+      const parsed = deleteInput.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.code(400).send({ error: 'Check the fields' });
+      }
+
+      const user = db
+        .prepare('SELECT password_hash, totp_secret, totp_confirmed_at FROM users WHERE id = ?')
+        .get(req.user!.id) as {
+        password_hash: string;
+        totp_secret: string | null;
+        totp_confirmed_at: string | null;
+      };
+
+      if (!(await verifyPassword(parsed.data.password, user.password_hash))) {
+        return reply.code(400).send({ error: 'The current password is incorrect' });
+      }
+      if (user.totp_confirmed_at && user.totp_secret) {
+        if (!parsed.data.code) {
+          return reply.code(400).send({ error: 'Enter the code' });
+        }
+        if (!consumeTotp(req.user!.id, user.totp_secret, parsed.data.code)) {
+          return reply.code(401).send({ error: 'Wrong code' });
+        }
+      }
+
+      const { familySlug, deleteFamilyData } = await import('../lib/tenants.js');
+      const slug = familySlug(familyId);
+      if (!slug || parsed.data.confirm.trim().toLowerCase() !== slug) {
+        return reply.code(400).send({ error: 'The confirmation phrase does not match the family address' });
+      }
+
+      log.notice(`family self-deletion: ${slug} (${familyId}) by ${req.user!.email}`);
+      // Beyond this line the family's database is closed and gone —
+      // nothing below may touch db, and the reply is assembled from
+      // what was read above.
+      deleteFamilyData(familyId);
+      clearSessionCookie(reply);
+      return { ok: true };
+    },
+  );
+}

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -108,7 +108,7 @@ describe('host routing', () => {
       url: '/api/auth/state',
       headers: onHost('nosuch-x9y8.neiliro.test'),
     });
-    expect(state.json()).toEqual({ initialized: true, google: false, demo: false });
+    expect(state.json()).toEqual({ initialized: true, google: false, demo: false, hosted: true });
 
     // ...that rejects a sign-in exactly like a real family would
     const login = await app.inject({

--- a/web/src/components/FamilyDataSection.tsx
+++ b/web/src/components/FamilyDataSection.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import { useAuth } from '../lib/auth';
+import { t } from '../lib/i18n';
+
+/*
+  The family's data, admin-only: the complete archive and, on the hosted
+  service, the delete-everything button. Both mirror the privacy policy's
+  promises; the rules live server-side (routes/family.ts), this is only
+  their surface.
+
+  The Danger zone is hosted-only by design. A self-hosted install has one
+  family, so the button would mean "erase this whole server" — the person
+  who owns the machine does that at the filesystem, not from a web form
+  one misclick away from the only copy of the data.
+*/
+
+const inputClass =
+  'w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent';
+
+function startExportDownload() {
+  // A plain navigation, not fetch: the browser streams the tar.gz to disk
+  // instead of buffering a potentially multi-gigabyte blob in memory.
+  window.location.href = '/api/family/export';
+}
+
+function ExportCard() {
+  return (
+    <section className="rounded-card border border-line bg-surface p-5">
+      <h2 className="eyebrow mb-2">{t('Family archive')}</h2>
+      <p className="mb-4 text-sm text-muted">
+        {t('The complete archive: the database plus every attachment, as one tar.gz. It restores into a self-hosted hub with the import script — your data is never locked in.')}
+      </p>
+      <button
+        type="button"
+        onClick={startExportDownload}
+        className="rounded-lg border border-line px-4 py-2 text-sm font-medium text-ink transition-colors hover:bg-surface-2"
+      >
+        {t('Download the archive')}
+      </button>
+      <p className="mt-3 text-xs text-muted">
+        {t('On a large family this takes a moment — the download starts once the archive is ready.')}
+      </p>
+    </section>
+  );
+}
+
+function DangerZone() {
+  const { user, logout } = useAuth();
+  // The confirmation phrase is the family's subdomain slug — the server
+  // verifies it against the registry; this is only the hint in the label.
+  const slug = window.location.hostname.split('.')[0] ?? '';
+  const [open, setOpen] = useState(false);
+  const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!user) return null;
+  const needsCode = Boolean(user.totp_enabled);
+  const ready =
+    password.length > 0 &&
+    (!needsCode || code.trim().length >= 6) &&
+    confirm.trim().toLowerCase() === slug;
+
+  async function destroy() {
+    setBusy(true);
+    setError(null);
+    try {
+      await api.post('/family/delete', {
+        password,
+        code: needsCode ? code.trim() : undefined,
+        confirm: confirm.trim(),
+      });
+      // The family — sessions included — no longer exists; logout only
+      // clears this device's cookie and the offline caches.
+      await logout();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('Could not save'));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-card border border-urgent/40 bg-surface p-5">
+      <h2 className="eyebrow mb-2 text-urgent">{t('Danger zone')}</h2>
+      <p className="mb-4 text-sm text-muted">
+        {t('This deletes the family for everyone: the database, every attachment, every account. There is no undo. Encrypted backups expire on their own within 14 days.')}
+      </p>
+
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-lg border border-urgent/40 bg-urgent/10 px-4 py-2 text-sm font-medium text-urgent hover:opacity-90"
+        >
+          {t('Delete the family…')}
+        </button>
+      ) : (
+        <div className="max-w-md space-y-3">
+          <div className="rounded-lg border border-urgent/40 bg-urgent/10 p-3 text-sm text-ink">
+            <p className="mb-2 font-medium">
+              {t('Download the archive first — once the family is gone, so is the data.')}
+            </p>
+            <button
+              type="button"
+              onClick={startExportDownload}
+              className="rounded-lg border border-line bg-surface px-3 py-1.5 text-sm text-ink transition-colors hover:bg-surface-2"
+            >
+              {t('Download the archive')}
+            </button>
+          </div>
+
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-ink">{t('Password')}</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+              className={inputClass}
+            />
+          </label>
+
+          {needsCode && (
+            <label className="block">
+              <span className="mb-1.5 block text-sm font-medium text-ink">
+                {t('Code from the authenticator app')}
+              </span>
+              <input
+                inputMode="numeric"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                autoComplete="one-time-code"
+                className={inputClass}
+              />
+            </label>
+          )}
+
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-ink">
+              {t('Type the family address name ({slug}) to confirm', { slug })}
+            </span>
+            <input
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              autoComplete="off"
+              placeholder={slug}
+              className={`${inputClass} font-mono`}
+            />
+          </label>
+
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              type="button"
+              disabled={!ready || busy}
+              onClick={() => void destroy()}
+              className="rounded-lg bg-urgent px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {t('Delete the family forever')}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setPassword('');
+                setCode('');
+                setConfirm('');
+                setError(null);
+              }}
+              className="text-sm text-muted underline underline-offset-2 hover:text-ink"
+            >
+              {t('Cancel')}
+            </button>
+          </div>
+
+          {error && <p className="text-sm text-urgent">{error}</p>}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function FamilyDataSection() {
+  const { user } = useAuth();
+  const [state, setState] = useState<{ demo: boolean; hosted: boolean } | null>(null);
+
+  useEffect(() => {
+    void api
+      .get<{ demo: boolean; hosted: boolean }>('/auth/state')
+      .then(setState)
+      .catch(() => {});
+  }, []);
+
+  // Demo sandboxes are throwaways: nothing worth archiving, nothing to
+  // delete — the sandbox buries itself. Both cards disappear entirely.
+  if (user?.role !== 'admin' || !state || state.demo) return null;
+
+  return (
+    <>
+      <ExportCard />
+      {state.hosted && <DangerZone />}
+    </>
+  );
+}

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -728,6 +728,21 @@ export const ru: Record<string, string> = {
   'The shared address the Mail section reads. A dedicated mailbox works best; a personal Gmail works too — filter letters into a separate label and set it as the folder below.': 'Общий адрес, который читает раздел «Почта». Лучше всего отдельный ящик; личный Gmail тоже подходит — настройте фильтр в отдельный ярлык и укажите его как папку ниже.',
   'task': 'задача',
   'Username': 'Логин',
+
+  // ── Family archive and self-deletion (Settings → admin) ──
+  'Family archive': 'Семейный архив',
+  'The complete archive: the database plus every attachment, as one tar.gz. It restores into a self-hosted hub with the import script — your data is never locked in.': 'Полный архив: база данных и все вложения одним tar.gz. Восстанавливается в self-hosted-хабе скриптом импорта — ваши данные никогда не заперты.',
+  'Download the archive': 'Скачать архив',
+  'On a large family this takes a moment — the download starts once the archive is ready.': 'На большой семье это занимает время — скачивание начнётся, когда архив будет готов.',
+  'Danger zone': 'Опасная зона',
+  'This deletes the family for everyone: the database, every attachment, every account. There is no undo. Encrypted backups expire on their own within 14 days.': 'Это удалит семью для всех: базу данных, все вложения, все аккаунты. Отменить нельзя. Зашифрованные резервные копии истекут сами в течение 14 дней.',
+  'Delete the family…': 'Удалить семью…',
+  'Download the archive first — once the family is gone, so is the data.': 'Сначала скачайте архив — вместе с семьёй исчезнут и данные.',
+  'Code from the authenticator app': 'Код из приложения-аутентификатора',
+  'Type the family address name ({slug}) to confirm': 'Введите имя адреса семьи ({slug}) для подтверждения',
+  'Delete the family forever': 'Удалить семью навсегда',
+  'Family deletion is available on the hosted service only': 'Удаление семьи доступно только в облачном сервисе',
+  'The confirmation phrase does not match the family address': 'Контрольная фраза не совпадает с адресом семьи',
 };
 
 /** one / few / many, keyed by the English singular used in plural() calls. */

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -13,6 +13,7 @@ import { COMMON_CURRENCIES, formatAmountInput, parseAmount } from '../lib/money'
 import { PeopleSection } from '../components/PeopleSection';
 import { MailSection } from '../components/MailSection';
 import { TotpSection } from '../components/TotpSection';
+import { FamilyDataSection } from '../components/FamilyDataSection';
 
 /**
  * Own name and avatar colour, self-service (#64). Colour is the whole
@@ -740,6 +741,7 @@ export function Settings() {
         <div className="mx-auto mt-5 max-w-md space-y-5 lg:max-w-4xl 3xl:max-w-[86rem] 4xl:max-w-[114rem]">
           <MailSection />
           <PeopleSection />
+          <FamilyDataSection />
         </div>
       )}
     </Page>


### PR DESCRIPTION
Makes the privacy policy's two GDPR promises (neiliro/www#1) true in the product: "download your family's complete archive from settings" and "deleting your family removes its database and files". Both were concierge operations until now — `scripts/export.mjs` by hand and `family:delete` in the cloud runbook.

## Export (Settings → admin, all modes)

- `GET /api/family/export` snapshots the database via `VACUUM INTO` — the WAL journal is folded in, so fresh writes are never lost the way a plain file copy would lose them — and streams `hub.db` + `attachments/` + `manifest.json` as one tar.gz straight from `tar`'s stdout. Nothing but the DB snapshot ever lands on disk.
- Everything goes through the tenant context (`db` proxy, `currentTenant().attachmentsDir`), never `paths.*` — in hosted mode the archive contains the requesting family and nothing else. Cross-checked in tests with two live families.
- The manifest is read off the snapshot, not the live database, so the counts match the file actually inside the archive. `source_data_dir` is deliberately omitted: a hosted archive must not leak server filesystem paths, and `import.mjs` never reads it.
- **Round-trip is a test, not a hope**: `family-export.test.ts` runs a settings export through the real `scripts/import.mjs` into a fresh `DATA_DIR` and checks integrity, users, notes and attachment files on the far side. If the formats drift, that test goes red.
- Rate limit 3 / 15 min — `VACUUM INTO` + tar over every attachment is the most expensive request in the app.

## Deletion (Settings → Danger zone, hosted only)

- `POST /api/family/delete` requires three proofs, all server-side: the admin's password, a current TOTP code when the account has one (`consumeTotp`, so the code is spent), and the family's slug typed by hand (verified against the registry, not the client). Login-strength rate limit: a stolen session gets no free password guesses.
- Order of operations is the safety property: registry row → `status='deleted'` and slug cache purged **first**, then the handle closes, then `hub.db`/`-wal`/`-shm` and `attachments/` are removed. Reversed, a request landing mid-deletion would call `tenantFor`, which recreates directories — and the family would resurrect as an empty hub on its old address. `initHosted` now also skips `deleted` rows for the same reason (migrate used to recreate `hub.db` for every registry row at startup).
- **Registry**: the app already writes `registry.db` (`createFamily` inserts), so the status flip happens in-process — no file marker needed. The row itself stays: re-issuing the slug would hand a stranger the family's bookmarks and mail address, and the control plane reads the status to finish its own bookkeeping (billing, sweeping the leftover `families/<id>/` folder). I considered scrubbing the slug as potentially-personal data and rejected it for exactly the re-registration reason — flagging in case the cloud runbook wants a second pass here.
- **Backups untouched**, as the policy states: encrypted, self-expiring within 14 days. The test asserts `backups/` survives while everything else is gone.
- Afterwards the old address behaves like any unknown subdomain (the ghost): claims to be set up, rejects sign-ins — deletion leaves no enumeration signal.

## Decisions I had to make

- **Self-hosted gets the export but not the delete button.** One family per server means the button reads "erase this entire instance"; the machine's owner does that at the filesystem (and the docs already cover it), not from a web form one misclick away from the only copy of the data. The route answers 403 outside hosted mode; the UI never renders the card (gated on a new `hosted` flag in `/api/auth/state` — safe to expose, ghost included: *that* the service is hosted is public, only *which* families exist is not).
- **Demo**: both features are off. The POST is in `demoBlocked`; the export is a GET (which `demoBlocked` passes through by design), so it carries its own route-level check.
- **Confirmation phrase = the slug**, not a localized sentence: ASCII, known to the admin, verified server-side against the registry, and immune to i18n drift.

## Verified by hand

Full suite green locally (`typecheck`, `lint`, `test` — 126 server + 58 web, i18n coverage included). The hosted tests exercise the real flow over two families: export A never contains B's rows or files, deleting one family leaves the other signing in normally.

Docs: a paragraph in `docs/architecture.md` (Hosted mode). `features.md`/`family-mail.md` untouched per convention. No schema changes — the registry is operational state, not app schema, so no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)