### PR TITLE
docs: catch up with 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The hub comes up on `http://localhost:8787` and is reachable from other devices 
 Tagged releases publish a prebuilt multi-arch image (amd64 + arm64, so Raspberry Pi works) to GitHub Container Registry — point `image:` in the compose file at it to skip building:
 
 ```bash
-docker pull ghcr.io/neiliro/neiliro:latest   # or a pinned release: :1.2.0
+docker pull ghcr.io/neiliro/neiliro:latest   # or a pinned release: :1.6.0
 ```
 
 For development:

--- a/docs/features.md
+++ b/docs/features.md
@@ -144,18 +144,26 @@ utilities, bookings, insurance. Everyone sees the same inbox; opening a
 letter marks it read for the whole family — a household desk has one
 "handled" state, not a per-person one.
 
-The hub polls an external mailbox over IMAP (any provider; a dedicated
-mailbox is best, a personal Gmail works via a filter into a separate
-label — the hub reads only the configured folder and never touches
-personal mail). Setup: [family-mail.md](family-mail.md).
+Where the letters come from depends on where the hub runs. **Self-hosted**,
+it polls an external mailbox over IMAP (any provider; a dedicated mailbox
+is best, a personal Gmail works via a filter into a separate label — the
+hub reads only the configured folder and never touches personal mail).
+**On a hosted hub** the address comes with the family: `<family>@<mail
+domain>`, shown in Settings, fed by an inbound webhook, with nothing to
+connect and no password to store. Both paths end in the same ingest
+function, so everything below works identically. Setup:
+[family-mail.md](family-mail.md).
 
 A letter becomes a task in one click; the task lands in the Inbox project
 and links back to the message. Attachments ride the regular attachments
 pipeline and storage budget.
 
-Replies are sent through the same mailbox's SMTP and always **from the
-family address** — the member's name travels in the display name and is
-recorded in the hub. Replies to your reply land back in the family
+Replies always go out **from the family address** — the member's name
+travels in the display name and is recorded in the hub. A connected
+mailbox sends through its own SMTP; a service-issued address sends over
+the provider's HTTP API, which is not a detail of taste: cloud hosts
+routinely block outbound SMTP ports, and a reply path that depends on
+them breaks on the next provider. Replies to your reply land back in the family
 mailbox, so the whole thread stays in one place. There is no
 compose-from-scratch: a paperwork desk answers letters, it does not
 start correspondence.


### PR DESCRIPTION
Documentation sweep after three releases in two days. Audited all of `README.md` and `docs/`; two files were actually stale.

## README

The prebuilt-image example told readers to pin `:1.2.0` — four releases old. Now `:1.6.0`.

## features.md — the Mail section

It described IMAP as the only way letters arrive, which stopped being true in 1.6.0. Rewritten to name both sources and to say they converge on the same ingest function, so the rest of the section needs no per-source caveats:

- **self-hosted** — polls a mailbox you connect;
- **hosted** — the address comes with the family, fed by an inbound webhook, nothing to connect.

The reply paragraph now carries *why* service-side sending goes over HTTP rather than SMTP: cloud hosts routinely block outbound SMTP ports (ours does), so it is a portability property rather than a preference.

## Checked and deliberately left alone

- `docs/architecture.md`, `docs/family-mail.md` — already updated alongside the code in #151/#152.
- `docs/deploy-vps.md` — a self-hosted VPS guide. `MAIL_DOMAIN` / `MAILGUN_*` are hosted-only, so their absence is correct, not an omission.
- `README`'s "no external services required" — still true of the self-hosted product this repo ships.
- `.env.example` — carries the new variables already.

Docs-only; no code touched.