### PR TITLE
test: pin hosted invariants, and two guards for the PR gate

### DIFF
--- a/server/src/env.documented.test.ts
+++ b/server/src/env.documented.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/*
+  Every environment variable the server reads has to be documented.
+
+  This exists because documentation drifts silently: a variable added to
+  env.ts works immediately, so nothing forces the person adding it to
+  mention it anywhere an operator would look. `.env.example` is that
+  place — it is what a self-hoster copies and what the hosted runbook
+  points at — and it has fallen behind before.
+
+  The check is one-directional: env.ts -> .env.example. The reverse would
+  fail on the infrastructure variables that only compose, Caddy and the
+  backup script read (HUB_DOMAIN, AGE_RECIPIENT, DEMO_DATA_DIR …), which
+  are legitimately absent from the server's own code.
+*/
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENV_TS = join(HERE, 'env.ts');
+const ENV_EXAMPLE = join(HERE, '..', '..', '.env.example');
+
+/*
+  Set by the container or the process, never by a human editing .env, so
+  documenting them in a copy-me file would be noise. Each one needs a
+  reason to be here — that is the point of the list.
+*/
+const NOT_FOR_HUMANS = new Set([
+  'NODE_ENV', // set by the image
+  'HOST', // bind address; the container always wants 0.0.0.0
+  'WEB_DIST', // build layout, not deployment
+  'DATA_DIR', // written by compose from the documented DATA_DIR mount
+  'TRUST_PROXY', // compose sets it: mandatory behind Caddy, unsafe without
+  'SECURE_COOKIES', // same — compose decides, and .env.example explains the flag itself
+  'PUBLIC_URL', // compose builds it from HUB_DOMAIN
+  'DEMO_MODE', // the demo overlay sets it
+]);
+
+/** `process.env.FOO`, plus the validated forms `intFrom('FOO'` / `boolFrom('FOO'`. */
+function readsFromEnv(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const m of source.matchAll(/process\.env\.([A-Z0-9_]+)/g)) names.add(m[1]!);
+  for (const m of source.matchAll(/(?:intFrom|boolFrom)\(\s*'([A-Z0-9_]+)'/g)) names.add(m[1]!);
+  return names;
+}
+
+describe('environment documentation', () => {
+  const source = readFileSync(ENV_TS, 'utf8');
+  const example = readFileSync(ENV_EXAMPLE, 'utf8');
+  const read = readsFromEnv(source);
+
+  it('found the variables at all', () => {
+    // Guards the regexes themselves: a rename in env.ts must not turn this
+    // suite into a test that silently checks nothing.
+    expect(read.size).toBeGreaterThan(10);
+    expect(read.has('HOSTED_MODE')).toBe(true);
+  });
+
+  it('documents every operator-facing variable in .env.example', () => {
+    const documented = new Set(
+      [...example.matchAll(/^#?\s*([A-Z0-9_]+)=/gm)].map((m) => m[1]!),
+    );
+    const missing = [...read].filter((name) => !NOT_FOR_HUMANS.has(name) && !documented.has(name));
+    expect(missing.sort()).toEqual([]);
+  });
+
+  it('keeps the exemption list honest', () => {
+    // An exemption for a variable env.ts no longer reads is stale, and a
+    // stale exemption is how a real variable slips through later.
+    const unused = [...NOT_FOR_HUMANS].filter((name) => !read.has(name));
+    expect(unused.sort()).toEqual([]);
+  });
+});

--- a/server/src/lib/auth.public-surface.test.ts
+++ b/server/src/lib/auth.public-surface.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { buildTestApp } from '../test-harness.js';
+
+/*
+  The list of routes reachable without a session, pinned.
+
+  Every entry in PUBLIC_PATHS is a door in the wall, and the wall is the
+  reason a stranger on the internet cannot read a family's notes. Adding a
+  door is sometimes right — sign-in, invites, the mail webhook all had to
+  be public — but it must never happen as a side effect of something else.
+  So the surface is a snapshot: widening it fails here, and the PR has to
+  say why in its diff.
+
+  Two claims are checked, because the list alone proves neither: that the
+  source still contains exactly these paths, and that the wall around them
+  is actually standing.
+*/
+
+const AUTH_TS = join(dirname(fileURLToPath(import.meta.url)), 'auth.ts');
+
+const PUBLIC_SNAPSHOT = [
+  '/api/auth/demo',
+  '/api/auth/google/callback',
+  '/api/auth/google/finish',
+  '/api/auth/google/start',
+  '/api/auth/invite',
+  '/api/auth/join',
+  '/api/auth/login',
+  '/api/auth/mfa',
+  '/api/auth/setup',
+  '/api/auth/state',
+  '/api/health',
+  '/api/home-name',
+  // Signature-authenticated, not session-authenticated: Mailgun is not a
+  // browser (routes/mail-inbound.ts refuses anything unsigned).
+  '/api/mail/inbound/mime',
+];
+
+describe('public API surface', () => {
+  const source = readFileSync(AUTH_TS, 'utf8');
+
+  it('is exactly the pinned list', () => {
+    const block = source.slice(
+      source.indexOf('const PUBLIC_PATHS'),
+      source.indexOf('export async function authenticate'),
+    );
+    const paths = [...block.matchAll(/'(\/api\/[^']+)'/g)].map((m) => m[1]!).sort();
+    expect(paths).toEqual([...PUBLIC_SNAPSHOT].sort());
+  });
+
+  it('exempts exactly one path prefix, the public wishlist', () => {
+    // A prefix exemption is broader than a path and deserves louder review:
+    // '/api/wishlist/' opens a whole subtree by design (token-addressed).
+    const fn = source.slice(source.indexOf('export async function authenticate'));
+    const prefixes = [...fn.matchAll(/startsWith\('(\/api[^']*)'\)/g)].map((m) => m[1]!);
+    expect(prefixes.filter((p) => p !== '/api')).toEqual(['/api/wishlist/']);
+  });
+
+  it('still refuses an anonymous request to a route outside the list', async () => {
+    // The snapshot would be worthless if the check it describes stopped
+    // running — assert the wall, not only the door list.
+    const { app } = await buildTestApp();
+    for (const url of ['/api/mail', '/api/notes', '/api/money/accounts', '/api/settings']) {
+      const res = await app.inject({ url });
+      expect(res.statusCode, url).toBe(401);
+    }
+  });
+});

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
 import type { FastifyInstance } from 'fastify';
 
 /*
@@ -14,6 +17,7 @@ process.env.HOSTED_DOMAIN = 'neiliro.test';
 
 const tenants = await import('../lib/tenants.js');
 const { buildApp } = await import('../app.js');
+const { env } = await import('../env.js');
 
 afterAll(() => {
   delete process.env.HOSTED_MODE;
@@ -51,8 +55,90 @@ describe('createFamily', () => {
     expect(() => tenants.createFamily('petrovs!')).toThrow(/Bad slug/);
     expect(() => tenants.createFamily('mail')).toThrow(/reserved/);
 
+    /*
+      The service's own entrances must stay unclaimable — a family holding
+      one would take over a door, not merely confuse a URL. `auth` is the
+      single Google callback host (routes/google.ts); `in` is the inbound
+      mail webhook (routes/mail-inbound.ts).
+
+      Note which rule actually stops each one. `auth` is refused by
+      RESERVED_SLUGS; `in` and `mx` never reach that list, because the slug
+      pattern demands three characters. So they are guarded twice, and the
+      assertion is "refused", not "refused for this reason" — a refactor
+      that relaxed the length rule would still have the reserved list, and
+      this test would still hold.
+    */
+    expect(() => tenants.createFamily('auth')).toThrow(/reserved/);
+    expect(() => tenants.createFamily('in')).toThrow();
+    expect(() => tenants.createFamily('mx')).toThrow();
+
     tenants.createFamily('taken-q1w2');
     expect(() => tenants.createFamily('taken-q1w2')).toThrow(/already taken/);
+  });
+});
+
+describe('suspension and deletion', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    tenants.initHosted();
+    app = await buildApp();
+  });
+
+  /*
+    Suspension is an operator action taken straight in the registry (the
+    control plane's set-status script), so the test writes the status the
+    same way the operator does.
+
+    Both cases below use a family the app has never served: familyIdBySlug
+    caches a slug for 30 s, so a status flipped under a warm slug keeps
+    answering in the old state until the TTL passes. That is accepted
+    behaviour — suspension is an operator action, not a security boundary —
+    and it is why these tests start cold rather than sleeping.
+  */
+  function setStatus(slug: string, status: string): void {
+    const registry = new Database(join(env.dataDir, 'registry.db'));
+    registry.prepare('UPDATE families SET status = ? WHERE slug = ?').run(status, slug);
+    registry.close();
+  }
+
+  it('hides a suspended family behind the ghost, and keeps its data', () => {
+    const family = tenants.createFamily('paused-p1q2');
+    setStatus('paused-p1q2', 'suspended');
+
+    const dbFile = join(env.dataDir, 'families', family.familyId, 'hub.db');
+    expect(existsSync(dbFile)).toBe(true); // suspended is not deleted
+
+    return app
+      .inject({ url: '/api/auth/state', headers: onHost('paused-p1q2.neiliro.test') })
+      .then(async (state) => {
+        // Indistinguishable from an unknown subdomain: a suspended family
+        // must not be enumerable either
+        expect(state.statusCode).toBe(200);
+
+        const setup = await app.inject({
+          method: 'POST',
+          url: '/api/auth/setup',
+          headers: onHost('paused-p1q2.neiliro.test'),
+          payload: { name: 'Squatter', email: 'squatter@example.test', password: 'correct horse battery' },
+        });
+        // The ghost's decoy database may never grow an admin — whoever
+        // "set it up" would own every unknown subdomain at once
+        expect(setup.statusCode).toBe(403);
+
+        // And the family's own file is still untouched by that attempt
+        expect(existsSync(dbFile)).toBe(true);
+      });
+  });
+
+  it('never re-issues the slug of a deleted family', () => {
+    const family = tenants.createFamily('gone-g1h2');
+    tenants.deleteFamilyData(family.familyId);
+
+    expect(existsSync(join(env.dataDir, 'families', family.familyId, 'hub.db'))).toBe(false);
+    // A stranger inheriting the slug would inherit bookmarks and mail
+    // addressed to the family that left
+    expect(() => tenants.createFamily('gone-g1h2')).toThrow(/already taken/);
   });
 });
 

--- a/server/src/routes/mail-inbound.test.ts
+++ b/server/src/routes/mail-inbound.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createHmac } from 'node:crypto';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
 import type { FastifyInstance } from 'fastify';
 
 /*
@@ -21,6 +24,7 @@ process.env.MAILGUN_SIGNING_KEY = 'test-signing-key';
 
 const tenants = await import('../lib/tenants.js');
 const { buildApp } = await import('../app.js');
+const { env } = await import('../env.js');
 
 const SIGNING_KEY = 'test-signing-key';
 const INBOUND = '/api/mail/inbound/mime';
@@ -210,6 +214,85 @@ describe('inbound family mail', () => {
     );
     // 406 and not 5xx: anything else buys eight hours of Mailgun retries
     expect(res.statusCode).toBe(406);
+  });
+
+  it('refuses letters for a suspended family, and does not touch its data', async () => {
+    /*
+      Suspension is an operator action written straight into the registry.
+      The slug is deliberately one the app has never served: familyIdBySlug
+      caches for 30 s, so a status flipped under a warm slug keeps answering
+      in the old state — accepted, and the reason this starts cold.
+    */
+    const paused = tenants.createFamily('paused-m9n8');
+    const registry = new Database(join(env.dataDir, 'registry.db'));
+    registry.prepare("UPDATE families SET status = 'suspended' WHERE slug = ?").run('paused-m9n8');
+    registry.close();
+
+    const res = await post(
+      delivery({
+        recipient: 'paused-m9n8@mail.neiliro.test',
+        'body-mime': letter('paused-1@school.example', 'While away'),
+      }),
+    );
+    // 406, so the sender gets a bounce instead of eight hours of retries
+    expect(res.statusCode).toBe(406);
+
+    // Nothing was written into the suspended family's database
+    const file = new Database(join(env.dataDir, 'families', paused.familyId, 'hub.db'), {
+      readonly: true,
+    });
+    const { n } = file.prepare('SELECT count(*) AS n FROM mail_messages').get() as { n: number };
+    file.close();
+    expect(n).toBe(0);
+  });
+
+  it('files an attachment inside the addressed family, and nowhere else', async () => {
+    // Attachments follow the tenant, not the process: they land in the
+    // family's own directory (Tenant.attachmentsDir), so a letter for one
+    // family must leave the other's storage empty.
+    const pdf = Buffer.from('%PDF-1.4 report').toString('base64');
+    const withAttachment = [
+      'Message-ID: <report-1@school.example>',
+      'From: office@school.example',
+      `To: ${SMITHS}@mail.neiliro.test`,
+      'Subject: Term report',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/mixed; boundary="B"',
+      '',
+      '--B',
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      'Report attached.',
+      '--B',
+      'Content-Type: application/pdf',
+      'Content-Disposition: attachment; filename="term.pdf"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      pdf,
+      '--B--',
+      '',
+    ].join('\r\n');
+
+    const res = await post(
+      delivery({ recipient: `${SMITHS}@mail.neiliro.test`, 'body-mime': withAttachment }),
+    );
+    expect(res.statusCode).toBe(200);
+
+    const idOf = (slug: string) => {
+      const registry = new Database(join(env.dataDir, 'registry.db'), { readonly: true });
+      const row = registry.prepare('SELECT id FROM families WHERE slug = ?').get(slug) as { id: string };
+      registry.close();
+      return row.id;
+    };
+    const files = (slug: string) => {
+      const dir = join(env.dataDir, 'families', idOf(slug), 'attachments');
+      return readdirSync(dir, { recursive: true, withFileTypes: true })
+        .filter((e) => e.isFile())
+        .map((e) => e.name);
+    };
+
+    expect(files(SMITHS).length).toBeGreaterThan(0);
+    expect(files(JONES)).toEqual([]);
   });
 
   it('refuses letters addressed to another domain', async () => {


### PR DESCRIPTION
Came out of auditing hosted coverage while updating the QA skill. Hosted is where the real families live and where a bug is a cross-family leak rather than a broken screen — these are the gaps that audit found.

## Hosted invariants

- **A suspended family hides behind the ghost and keeps its data.** Also asserts the ghost still refuses first-run setup: if that ever succeeded, whoever ran it would own every unknown subdomain at once.
- **A deleted family's slug is never re-issued** — a stranger inheriting it would inherit bookmarks and mail addressed to the family that left.
- **The service's own entrances stay unclaimable.** This one found something worth writing down: `auth` is refused by `RESERVED_SLUGS`, but `in` and `mx` never reach that list — the slug pattern demands three characters, so they are stopped by length. Guarded twice, which is why the assertion is "refused" rather than "refused for this reason".

## Mail

- **A letter for a suspended family is refused `406`** and writes nothing into that family's database.
- **An attachment lands in the addressed family's own directory** and leaves the neighbour's storage empty. Attachments follow the tenant, not the process — a path built from process config would pass every UI check and fail only this.

## Two guards for the PR gate

Both aimed at classes of mistake that hit us this week, and both verified by breaking them on purpose:

**`env.documented.test.ts`** — every variable `env.ts` reads must appear in `.env.example`, with an explicit exemption list for the ones only compose sets (each carrying its reason). Documentation drifting behind code is precisely what happened: a new variable works the moment it is added, so nothing forces the author to mention it where an operator would look. Verified: adding `TOTALLY_NEW_KNOB` to `env.ts` fails the test *by name*.

**`auth.public-surface.test.ts`** — the set of routes reachable without a session is pinned as a snapshot, prefix exemptions are counted (exactly one: the token-addressed public wishlist), and an anonymous request to a protected route is asserted to still return 401. Adding a public door is sometimes right — sign-in, invites, the mail webhook all needed one — but it must never happen as a side effect. Verified: adding `/api/notes` to `PUBLIC_PATHS` fails both the snapshot and the live check (`expected 200 to be 401`).

## Testing

218 total (160 server + 58 web), typecheck and lint clean. No production code touched — tests only.

The QA skill itself and the new `qa-hosted` launch configuration live under `.claude/`, which is gitignored, so they are not in this diff.