### PR TITLE
chore: a machine can keep the demo after its hub has moved away

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,23 +79,35 @@ jobs:
         # (DEMO_DOMAIN set): the demo shares the image, so it has to be
         # recreated on deploy too — otherwise it would keep running the
         # previous image forever.
+        #
+        # The hub itself can be opted out the same way (HUB_ENABLED=false):
+        # a machine that keeps the public demo after its hub has moved
+        # elsewhere must not have the hub restarted under it on every push.
         run: |
           ssh "$DEPLOY" '
             cd /srv/family-hub/app
             files="-f docker-compose.prod.yml"
+            services="caddy"
+            grep -q "^HUB_ENABLED=false" .env 2>/dev/null || services="$services app"
             if grep -q "^DEMO_DOMAIN=" .env 2>/dev/null; then
               files="$files -f docker-compose.demo.yml"
+              services="$services app-demo"
             fi
-            docker compose $files up -d
+            docker compose $files up -d $services
           '
 
       - name: Health check
         # Relies on the container's own HEALTHCHECK (GET /api/health),
-        # so no public hostname needs to live in this file.
+        # so no public hostname needs to live in this file. On a machine
+        # that only carries the demo, the demo is what has to come up.
         run: |
+          container=family-hub
+          if ssh "$DEPLOY" 'grep -q "^HUB_ENABLED=false" /srv/family-hub/app/.env'; then
+            container=family-hub-demo
+          fi
           for i in $(seq 1 18); do
             status=$(ssh "$DEPLOY" \
-              'docker inspect --format "{{.State.Health.Status}}" family-hub' 2>/dev/null || true)
+              "docker inspect --format '{{.State.Health.Status}}' $container" 2>/dev/null || true)
             if [ "$status" = "healthy" ]; then
               echo "ok"; exit 0
             fi

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,8 +51,10 @@ services:
     container_name: family-hub-caddy
     restart: unless-stopped
     logging: *logging
-    depends_on:
-      - app
+    # No depends_on: Caddy resolves an upstream when a request arrives, not
+    # at startup, so it comes up fine on its own — the demo overlay has
+    # always relied on that. Without the dependency a machine can also run
+    # the demo alone, with the hub service defined but never started.
     ports:
       - "80:80"
       - "443:443"

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -332,6 +332,25 @@ just as much a one-domain job.
 No nightly reset cron is needed: sandbox cleanup and daily template
 rebuilds happen inside the app itself.
 
+### Keeping only the demo
+
+A hub can move on — to another machine, or to a hosted service — while
+the demo stays where it is. Set `HUB_ENABLED=false` in `.env`, point
+`HUB_DOMAIN` at a placeholder that resolves nowhere (`hub.localhost`
+takes an internal certificate and never bothers Let's Encrypt), and stop
+the hub container once:
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.demo.yml rm -f -s app
+docker compose -f docker-compose.prod.yml -f docker-compose.demo.yml up -d caddy app-demo
+```
+
+Auto-deploy reads the same flag: it starts the demo and Caddy, leaves
+the hub service defined but never started, and waits on the demo's
+health instead. The data directory is untouched by all of this — deleting
+it is a separate, deliberate `rm`, and worth postponing until the hub has
+lived somewhere else for a week.
+
 ### Usage statistics
 
 The demo keeps anonymous usage statistics in `demo-stats.db` next to its


### PR DESCRIPTION
The personal hub that lived on the demo machine has moved to the hosted service. That machine keeps the public demo and the monitoring stack — a shape nothing in the repo supported: every deploy restarted the hub, and `depends_on` brought the container back even when Compose was asked for specific services.

- **`docker-compose.prod.yml`**: Caddy drops `depends_on: app`. It resolves upstreams per request, not at startup — the demo overlay has always relied on that, so this only makes it explicit.
- **`deploy.yml`**: `HUB_ENABLED=false` in the server's `.env` opts the hub out, mirroring how `DEMO_DOMAIN` opts the demo in. The health check then waits on `family-hub-demo` instead of `family-hub`.
- **`docs/deploy-vps.md`**: a short "Keeping only the demo" subsection with the exact steps.

The hub remains the default in every case: an unset flag behaves exactly as before, and no data is touched — retiring a hub from a machine and deleting its database stay separate acts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)