### PR TITLE
chore: version 1.4.0

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -126,6 +126,12 @@ The **wishlist** keeps its surprise on the server: the owner is never sent what 
 
 A wishlist can also be shared with guests — grandparents without an account — by an unguessable link, revocable at any time. The link stays copyable from the profile for as long as it lives — it is meant to be re-sent, so unlike an invite token it is stored as is; what it unlocks is a first name and a wish list, not an account. The guest page is the hub's only anonymous surface and shows the bare minimum: the first name, the wishes, and a "reserved" flag with no names, so two guests don't buy the same gift and a stranger with the link learns nothing about the family. Guests reserve by typing their name; the family sees that name inside the hub, the owner still sees nothing. One honest limitation: the owner opening their own guest link will see the "reserved" flags — that is shaking the gift box, and no server can prevent it.
 
+### Your data
+
+Everything the household owns leaves in one file whenever it wants: Settings → **Export archive** streams a `tar.gz` with the database, every attachment and a manifest — the exact layout `scripts/import.mjs` restores, so a hosted family can move onto its own server (or a self-hosted one onto another machine) without asking anyone for help. It doubles as the GDPR portability answer.
+
+On the hosted service the same section holds **Delete everything**: the administrator confirms with the password, a two-factor code when one is set, and by typing the family's own address, after which the database and the attachments are gone and the encrypted nightly backups expire on their own within a fortnight. A self-hosted install gets the export but no such button — there, deleting the only family means erasing the instance, and that belongs to whoever owns the machine.
+
 ## Mail
 
 ![Mail: the shared household inbox, one click from letter to task](screenshots/mail.png)
@@ -282,3 +288,5 @@ The sidebar does not scroll with the content: on a long task list the sections s
 "All projects" shows a total open-task counter — the same one each project has individually.
 
 The interface speaks English by default; Russian is available in Settings. The first day of the week (Monday or Sunday) is configurable there too. Both are per-device settings: a phone and the shared kiosk can differ.
+
+The hub also answers to a name of your own: Settings → **Home name** replaces "Neiliro" in the sidebar, on the sign-in screen and in the browser tab. Unlike the language and the first weekday it belongs to the household, not to the device — everyone sees it. It is a label, never an address: two families may both call themselves "Home". On the hosted service the public sign-in screen keeps saying Neiliro — a chosen name is the family's own business, and a renamed family has to stay indistinguishable from a subdomain that does not exist.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -130,6 +130,39 @@ describe('host routing', () => {
     expect(setup.statusCode).toBe(403);
   });
 
+  it('keeps a renamed family behind the session: the public name is the brand', async () => {
+    const login = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: onHost('smiths-a1b2.neiliro.test'),
+      payload: { email: 'sam@smiths.test', password: 'correct horse battery' },
+    });
+    const session = login.cookies.find((c) => c.name === 'hub_session')!;
+    const asSam = { ...onHost('smiths-a1b2.neiliro.test'), cookie: `hub_session=${session.value}` };
+
+    const renamed = await app.inject({
+      method: 'PATCH',
+      url: '/api/settings',
+      headers: asSam,
+      payload: { 'home.name': 'The Smiths' },
+    });
+    expect(renamed.statusCode).toBe(200);
+
+    // The name is theirs and it works — behind the session
+    const settings = await app.inject({ url: '/api/settings', headers: asSam });
+    expect(settings.json()['home.name']).toBe('The Smiths');
+
+    // ...but /api/home-name is public, and the sign-in screen of a hosted
+    // family must stay indistinguishable from a subdomain that does not
+    // exist. A chosen name handed to the internet would enumerate families
+    // by itself.
+    const named = await app.inject({ url: '/api/home-name', headers: onHost('smiths-a1b2.neiliro.test') });
+    expect(named.json()).toEqual({ name: 'Neiliro' });
+
+    const ghost = await app.inject({ url: '/api/home-name', headers: onHost('nosuch-x9y8.neiliro.test') });
+    expect(ghost.json()).toEqual({ name: 'Neiliro' });
+  });
+
   it('counts module requests into per-family day stats, never the ghost', async () => {
     const login = await app.inject({
       method: 'POST',

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release prep for v1.4.0 — the two features merged since v1.3.0, plus the debt they left behind.

- **test**: the hosted guard on `/api/home-name` from #144 arrived in review without a test. It protects an invariant that is easy to undo by accident (a renamed family must stay indistinguishable from a subdomain that does not exist), so it gets one.
- **docs**: `features.md` had no paragraph for renaming the hub (#136) or for the export/delete section in Settings (#145).
- **chore**: version to 1.4.0 in the three `package.json` — it shows in Settings → About and at the foot of the sidebar, so it goes up before the tag.

No schema change since v1.3.0: `server/src/db/migrations/` is untouched, which also means the hosted server can move to this image without any per-family migration work.

After merge: `git tag v1.4.0 && git push origin v1.4.0`, then the release page by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)