### PR TITLE
feat: shared lists (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A self-hosted family hub: tasks, notes, calendar and money in one place. Built for a household, not a corporation: one Docker container, one SQLite file, no external services required. Runs on a home machine over the local network or on a cheap VPS with a real domain.
 
-The core is complete and battle-tested by daily family use: accounts and sign-in (password and Google, with optional two-factor codes), projects and tasks with a kanban board, notes with attachments and wiki-links, a calendar with recurring events, a shared family mailbox that turns letters into tasks, full-text search, a home screen you arrange yourself out of widgets, and a money section — accounts with balances, expenses, income, transfers, bank reconciliation, categories, budgets, recurring transactions, receipts. It installs to the home screen as an app and keeps working read-only when the Wi-Fi does not.
+The core is complete and battle-tested by daily family use: accounts and sign-in (password and Google, with optional two-factor codes), projects and tasks with a kanban board, notes with attachments and wiki-links, a calendar with recurring events, shared lists for the shopping run, a shared family mailbox that turns letters into tasks, full-text search, a home screen you arrange yourself out of widgets, and a money section — accounts with balances, expenses, income, transfers, bank reconciliation, categories, budgets, recurring transactions, receipts. It installs to the home screen as an app and keeps working read-only when the Wi-Fi does not.
 
 ## A quick look
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -138,6 +138,16 @@ Everything the household owns leaves in one file whenever it wants: Settings →
 
 On the hosted service the same section holds **Delete everything**: the administrator confirms with the password, a two-factor code when one is set, and by typing the family's own address, after which the database and the attachments are gone and the encrypted nightly backups expire on their own within a fortnight. A self-hosted install gets the export but no such button — there, deleting the only family means erasing the instance, and that belongs to whoever owns the machine.
 
+## Lists
+
+The shopping list, and whatever else the household keeps as a list. Shared with everyone by default — a list nobody else can see would defeat the point, so this is the one user-owned thing in the hub with no per-person visibility.
+
+The whole design is about speed on a phone, because that is where a shopping list is actually used: type an item and press Enter, and the field keeps focus for the next one; tap a row to check it. Checked items are not deleted — they sink to the bottom, struck through, so what was just bought is still visible on the walk home. "Clear checked" removes the pile in one action when the trip is over.
+
+Items are deliberately plain text with no quantity, assignee or due date: a list item is a word, and every field added to it is a field to fill in while standing in a shop. Duplicates are allowed — two "milk" means two bottles, and a dedupe check would be a surprise at the worst moment.
+
+One list ships with a fresh hub, so the feature works before anyone configures anything; more can be added, and the seeded name is translated by id, so renaming it keeps your name. Adding is also one of the four one-tap actions on the phone home screen.
+
 ## Mail
 
 ![Mail: the shared household inbox, one click from letter to task](screenshots/mail.png)

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,6 +26,7 @@ import { registerSetupRoutes } from './routes/setup.js';
 import { registerUserRoutes } from './routes/users.js';
 import { registerProfileRoutes, registerPublicWishlistRoutes } from './routes/profiles.js';
 import { registerProjectRoutes } from './routes/projects.js';
+import { registerListRoutes } from './routes/lists.js';
 import { registerTaskRoutes } from './routes/tasks.js';
 import { registerNoteRoutes } from './routes/notes.js';
 import { MAX_FILE_BYTES, registerAttachmentRoutes } from './routes/attachments.js';
@@ -284,6 +285,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await registerProfileRoutes(app);
   await registerPublicWishlistRoutes(app);
   await registerProjectRoutes(app);
+  await registerListRoutes(app);
   await registerTaskRoutes(app);
   await registerNoteRoutes(app);
   await registerAttachmentRoutes(app);

--- a/server/src/db/migrations/025_lists.sql
+++ b/server/src/db/migrations/025_lists.sql
@@ -1,0 +1,44 @@
+-- Shared lists (#11) — the shopping list and its friends.
+--
+-- The most-requested thing in early feedback, and the request was never
+-- "notes with checkboxes" (which already worked) but *speed*: one tap to
+-- add, one tap to check, and a list that stays clean without tidying.
+-- That is why this is its own pair of tables rather than a view over
+-- tasks or notes. A task carries status, priority, due date, assignee and
+-- recurrence — all meaningless for "milk" — and a note is one document,
+-- so checking an item would rewrite the whole thing through the editor.
+-- Here an add is one INSERT and a check is one UPDATE of one column.
+--
+-- Deliberately NO owner_id. Everything else private in this hub is
+-- private per person; a shared list is the opposite by definition — the
+-- point is that whoever is nearest the shop can see it. Privacy here
+-- would make the feature pointless, so the absence is a decision, not an
+-- omission.
+
+CREATE TABLE lists (
+  id          TEXT PRIMARY KEY,
+  title       TEXT NOT NULL,
+  position    REAL NOT NULL DEFAULT 0,
+  created_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TEXT NOT NULL
+);
+
+CREATE TABLE list_items (
+  id          TEXT PRIMARY KEY,
+  list_id     TEXT NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+  title       TEXT NOT NULL,
+  -- Checked state is a timestamp, not a flag: "what did we buy today"
+  -- is answerable, and the checked pile can be sorted by when it happened.
+  checked_at  TEXT,
+  position    REAL NOT NULL DEFAULT 0,
+  created_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX idx_list_items_list ON list_items(list_id, position);
+
+-- One list to start with, so the feature is useful before anyone
+-- configures anything. Fixed id, like the Inbox project and the Shared
+-- calendar: the client translates the seeded name back for Russian
+-- devices (listTitle helper) and a rename by the family survives.
+INSERT INTO lists (id, title, position, created_at)
+VALUES ('00000000-0000-4000-8000-000000000301', 'Shopping', 0, datetime('now'));

--- a/server/src/routes/lists.test.ts
+++ b/server/src/routes/lists.test.ts
@@ -1,0 +1,127 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+
+/*
+  Shared lists (#11).
+
+  Two things are worth pinning here, and neither is CRUD. First, the
+  ordering: it *is* the "auto-clear" behaviour the issue asks for — the
+  list reads clean because checked items sink, not because anything was
+  deleted behind the family's back. Second, sharing: every other
+  user-owned thing in this hub is private per person, so a list being
+  visible to everyone is the one place where the absence of an owner check
+  is the correct answer rather than a missing guard.
+*/
+
+const SHOPPING = '00000000-0000-4000-8000-000000000301';
+
+let h: Harness;
+let alice: { userId: string; cookie: string };
+let bob: { userId: string; cookie: string };
+
+beforeAll(async () => {
+  h = await buildTestApp();
+  alice = h.join('Alice');
+  bob = h.join('Bob');
+});
+
+async function items(cookie: string, listId = SHOPPING) {
+  const res = await h.as(cookie, 'GET', `/api/lists/${listId}`);
+  expect(res.statusCode).toBe(200);
+  return res.json<{ items: { id: string; title: string; checked_at: string | null }[] }>().items;
+}
+
+async function add(cookie: string, title: string, listId = SHOPPING) {
+  const res = await h.as(cookie, 'POST', `/api/lists/${listId}/items`, { title });
+  expect(res.statusCode).toBe(201);
+  return res.json<{ id: string }>().id;
+}
+
+describe('shared lists', () => {
+  it('ships one list, so the feature works before anyone configures anything', async () => {
+    const res = await h.as(alice.cookie, 'GET', '/api/lists');
+    const lists = res.json<{ id: string; title: string }[]>();
+    expect(lists.map((l) => l.id)).toContain(SHOPPING);
+    // English seed; the client translates it back by id (listTitle)
+    expect(lists.find((l) => l.id === SHOPPING)!.title).toBe('Shopping');
+  });
+
+  it('is shared: what one person adds, the other sees', async () => {
+    await add(alice.cookie, 'milk');
+    // The deliberate opposite of notes — no owner filter, by design
+    expect((await items(bob.cookie)).map((i) => i.title)).toEqual(['milk']);
+  });
+
+  it('keeps duplicates, because two bottles are two items', async () => {
+    await add(bob.cookie, 'milk');
+    const titles = (await items(alice.cookie)).map((i) => i.title);
+    expect(titles.filter((t) => t === 'milk')).toHaveLength(2);
+  });
+
+  it('adds to the end, so the list reads in the order it was written', async () => {
+    await add(alice.cookie, 'bread');
+    expect((await items(alice.cookie)).map((i) => i.title)).toEqual(['milk', 'milk', 'bread']);
+  });
+
+  it('sinks checked items instead of deleting them', async () => {
+    const [first] = await items(alice.cookie);
+    const toggled = await h.as(bob.cookie, 'POST', `/api/list-items/${first!.id}/toggle`);
+    expect(toggled.statusCode).toBe(200);
+    expect(toggled.json<{ checked_at: string | null }>().checked_at).toBeTruthy();
+
+    const after = await items(alice.cookie);
+    // Still there, and now last: bought is visible on the walk home
+    expect(after).toHaveLength(3);
+    expect(after[after.length - 1]!.id).toBe(first!.id);
+    expect(after.slice(0, 2).every((i) => i.checked_at === null)).toBe(true);
+  });
+
+  it('unchecks back, so a mis-tap in a shop is one tap to undo', async () => {
+    const checked = (await items(alice.cookie)).find((i) => i.checked_at)!;
+    await h.as(alice.cookie, 'POST', `/api/list-items/${checked.id}/toggle`);
+    expect((await items(alice.cookie)).every((i) => i.checked_at === null)).toBe(true);
+  });
+
+  it('clears only the checked pile, and says how much it removed', async () => {
+    const all = await items(alice.cookie);
+    await h.as(alice.cookie, 'POST', `/api/list-items/${all[0]!.id}/toggle`);
+    await h.as(alice.cookie, 'POST', `/api/list-items/${all[1]!.id}/toggle`);
+
+    const cleared = await h.as(alice.cookie, 'POST', `/api/lists/${SHOPPING}/clear-checked`);
+    expect(cleared.json<{ cleared: number }>().cleared).toBe(2);
+
+    const left = await items(alice.cookie);
+    expect(left).toHaveLength(1);
+    expect(left[0]!.checked_at).toBeNull();
+  });
+
+  it('counts open and checked items for the list index', async () => {
+    await add(alice.cookie, 'eggs');
+    const eggs = (await items(alice.cookie)).find((i) => i.title === 'eggs')!;
+    await h.as(alice.cookie, 'POST', `/api/list-items/${eggs.id}/toggle`);
+
+    const lists = (await h.as(alice.cookie, 'GET', '/api/lists')).json<
+      { id: string; open_items: number; checked_items: number }[]
+    >();
+    const shopping = lists.find((l) => l.id === SHOPPING)!;
+    expect(shopping.open_items).toBe(1);
+    expect(shopping.checked_items).toBe(1);
+  });
+
+  it('takes its items with it when a list is deleted', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Hardware store' });
+    const listId = made.json<{ id: string }>().id;
+    const itemId = await add(alice.cookie, 'screws', listId);
+
+    expect((await h.as(alice.cookie, 'DELETE', `/api/lists/${listId}`)).statusCode).toBe(200);
+    expect((await h.as(alice.cookie, 'GET', `/api/lists/${listId}`)).statusCode).toBe(404);
+    // ON DELETE CASCADE, not orphans
+    expect((await h.as(alice.cookie, 'POST', `/api/list-items/${itemId}/toggle`)).statusCode).toBe(404);
+  });
+
+  it('refuses an empty name and an unknown list', async () => {
+    expect((await h.as(alice.cookie, 'POST', '/api/lists', { title: '   ' })).statusCode).toBe(400);
+    const ghostList = '00000000-0000-4000-8000-0000000009f9';
+    expect((await h.as(alice.cookie, 'POST', `/api/lists/${ghostList}/items`, { title: 'x' })).statusCode).toBe(404);
+  });
+});

--- a/server/src/routes/lists.ts
+++ b/server/src/routes/lists.ts
@@ -1,0 +1,146 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { db, id, now } from '../db/index.js';
+
+/*
+  Shared lists (#11) — the shopping list and its friends.
+
+  Everything here is shaped by one requirement: it has to feel instant on a
+  phone. So the write endpoints are as small as they can be — an add takes
+  a title and nothing else, a check is a toggle with no body — and the read
+  endpoint returns the whole list in one go, because a list is small and a
+  second round-trip costs more than the rows do.
+
+  Lists are shared, with no per-person visibility. See migration 025: for
+  this feature privacy would defeat the purpose.
+*/
+
+export const SHOPPING_LIST_ID = '00000000-0000-4000-8000-000000000301';
+
+const titleInput = z.object({ title: z.string().trim().min(1, 'Enter a name').max(200) });
+
+export async function registerListRoutes(app: FastifyInstance): Promise<void> {
+  /** Every list with its open count — enough to render the sidebar badge. */
+  app.get('/api/lists', () => {
+    return db
+      .prepare(
+        `SELECT l.*,
+                (SELECT count(*) FROM list_items i
+                  WHERE i.list_id = l.id AND i.checked_at IS NULL) AS open_items,
+                (SELECT count(*) FROM list_items i
+                  WHERE i.list_id = l.id AND i.checked_at IS NOT NULL) AS checked_items
+           FROM lists l
+          ORDER BY l.position, l.created_at`,
+      )
+      .all();
+  });
+
+  app.post('/api/lists', (req, reply) => {
+    const parsed = titleInput.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    const listId = id();
+    db.prepare(
+      `INSERT INTO lists (id, title, position, created_by, created_at)
+       VALUES (?, ?, (SELECT coalesce(max(position), 0) + 1 FROM lists), ?, ?)`,
+    ).run(listId, parsed.data.title, req.user!.id, now());
+    return reply.code(201).send(db.prepare('SELECT * FROM lists WHERE id = ?').get(listId));
+  });
+
+  app.get('/api/lists/:id', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const list = db.prepare('SELECT * FROM lists WHERE id = ?').get(listId);
+    if (!list) return reply.code(404).send({ error: 'List not found' });
+
+    /*
+      Unchecked first in their own order, then the checked pile newest
+      first. That ordering is the whole "auto-clear" behaviour: the list
+      reads as clean without anything being deleted behind the family's
+      back, and what was just bought is still visible for the walk home.
+    */
+    const items = db
+      .prepare(
+        `SELECT * FROM list_items
+          WHERE list_id = ?
+          ORDER BY checked_at IS NOT NULL, CASE WHEN checked_at IS NULL THEN position END,
+                   checked_at DESC`,
+      )
+      .all(listId);
+    return { ...list, items };
+  });
+
+  app.patch('/api/lists/:id', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const parsed = titleInput.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    const result = db
+      .prepare('UPDATE lists SET title = ? WHERE id = ?')
+      .run(parsed.data.title, listId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'List not found' });
+    return db.prepare('SELECT * FROM lists WHERE id = ?').get(listId);
+  });
+
+  app.delete('/api/lists/:id', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const result = db.prepare('DELETE FROM lists WHERE id = ?').run(listId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'List not found' });
+    return { ok: true };
+  });
+
+  /** One tap: add an item. Position goes to the end — a list reads in the order it was written. */
+  app.post('/api/lists/:id/items', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const parsed = titleInput.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    const exists = db.prepare('SELECT 1 FROM lists WHERE id = ?').get(listId);
+    if (!exists) return reply.code(404).send({ error: 'List not found' });
+
+    // Duplicates are allowed on purpose: "milk" twice means two bottles,
+    // and a dedupe check would be a surprise mid-shop.
+    const itemId = id();
+    db.prepare(
+      `INSERT INTO list_items (id, list_id, title, position, created_by, created_at)
+       VALUES (?, ?, ?, (SELECT coalesce(max(position), 0) + 1 FROM list_items WHERE list_id = ?), ?, ?)`,
+    ).run(itemId, listId, parsed.data.title, listId, req.user!.id, now());
+    return reply.code(201).send(db.prepare('SELECT * FROM list_items WHERE id = ?').get(itemId));
+  });
+
+  /** One tap: check or uncheck. Idempotent per state, so a double-tap in a shop is harmless. */
+  app.post('/api/list-items/:id/toggle', (req, reply) => {
+    const { id: itemId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const item = db.prepare('SELECT id, checked_at FROM list_items WHERE id = ?').get(itemId) as
+      | { id: string; checked_at: string | null }
+      | undefined;
+    if (!item) return reply.code(404).send({ error: 'Item not found' });
+
+    db.prepare('UPDATE list_items SET checked_at = ? WHERE id = ?').run(
+      item.checked_at ? null : now(),
+      itemId,
+    );
+    return db.prepare('SELECT * FROM list_items WHERE id = ?').get(itemId);
+  });
+
+  app.delete('/api/list-items/:id', (req, reply) => {
+    const { id: itemId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const result = db.prepare('DELETE FROM list_items WHERE id = ?').run(itemId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'Item not found' });
+    return { ok: true };
+  });
+
+  /** Clear the checked pile — one action instead of deleting items one by one. */
+  app.post('/api/lists/:id/clear-checked', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const exists = db.prepare('SELECT 1 FROM lists WHERE id = ?').get(listId);
+    if (!exists) return reply.code(404).send({ error: 'List not found' });
+
+    const result = db
+      .prepare('DELETE FROM list_items WHERE list_id = ? AND checked_at IS NOT NULL')
+      .run(listId);
+    return { cleared: result.changes };
+  });
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { Calendar } from './pages/Calendar';
 import { Settings } from './pages/Settings';
 import { Money } from './pages/Money';
 import { Mail } from './pages/Mail';
+import { Lists } from './pages/Lists';
 import { Family } from './pages/Family';
 import { PublicWishlist } from './pages/PublicWishlist';
 import { VerifyEmail } from './pages/VerifyEmail';
@@ -31,6 +32,7 @@ function Gate() {
         <Route path="calendar" element={<Calendar />} />
         <Route path="notes" element={<Notes />} />
         <Route path="money" element={<Money />} />
+        <Route path="lists" element={<Lists />} />
         <Route path="mail" element={<Mail />} />
         <Route path="family" element={<Family />} />
         <Route path="family/:userId" element={<Family />} />

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -94,6 +94,15 @@ const SECONDARY: NavItem[] = [
     ),
   },
   {
+    to: '/lists',
+    label: t('Lists'),
+    icon: (
+      <svg viewBox="0 0 24 24" {...stroke}>
+        <path d="M4 7h2M4 12h2M4 17h2M9 7h11M9 12h11M9 17h7" />
+      </svg>
+    ),
+  },
+  {
     to: '/mail',
     label: t('Mail'),
     icon: (

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -655,6 +655,18 @@ export const ru: Record<string, string> = {
   'Your own colors for projects, accounts, categories and calendars — on top of the stock ones. Grows from here and from the "+" button right in the color picker.': 'Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.',
   'Zero — the goal is only a countdown': 'Ноль — только отсчёт, без накоплений',
 
+  // ── Общие списки (#11) ────────────────────────────────────────────────
+  'Lists': 'Списки',
+  'Shopping': 'Покупки',
+  'Shared with the whole family': 'Общее для всей семьи',
+  'New list': 'Новый список',
+  'Name of the new list': 'Название нового списка',
+  'Add an item and press Enter': 'Добавьте пункт и нажмите Enter',
+  'Nothing here yet. Add the first item above.': 'Пока пусто. Добавьте первый пункт выше.',
+  'Clear checked ({n})': 'Убрать отмеченные ({n})',
+  'List not found': 'Список не найден',
+  'Item not found': 'Пункт не найден',
+
   // ── Сброс пароля по email (hosted) ────────────────────────────────────
   'Forgot your password?': 'Забыли пароль?',
   'Password reset': 'Сброс пароля',

--- a/web/src/lib/lists.ts
+++ b/web/src/lib/lists.ts
@@ -1,0 +1,32 @@
+import { t } from './i18n';
+
+/**
+ * The seeded list, like the Inbox project and the Shared calendar: its
+ * name lives in the database in English and is translated back by id, so
+ * a family that renames it keeps their own name.
+ */
+export const SHOPPING_LIST_ID = '00000000-0000-4000-8000-000000000301';
+
+export function listTitle(id: string, title: string): string {
+  return id === SHOPPING_LIST_ID ? t('Shopping') : title;
+}
+
+export interface ListItem {
+  id: string;
+  list_id: string;
+  title: string;
+  checked_at: string | null;
+  position: number;
+}
+
+export interface SharedList {
+  id: string;
+  title: string;
+  position: number;
+  open_items: number;
+  checked_items: number;
+}
+
+export interface ListWithItems extends SharedList {
+  items: ListItem[];
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -242,7 +242,7 @@ function QuickActions() {
   };
 
   return (
-    <div className="grid grid-cols-3 gap-3 md:hidden">
+    <div className="grid grid-cols-4 gap-3 md:hidden">
       <button
         type="button"
         onClick={() => window.dispatchEvent(new Event('hub:quick-add'))}
@@ -268,6 +268,15 @@ function QuickActions() {
           <path d="M9 12h6M12 9v6" />
         </svg>
         {t('Note')}
+      </button>
+      {/* Shared lists (#11): the whole point is adding without navigating,
+          so this lands in the input rather than on the page. */}
+      <button type="button" onClick={() => navigate('/lists?add=1')} className={action}>
+        <svg viewBox="0 0 24 24" className="size-6 text-accent" {...iconProps}>
+          <path d="M4 7h2M4 12h2M4 17h2M9 7h11M9 12h7" />
+          <path d="M17 15v6M14 18h6" />
+        </svg>
+        {t('List')}
       </button>
     </div>
   );

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -1,0 +1,216 @@
+import { t } from '../lib/i18n';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '../lib/api';
+import { Empty, Page } from '../components/Page';
+import { onEnter } from '../lib/keys';
+import { listTitle, type ListItem, type ListWithItems, type SharedList } from '../lib/lists';
+
+/*
+  Shared lists (#11) — the shopping list and its friends.
+
+  The requirement was speed on a phone, so the interactions are optimistic:
+  a tap moves the row immediately and the request follows. A list is small
+  and the operations are trivial, so the honest failure mode is "reload and
+  show the truth" rather than a spinner on every checkbox. The input keeps
+  focus after adding, because the real gesture is three items in a row.
+*/
+export function Lists() {
+  const [lists, setLists] = useState<SharedList[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [list, setList] = useState<ListWithItems | null>(null);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  /*
+    Items typed but not yet confirmed by the server, as plain titles. Not
+    placeholder rows with invented ids: a fake id needs a counter, and every
+    way to keep one here (a ref, a module variable, the clock) is something
+    the React lint rules correctly refuse in an event path. Titles are
+    enough — these rows are not interactive, and the reload replaces them.
+  */
+  const [pending, setPending] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const loadLists = useCallback(async () => {
+    const all = await api.get<SharedList[]>('/lists');
+    setLists(all);
+    setActiveId((current) => current ?? all[0]?.id ?? null);
+  }, []);
+
+  const loadList = useCallback(async (id: string) => {
+    setList(await api.get<ListWithItems>(`/lists/${id}`));
+  }, []);
+
+  useEffect(() => {
+    void loadLists();
+  }, [loadLists]);
+
+  useEffect(() => {
+    if (activeId) void loadList(activeId);
+  }, [activeId, loadList]);
+
+  useEffect(() => {
+    // Arrived from the phone's quick actions: land in the input, not on the page
+    if (new URLSearchParams(window.location.search).get('add') === '1') {
+      inputRef.current?.focus();
+    }
+  }, [list]);
+
+  async function addItem() {
+    const title = draft.trim();
+    if (!title || !activeId) return;
+    setDraft('');
+    setError(null);
+    // The row shows immediately; the request follows
+    setPending((p) => [...p, title]);
+    try {
+      await api.post(`/lists/${activeId}/items`, { title });
+      await Promise.all([loadList(activeId), loadLists()]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('Something went wrong'));
+      void loadList(activeId);
+    } finally {
+      setPending((p) => p.filter((x) => x !== title));
+    }
+  }
+
+  async function toggle(item: ListItem) {
+    if (!activeId) return;
+    setList((l) =>
+      l
+        ? {
+            ...l,
+            items: l.items.map((i) =>
+              // A marker, not a real timestamp: this row is replaced by the
+              // server's answer a moment later, and until then only
+              // "checked or not" is read from it
+              i.id === item.id ? { ...i, checked_at: i.checked_at ? null : 'pending' } : i,
+            ),
+          }
+        : l,
+    );
+    try {
+      await api.post(`/list-items/${item.id}/toggle`, {});
+      await Promise.all([loadList(activeId), loadLists()]);
+    } catch {
+      void loadList(activeId);
+    }
+  }
+
+  async function clearChecked() {
+    if (!activeId) return;
+    await api.post(`/lists/${activeId}/clear-checked`, {});
+    await Promise.all([loadList(activeId), loadLists()]);
+  }
+
+  async function newList() {
+    const title = window.prompt(t('Name of the new list')) ?? '';
+    if (!title.trim()) return;
+    const made = await api.post<SharedList>('/lists', { title: title.trim() });
+    await loadLists();
+    setActiveId(made.id);
+  }
+
+  // The open list names the page: with a single list there are no chips to
+  // switch between, so the heading is the only place its name can show.
+  const open = list?.items.filter((i) => !i.checked_at) ?? [];
+  const checked = list?.items.filter((i) => i.checked_at) ?? [];
+
+  return (
+    <Page
+      title={list ? listTitle(list.id, list.title) : t('Lists')}
+      eyebrow={t('Shared with the whole family')}
+      action={
+        <button
+          type="button"
+          onClick={() => void newList()}
+          className="rounded-lg border border-line bg-surface px-3 py-1.5 text-sm text-ink hover:bg-surface-2"
+        >
+          {t('New list')}
+        </button>
+      }
+    >
+      {lists.length > 1 && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {lists.map((l) => (
+            <button
+              key={l.id}
+              type="button"
+              onClick={() => setActiveId(l.id)}
+              className={`rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                l.id === activeId
+                  ? 'border-accent bg-accent-soft text-ink'
+                  : 'border-line bg-surface text-muted hover:bg-surface-2'
+              }`}
+            >
+              {listTitle(l.id, l.title)}
+              {l.open_items > 0 && <span className="ml-1.5 font-mono text-xs">{l.open_items}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="max-w-xl">
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onEnter(() => void addItem())}
+          placeholder={t('Add an item and press Enter')}
+          className="w-full rounded-card border border-line bg-surface px-4 py-3 text-base text-ink outline-none focus:border-accent"
+        />
+        {error && <p className="mt-2 text-sm text-urgent">{error}</p>}
+
+        {open.length === 0 && checked.length === 0 && pending.length === 0 ? (
+          <div className="mt-4">
+            <Empty>{t('Nothing here yet. Add the first item above.')}</Empty>
+          </div>
+        ) : (
+          <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
+            {pending.map((title, i) => (
+              <li key={`pending-${i}`} className="border-b border-line last:border-0">
+                <span className="flex items-center gap-3 px-4 py-3 text-muted">
+                  <span className="size-5 shrink-0 rounded border border-line" />
+                  {title}
+                </span>
+              </li>
+            ))}
+            {[...open, ...checked].map((item) => (
+              <li key={item.id} className="border-b border-line last:border-0">
+                <button
+                  type="button"
+                  onClick={() => void toggle(item)}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors active:bg-surface-2"
+                >
+                  <span
+                    className={`flex size-5 shrink-0 items-center justify-center rounded border ${
+                      item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
+                    }`}
+                  >
+                    {item.checked_at && (
+                      <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
+                        <path d="m5 13 4 4 10-10" />
+                      </svg>
+                    )}
+                  </span>
+                  <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>
+                    {item.title}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {checked.length > 0 && (
+          <button
+            type="button"
+            onClick={() => void clearChecked()}
+            className="mt-3 text-sm text-muted underline hover:text-ink"
+          >
+            {t('Clear checked ({n})', { n: String(checked.length) })}
+          </button>
+        )}
+      </div>
+    </Page>
+  );
+}


### PR DESCRIPTION
Closes #11.

The issue left the design open, and the comment on it pinned the priority: **speed on a phone**, with adding living next to the existing one-tap actions. Everything below follows from that.

## Why its own entity

- **not tasks** — a task carries status, priority, due date, assignee and recurrence, all meaningless for "milk", and shopping items would pollute task counts;
- **not a note view** — a note is one document, so checking an item rewrites the whole thing through the editor. Nothing about that is instant.

Here an add is one `INSERT`, a check is one `UPDATE` of one column, and the list arrives in a single request.

## Decisions worth reviewing

**No `owner_id`, on purpose.** Every other user-owned thing in this hub is private per person; a shared list is the opposite by definition — whoever is nearest the shop needs to see it. Since "no visibility check" normally means "someone forgot the guard", there is a test asserting one member sees what another added, and the migration says why in a comment.

**Checked items are not deleted.** They sink to the bottom, struck through. That is what the issue's "auto-clear" actually asks for: the list reads clean without rows vanishing behind the family's back, and what was just bought stays visible on the walk home. `Clear checked` removes the pile in one action.

**Items are plain text** — no quantity, no assignee, no date. Every field added is a field to fill in while standing in a shop. Duplicates are kept: two "milk" is two bottles, and a dedupe check would surprise at the worst moment.

**Placement.** Lists sit in the secondary nav row, because the phone's bottom bar is already `grid-cols-6` and a seventh entry would cramp it. The fast path is the **fourth one-tap action** on the phone home screen, which lands straight in the input.

## Verified in a browser, not only in tests

Ran a disposable instance: adding by Enter keeps focus for the next item, tapping a row checks it and moves it down, `Clear checked` empties the pile, and the four quick actions fit a 375px viewport without wrapping. One thing worth recording — my first "Enter does nothing" was the test harness sending `Return` rather than `Enter`, not a bug in the page.

## Testing

10 new tests covering the semantics rather than CRUD: the seeded list, sharing between members, duplicates, append order, sinking on check, unchecking, `clear-checked` counts, the index counters, cascade on list delete, and the refusals. Migration 025 smoke-run on a fresh `:memory:` database — 25 migrations, one seeded list, `integrity_check ok`. Suite 242 (184 server + 58 web), typecheck and lint clean.

Two React lint rules shaped the optimistic rendering: a fake row id needs a counter, and every way to hold one in an event path (a ref, a module variable, `Date.now()`) is something `react-hooks` correctly refuses. Pending items are kept as plain titles instead — not interactive, replaced by the reload.

Docs updated in the same pass: `README.md` feature line and a `docs/features.md` section.