### PR TITLE
chore: version 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.2.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.2.0",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -12065,7 +12065,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.2.0",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12090,7 +12090,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.2.0",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump ahead of the `v1.6.0` tag — the hosted stack pins a release tag, and the number shows in Settings → About and at the foot of the sidebar, so it goes up before the tag rather than after.

Contents of the release: family mail for hosted families ([#151](https://github.com/neiliro/neiliro/pull/151), [#152](https://github.com/neiliro/neiliro/pull/152)) — an address that comes with the family, letters arriving over the inbound webhook, replies going out over Mailgun's HTTP API.

**No schema change.** The last migration is still `022_goal_widget.sql`, so moving between 1.5.0 and 1.6.0 is uneventful in both directions.

`package-lock.json` comes along: it still said `1.2.0`, having been left behind for three releases. The diff is version numbers only — nothing from the dependency tree.