### PR TITLE
fix: the demo family gets a month, and a birthday looks like a birthday

### DIFF
--- a/server/src/lib/demo-seed.test.ts
+++ b/server/src/lib/demo-seed.test.ts
@@ -48,6 +48,24 @@ describe('seedDemo', () => {
     const income = rules.find((r) => r.kind === 'income');
     expect(income && income.start_on > today(), 'the next pay day is not ahead').toBe(true);
 
+    /*
+      The month view is the widest thing a visitor can open, and it reads
+      as an empty grid unless the seeds reach past the two weeks around
+      today. Recurring anchors count: they expand forward from wherever
+      they start, so an anchor three weeks back fills the earlier rows.
+    */
+    const events = db
+      .prepare('SELECT starts_at, recurrence_rule FROM events')
+      .all() as { starts_at: string; recurrence_rule: string | null }[];
+    const earlier = events.filter((e) => e.starts_at.slice(0, 10) < shiftDays(today(), -7));
+    const later = events.filter((e) => e.starts_at.slice(0, 10) > shiftDays(today(), 14));
+    expect(earlier.length, 'nothing in the weeks before today').toBeGreaterThan(0);
+    expect(later.length, 'nothing in the weeks after today').toBeGreaterThan(0);
+    expect(
+      events.filter((e) => e.recurrence_rule?.includes('WEEKLY')).length,
+      'no weekly rhythm to fill the month',
+    ).toBeGreaterThan(1);
+
     // Idempotence: a second run on a non-empty database is a no-op
     await runWithDb(db, () => seedDemo());
     expect(n('SELECT count(*) AS n FROM profiles')).toBe(2);

--- a/server/src/lib/demo.ts
+++ b/server/src/lib/demo.ts
@@ -164,6 +164,46 @@ export async function seedDemo(): Promise<void> {
       `INSERT INTO event_participants (event_id, user_id) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)`,
     ).run(gym, alex, gym, sam, dentist, sam, movie, alex, movie, sam);
 
+    // Every event above sits within two weeks of today, which is fine for
+    // the week and the agenda but leaves the month view as a grid of empty
+    // cells — the demo's calendar looked like a family that does nothing.
+    // A household's month is mostly rhythms and errands, so: two weekly
+    // rhythms anchored in the PAST (recurrences only expand forward from
+    // their anchor, so a rhythm starting tomorrow leaves every earlier
+    // week blank), errands behind us, and something to look forward to.
+    // The anchors use different offsets mod 7 so the two rhythms land in
+    // different columns whatever weekday the template is built on.
+    const swim = id();
+    const market = id();
+    const lake = id();
+    const dinner = id();
+    const boiler = id();
+    const vet = id();
+    db.prepare(
+      `INSERT INTO events (id, calendar_id, title, description, location, starts_at, ends_at, all_day, recurrence_rule, remind_days_before, created_by) VALUES
+       (?, ?, 'Swimming lesson', NULL, 'City pool', ?, ?, 0, 'FREQ=WEEKLY;INTERVAL=1', NULL, ?),
+       (?, ?, 'Farmers market', 'Bread, the good tomatoes, flowers if they have tulips', NULL, ?, ?, 0, 'FREQ=WEEKLY;INTERVAL=1', NULL, ?),
+       (?, ?, 'Car service', 'The rattle from the back, and an oil change', 'Vulco', ?, ?, 0, NULL, NULL, ?),
+       (?, ?, 'Dinner at Sam''s parents', NULL, NULL, ?, ?, 0, NULL, NULL, ?),
+       (?, ?, 'Boiler service', 'The engineer from the email — someone has to be home', NULL, ?, ?, 0, NULL, 1, ?),
+       (?, ?, 'Vet — Bruno''s shots', NULL, 'Dr. Pawel', ?, ?, 0, NULL, 1, ?),
+       (?, ?, 'Lake weekend', 'Two nights, take the small tent', NULL, ?, ?, 1, NULL, 3, ?)`,
+    ).run(
+      swim, shared, `${day(-19)}T16:30`, `${day(-19)}T17:15`, sam,
+      market, shared, `${day(-16)}T10:00`, `${day(-16)}T11:00`, alex,
+      id(), shared, `${day(-13)}T09:00`, `${day(-13)}T10:30`, alex,
+      dinner, shared, `${day(-8)}T18:30`, `${day(-8)}T21:00`, sam,
+      boiler, shared, `${day(7)}T10:00`, `${day(7)}T12:00`, alex,
+      vet, shared, `${day(24)}T15:30`, `${day(24)}T16:00`, sam,
+      lake, shared, day(18), day(19), alex,
+    );
+    db.prepare(
+      `INSERT INTO event_participants (event_id, user_id) VALUES (?, ?), (?, ?), (?, ?), (?, ?), (?, ?), (?, ?), (?, ?), (?, ?)`,
+    ).run(
+      swim, sam, market, alex, market, sam, dinner, alex, dinner, sam,
+      lake, alex, lake, sam, vet, sam,
+    );
+
     // ── Family mail ──
     // A believable paperwork inbox; one message is already a task, so
     // the mail → task link is visible without clicking anything

--- a/web/src/components/CalendarViews.tsx
+++ b/web/src/components/CalendarViews.tsx
@@ -1,5 +1,5 @@
 import { t } from '../lib/i18n';
-import type { Occurrence } from '../lib/calendar';
+import { birthdayLabel, type Occurrence } from '../lib/calendar';
 import type { Task } from '../lib/api';
 import {
   WEEKDAYS_SHORT,
@@ -88,6 +88,7 @@ function EventChip({
   compact?: boolean;
 }) {
   const time = timeOf(occurrence.starts_at);
+  const birthday = birthdayLabel(occurrence);
   return (
     <button
       type="button"
@@ -95,12 +96,14 @@ function EventChip({
         e.stopPropagation();
         onOpen(occurrence);
       }}
+      title={birthday ?? undefined}
       style={{ borderLeftColor: occurrence.calendar_color }}
       className={`flex w-full items-center gap-1.5 rounded border-l-2 bg-surface-2 text-left transition-colors hover:bg-surface-3 ${
         compact ? 'px-1.5 py-0.5 text-[0.6875rem]' : 'px-2 py-1 text-xs'
       }`}
     >
       {time && <span className="shrink-0 font-mono text-muted">{time}</span>}
+      {birthday && <span aria-hidden>🎂</span>}
       <span className="min-w-0 flex-1 truncate text-ink">{occurrence.title}</span>
       {occurrence.age !== null && (
         <span className="shrink-0 font-mono text-muted">{occurrence.age}</span>

--- a/web/src/lib/calendar.ts
+++ b/web/src/lib/calendar.ts
@@ -55,6 +55,17 @@ export interface Occurrence {
   participants: Participant[];
 }
 
+/**
+ * A birthday occurrence is a person's name plus an age, and the age renders as
+ * a bare number beside the title: 'Alex  38' is a riddle in a month cell. The
+ * cake solves it at a glance; this label says the same for hover and for
+ * screen readers, out of keys the dictionary already has.
+ */
+export function birthdayLabel(o: Pick<Occurrence, 'title' | 'age'>): string | null {
+  if (o.age === null) return null;
+  return `${t('Birthday')}: ${o.title}, ${t('{n} years old', { n: o.age })}`;
+}
+
 export type CalendarView = 'week' | 'month' | 'agenda';
 
 export const VIEW_LABEL: Record<CalendarView, string> = {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/core';
 import { api, ApiError, type Dashboard as DashboardData, type Task } from '../lib/api';
-import { calendarName, type Occurrence } from '../lib/calendar';
+import { birthdayLabel, calendarName, type Occurrence } from '../lib/calendar';
 import { loadLocal, saveLocal } from '../lib/storage';
 import { reportFailure } from '../lib/failures';
 import {
@@ -159,6 +159,7 @@ function TaskRow({
 
 function EventRow({ occurrence, detailed }: { occurrence: Occurrence; detailed?: boolean }) {
   const time = timeOf(occurrence.starts_at);
+  const birthday = birthdayLabel(occurrence);
   return (
     <li className="border-b border-line last:border-0">
       <Link
@@ -173,7 +174,8 @@ function EventRow({ occurrence, detailed }: { occurrence: Occurrence; detailed?:
             style={{ backgroundColor: occurrence.calendar_color }}
           />
         </span>
-        <span className="min-w-0 flex-1 truncate text-sm text-ink">
+        <span className="min-w-0 flex-1 truncate text-sm text-ink" title={birthday ?? undefined}>
+          {birthday && <span aria-hidden>🎂 </span>}
           {occurrence.title}
           {occurrence.age !== null && <span className="ml-2 text-muted">{occurrence.age}</span>}
         </span>
@@ -597,7 +599,13 @@ function SoonPanel({ items }: { items: Occurrence[] }) {
                 style={{ backgroundColor: o.calendar_color }}
                 aria-hidden
               />
-              <span className="min-w-0 flex-1 truncate text-sm text-ink">{o.title}</span>
+              <span
+                className="min-w-0 flex-1 truncate text-sm text-ink"
+                title={birthdayLabel(o) ?? undefined}
+              >
+                {birthdayLabel(o) && <span aria-hidden>🎂 </span>}
+                {o.title}
+              </span>
               <span className="font-mono text-xs text-urgent">{formatDate(o.date)}</span>
             </Link>
           </li>


### PR DESCRIPTION
Both came out of reshooting the landing calendar screenshot in the Month view.

## 1. The month was empty

Every seeded calendar event lives inside `day(-3)`…`day(12)` — the seeds were written for the Today, Week and Agenda views. Open **Month** in the live demo and four of six rows have nothing in them at all. The recurring `Gym` doesn't help: recurrences expand forward from their anchor, and its anchor is tomorrow, so every week before today stays blank.

That's not just a screenshot problem — it's what a visitor sees when they click Month.

| | | |
|---|---|---|
| Swimming lesson | weekly, anchored `day(-19)` | fills every week, backwards too |
| Farmers market | weekly, anchored `day(-16)` | different offset mod 7 → different column |
| Car service | `day(-13)` | |
| Dinner at Sam's parents | `day(-8)` | |
| Boiler service | `day(+7)` | the engineer from the mail the demo already seeds |
| Lake weekend | `day(+18)`–`day(+19)`, all-day | also the only multi-day event in the seeds |
| Vet — Bruno's shots | `day(+24)` | |

Participants are set on most of them, so the cells carry avatars the way a real family's calendar does.

Two constraints the copy and the offsets respect: the template is rebuilt **daily, all year**, so nothing seasonal (no winter tyres in August); and offsets are relative to whatever weekday the rebuild lands on, so no title implies a particular day of the week.

## 2. "Alex  38"

Visible in that same screenshot: a birthday event's title is the person's name and the age is a separate number, so the chip read `Alex 38` — a riddle in a month cell, where nothing else fits. The dashboard row had the same shape.

A cake before the title says what it is at a glance; `birthdayLabel()` also fills a `title` attribute for hover and screen readers, built from dictionary keys that already existed (`Birthday`, `{n} years old`), so there are no new translations to write.

## Checks

- `npm run typecheck`, `npm run lint`, `npm test` — 127 server + 58 web, green.
- `demo-seed.test.ts` now asserts the seeded calendar reaches past that fortnight in **both** directions and keeps more than one weekly rhythm, so the month can't silently empty out again.
- Ran the demo seeds locally (`DEMO_MODE`, fresh data dir) and read the rendered DOM: month rows are populated in every week, `Farmers market` at 10:00 on its weekly cadence, and the birthday chip renders `🎂 Alex 38` with the title `День рождения: Alex, 38 лет` in Russian, `Birthday: Alex, 38 years old` in English. The dashboard row shows the same. The `Soon` widget path uses the same helper but isn't in the default layout, so it's type-checked rather than seen.
- Landing screenshots get reshot from the demo after this deploys.