### PR TITLE
feat: subscribe to the family calendar from a calendar app

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -138,6 +138,14 @@ Everything the household owns leaves in one file whenever it wants: Settings →
 
 On the hosted service the same section holds **Delete everything**: the administrator confirms with the password, a two-factor code when one is set, and by typing the family's own address, after which the database and the attachments are gone and the encrypted nightly backups expire on their own within a fortnight. A self-hosted install gets the export but no such button — there, deleting the only family means erasing the instance, and that belongs to whoever owns the machine.
 
+### In your own calendar app
+
+The family calendar can be subscribed to from Apple Calendar, Google Calendar or Outlook: **Settings → Subscribe in your calendar** issues a read-only link, and the calendar shows up next to the work one on a phone.
+
+Three properties are worth knowing. The link is **per person**, not per family — calendars can be private, so a feed shows exactly what its owner is allowed to see and nothing more. It is **read-only by construction**: there is no write path behind that URL, so the hub is not a CalDAV server and cannot be edited from outside. And it is **revocable in one click**, which is the safety story for an address that lives in someone else's app: revoke it and every subscribed device goes dark at once.
+
+Times travel as local wall-clock, unconverted — a 9am school run stays 9am in whatever zone the reading device is in, which is the same convention the hub uses everywhere. Repeating events travel as their rule, so a weekly event is one entry that the calendar app expands, not fifty copies.
+
 ## Lists
 
 The shopping list, and whatever else the household keeps as a list. Shared with everyone by default — a list nobody else can see would defeat the point, so this is the one user-owned thing in the hub with no per-person visibility.

--- a/server/src/db/migrations/026_calendar_feed.sql
+++ b/server/src/db/migrations/026_calendar_feed.sql
@@ -1,0 +1,16 @@
+-- A subscribe-by-URL token for the calendar (#29 in part).
+--
+-- Lets a phone add the family calendar next to the work one: Apple,
+-- Google and Outlook all subscribe to an ICS URL, so the family gets its
+-- events where it already looks without the hub becoming a CalDAV server.
+--
+-- Per user, not per family: calendars can be private (calendars.shared),
+-- so a feed has to show exactly what its owner is allowed to see. One
+-- token per person, revocable, and the feed is read-only by construction.
+--
+-- Stored in plaintext, like the wishlist token (021) and for the same
+-- reason: this link is long-lived and meant to be re-shown — pasted into
+-- a second device a month later. Hashing it would make it unrecoverable
+-- after the dialog closes, and revoke-and-recreate is not a substitute
+-- for "show me the link again".
+ALTER TABLE users ADD COLUMN calendar_feed_token TEXT;

--- a/server/src/lib/auth.public-surface.test.ts
+++ b/server/src/lib/auth.public-surface.test.ts
@@ -54,12 +54,21 @@ describe('public API surface', () => {
     expect(paths).toEqual([...PUBLIC_SNAPSHOT].sort());
   });
 
-  it('exempts exactly one path prefix, the public wishlist', () => {
-    // A prefix exemption is broader than a path and deserves louder review:
-    // '/api/wishlist/' opens a whole subtree by design (token-addressed).
+  it('exempts only the token-addressed subtrees', () => {
+    /*
+      A prefix exemption is broader than a path and deserves louder review.
+      Both entries here are the same shape: an unguessable token in the
+      path, read-only, addressing one person's data — the public wishlist
+      and the calendar subscription feed. Anything else appearing in this
+      list is a subtree opened to the internet, which is the point of
+      failing here.
+    */
     const fn = source.slice(source.indexOf('export async function authenticate'));
     const prefixes = [...fn.matchAll(/startsWith\('(\/api[^']*)'\)/g)].map((m) => m[1]!);
-    expect(prefixes.filter((p) => p !== '/api')).toEqual(['/api/wishlist/']);
+    expect(prefixes.filter((p) => p !== '/api').sort()).toEqual([
+      '/api/calendar/feed/',
+      '/api/wishlist/',
+    ]);
   });
 
   it('still refuses an anonymous request to a route outside the list', async () => {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -153,6 +153,15 @@ export async function authenticate(req: FastifyRequest, reply: FastifyReply): Pr
   // a login-strength rate limit. Everything under this prefix is designed
   // for strangers; nothing else is.
   if (path.startsWith('/api/wishlist/')) return;
+  /*
+    The calendar subscription feed. Same shape as the wishlist: an
+    unguessable token in the path, addressing one person's view, read-only
+    by construction. A calendar app has no session to present — and the
+    sibling endpoints that create and revoke the token (/api/calendar/feed
+    with no trailing segment) stay behind auth, which is why this prefix
+    ends in a slash.
+  */
+  if (path.startsWith('/api/calendar/feed/')) return;
 
   const token = req.cookies[SESSION_COOKIE];
   const user = token ? userForToken(token) : null;

--- a/server/src/lib/ics.test.ts
+++ b/server/src/lib/ics.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { buildCalendarFeed, type FeedEvent } from './ics.js';
+
+/*
+  The feed is read by Apple, Google and Outlook, none of which we can
+  test against here — so the tests pin the parts of RFC 5545 that those
+  clients are strict about, and the one project-specific decision:
+  local wall-clock times travel as floating time, never converted to UTC.
+*/
+
+const AT = new Date('2026-08-26T08:00:00Z');
+
+function event(over: Partial<FeedEvent> = {}): FeedEvent {
+  return {
+    id: 'e1',
+    title: 'School run',
+    description: null,
+    location: null,
+    starts_at: '2026-08-20T09:00',
+    ends_at: '2026-08-20T09:30',
+    all_day: 0,
+    recurrence_rule: null,
+    ...over,
+  };
+}
+
+const lines = (ics: string) => ics.split('\r\n');
+
+describe('buildCalendarFeed', () => {
+  it('wraps events in a valid calendar envelope', () => {
+    const out = lines(buildCalendarFeed('Family', [event()], AT));
+    expect(out[0]).toBe('BEGIN:VCALENDAR');
+    expect(out).toContain('VERSION:2.0');
+    expect(out).toContain('X-WR-CALNAME:Family');
+    expect(out).toContain('BEGIN:VEVENT');
+    expect(out).toContain('END:VEVENT');
+    expect(out.at(-2)).toBe('END:VCALENDAR');
+    // CRLF endings, including the final one (§3.1)
+    expect(buildCalendarFeed('Family', [], AT).endsWith('\r\n')).toBe(true);
+  });
+
+  it('sends a timed event as floating local time, not UTC', () => {
+    const out = lines(buildCalendarFeed('Family', [event()], AT));
+    // 09:00 stays 09:00 in the reader's zone — the hub never recorded a
+    // zone, so inventing one here would move the event
+    expect(out).toContain('DTSTART:20260820T090000');
+    expect(out).toContain('DTEND:20260820T093000');
+    expect(out.some((l) => /^DTSTART.*Z$/.test(l))).toBe(false);
+  });
+
+  it('sends an all-day event as a date, with the exclusive end', () => {
+    const out = lines(
+      buildCalendarFeed(
+        'Family',
+        [event({ all_day: 1, starts_at: '2026-08-20', ends_at: '2026-08-20' })],
+        AT,
+      ),
+    );
+    expect(out).toContain('DTSTART;VALUE=DATE:20260820');
+    // DTEND is exclusive: a one-day event ends on the 21st
+    expect(out).toContain('DTEND;VALUE=DATE:20260821');
+  });
+
+  it('crosses a month boundary correctly for all-day events', () => {
+    const out = lines(
+      buildCalendarFeed(
+        'Family',
+        [event({ all_day: 1, starts_at: '2026-08-31', ends_at: '2026-08-31' })],
+        AT,
+      ),
+    );
+    expect(out).toContain('DTEND;VALUE=DATE:20260901');
+  });
+
+  it('passes the stored recurrence rule through as RRULE', () => {
+    const out = lines(buildCalendarFeed('Family', [event({ recurrence_rule: 'FREQ=WEEKLY;INTERVAL=2' })], AT));
+    // The hub stores a subset of RFC 5545, so it is already valid here —
+    // and the client expands it, instead of us shipping hundreds of copies
+    expect(out).toContain('RRULE:FREQ=WEEKLY;INTERVAL=2');
+  });
+
+  it('escapes the characters that would otherwise break a line', () => {
+    const out = buildCalendarFeed(
+      'Family',
+      [event({ title: 'Dentist; bring card, please', description: 'Line one\nline two \\ done' })],
+      AT,
+    );
+    // Both are escaped in the output: "\;" and "\," — note that writing
+    // '\;' in a JS string would be a plain semicolon, which is the trap
+    // this expectation fell into first time round.
+    expect(out).toContain('SUMMARY:Dentist\\; bring card\\, please');
+    expect(out).toContain('DESCRIPTION:Line one\\nline two \\\\ done');
+  });
+
+  it('folds long lines and keeps continuations marked', () => {
+    const long = 'A'.repeat(200);
+    const out = lines(buildCalendarFeed('Family', [event({ description: long })], AT));
+    const folded = out.filter((l) => l.startsWith(' '));
+    expect(folded.length).toBeGreaterThan(0);
+    // No line exceeds the 75-octet limit
+    expect(out.every((l) => Buffer.byteLength(l, 'utf8') <= 75)).toBe(true);
+  });
+
+  it('gives every event a stable uid, so a re-poll updates instead of duplicating', () => {
+    const first = buildCalendarFeed('Family', [event()], AT);
+    const later = buildCalendarFeed('Family', [event()], new Date('2026-09-01T08:00:00Z'));
+    expect(first).toContain('UID:e1@neiliro');
+    expect(later).toContain('UID:e1@neiliro');
+  });
+});

--- a/server/src/lib/ics.test.ts
+++ b/server/src/lib/ics.test.ts
@@ -101,6 +101,33 @@ describe('buildCalendarFeed', () => {
     expect(out.every((l) => Buffer.byteLength(l, 'utf8') <= 75)).toBe(true);
   });
 
+  it('reports LAST-MODIFIED so a client can tell an edit from a re-arrival', () => {
+    // Both storage shapes appear in practice: SQLite's column default and
+    // an ISO string from application code. Both are UTC.
+    const sqliteShape = lines(buildCalendarFeed('Family', [event({ updated_at: '2026-08-25 14:30:00' })], AT));
+    expect(sqliteShape).toContain('LAST-MODIFIED:20260825T143000Z');
+
+    const isoShape = lines(buildCalendarFeed('Family', [event({ updated_at: '2026-08-25T14:30:00.000Z' })], AT));
+    expect(isoShape).toContain('LAST-MODIFIED:20260825T143000Z');
+  });
+
+  it('omits LAST-MODIFIED rather than inventing one', () => {
+    const out = lines(buildCalendarFeed('Family', [event({ updated_at: null })], AT));
+    expect(out.some((l) => l.startsWith('LAST-MODIFIED'))).toBe(false);
+    // And a value that cannot be parsed is dropped, not passed through:
+    // a malformed date makes some clients discard the whole event
+    const bad = lines(buildCalendarFeed('Family', [event({ updated_at: 'not a date' })], AT));
+    expect(bad.some((l) => l.startsWith('LAST-MODIFIED'))).toBe(false);
+    expect(bad).toContain('SUMMARY:School run');
+  });
+
+  it('never sends SEQUENCE, which it has no counter to back', () => {
+    const out = lines(buildCalendarFeed('Family', [event({ updated_at: '2026-08-25 14:30:00' })], AT));
+    // A fabricated sequence that ever went backwards would make clients
+    // ignore genuine updates
+    expect(out.some((l) => l.startsWith('SEQUENCE'))).toBe(false);
+  });
+
   it('gives every event a stable uid, so a re-poll updates instead of duplicating', () => {
     const first = buildCalendarFeed('Family', [event()], AT);
     const later = buildCalendarFeed('Family', [event()], new Date('2026-09-01T08:00:00Z'));

--- a/server/src/lib/ics.ts
+++ b/server/src/lib/ics.ts
@@ -1,0 +1,123 @@
+/*
+  iCalendar (RFC 5545) output for the subscribe-by-URL feed.
+
+  Written by hand rather than pulled in as a dependency: the subset we
+  need is small, and the project keeps its dependency list short on
+  purpose.
+
+  The important decision is time. Events are stored as local wall-clock
+  strings ("2026-08-20T10:00") because that is what this hub means by a
+  time — the same convention as everywhere else in the codebase. In
+  iCalendar that is *floating* time: a DTSTART with no zone and no Z,
+  which every client interprets in the device's own zone. So a 9am school
+  run stays 9am, which is the honest translation of what the family typed.
+  Converting to UTC here would invent a timezone the hub never recorded.
+*/
+
+export interface FeedEvent {
+  id: string;
+  title: string;
+  description: string | null;
+  location: string | null;
+  /** Local wall-clock: "2026-08-20T10:00", or "2026-08-20" for all-day */
+  starts_at: string;
+  ends_at: string;
+  all_day: number;
+  /** RRULE subset as stored: "FREQ=WEEKLY;INTERVAL=2" */
+  recurrence_rule: string | null;
+}
+
+/** Text escaping per RFC 5545 §3.3.11. */
+function esc(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n');
+}
+
+/** "2026-08-20T10:00" -> "20260820T100000"; "2026-08-20" -> "20260820". */
+function stamp(value: string): string {
+  const compact = value.replace(/[-:]/g, '');
+  // Seconds are appended with a function replacement on purpose: "T$100"
+  // in a string replacement reads as group 10, not group 1 plus "00".
+  return compact.replace(/T(\d{4})$/, (_, hhmm: string) => `T${hhmm}00`);
+}
+
+/** All-day DTEND is exclusive, so the last day needs one added. */
+function dayAfter(date: string): string {
+  const [y, m, d] = date.split('-').map(Number);
+  const next = new Date(Date.UTC(y!, m! - 1, d!) + 24 * 60 * 60 * 1000);
+  return next.toISOString().slice(0, 10);
+}
+
+/*
+  Lines are folded at 75 octets (§3.1). Clients are mostly forgiving, but
+  a long DESCRIPTION is exactly where the unforgiving ones break, and
+  that is the field a family fills with detail.
+*/
+function fold(line: string): string {
+  if (Buffer.byteLength(line, 'utf8') <= 75) return line;
+  const out: string[] = [];
+  let current = '';
+  for (const char of line) {
+    // Continuation lines carry a leading space, so they hold one octet less
+    const limit = out.length === 0 ? 75 : 74;
+    if (Buffer.byteLength(current + char, 'utf8') > limit) {
+      out.push(current);
+      current = char;
+    } else {
+      current += char;
+    }
+  }
+  out.push(current);
+  return out.join('\r\n ');
+}
+
+export function buildCalendarFeed(
+  calendarName: string,
+  events: FeedEvent[],
+  generatedAt: Date,
+): string {
+  const utc = (d: Date) => `${d.toISOString().replace(/[-:]/g, '').slice(0, 15)}Z`;
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Neiliro//Family hub//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    `X-WR-CALNAME:${esc(calendarName)}`,
+    // A hint for how often to re-poll; clients treat it as advice
+    'X-PUBLISHED-TTL:PT1H',
+    'REFRESH-INTERVAL;VALUE=DURATION:PT1H',
+  ];
+
+  for (const event of events) {
+    lines.push('BEGIN:VEVENT');
+    // Stable across regenerations: a client updates the event it already
+    // has instead of creating a duplicate
+    lines.push(`UID:${event.id}@neiliro`);
+    lines.push(`DTSTAMP:${utc(generatedAt)}`);
+    if (event.all_day) {
+      lines.push(`DTSTART;VALUE=DATE:${stamp(event.starts_at.slice(0, 10))}`);
+      lines.push(`DTEND;VALUE=DATE:${stamp(dayAfter(event.ends_at.slice(0, 10)))}`);
+    } else {
+      lines.push(`DTSTART:${stamp(event.starts_at)}`);
+      lines.push(`DTEND:${stamp(event.ends_at)}`);
+    }
+    lines.push(`SUMMARY:${esc(event.title)}`);
+    if (event.description) lines.push(`DESCRIPTION:${esc(event.description)}`);
+    if (event.location) lines.push(`LOCATION:${esc(event.location)}`);
+    /*
+      The stored rule is already a valid RRULE — the hub keeps a subset of
+      RFC 5545 (FREQ plus INTERVAL), so it travels as-is and the client
+      expands it. Expanding here instead would mean choosing a window and
+      re-sending hundreds of copies of the same weekly event.
+    */
+    if (event.recurrence_rule) lines.push(`RRULE:${event.recurrence_rule}`);
+    lines.push('END:VEVENT');
+  }
+
+  lines.push('END:VCALENDAR');
+  return lines.map(fold).join('\r\n') + '\r\n';
+}

--- a/server/src/lib/ics.ts
+++ b/server/src/lib/ics.ts
@@ -25,6 +25,8 @@ export interface FeedEvent {
   all_day: number;
   /** RRULE subset as stored: "FREQ=WEEKLY;INTERVAL=2" */
   recurrence_rule: string | null;
+  /** When the row last changed, for LAST-MODIFIED. UTC, as the column stores it. */
+  updated_at?: string | null;
 }
 
 /** Text escaping per RFC 5545 §3.3.11. */
@@ -42,6 +44,18 @@ function stamp(value: string): string {
   // Seconds are appended with a function replacement on purpose: "T$100"
   // in a string replacement reads as group 10, not group 1 plus "00".
   return compact.replace(/T(\d{4})$/, (_, hhmm: string) => `T${hhmm}00`);
+}
+
+/*
+  updated_at reaches us in one of two shapes: SQLite's own
+  "2026-08-26 08:00:00" from the column default, or an ISO string when the
+  row was written by application code. Both are UTC; neither is worth a
+  migration to unify, so this normalises instead of assuming.
+*/
+function utcStamp(value: string): string | null {
+  const parsed = new Date(/[TZ]/.test(value) ? value : `${value.replace(' ', 'T')}Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return `${parsed.toISOString().replace(/[-:]/g, '').slice(0, 15)}Z`;
 }
 
 /** All-day DTEND is exclusive, so the last day needs one added. */
@@ -115,6 +129,16 @@ export function buildCalendarFeed(
       re-sending hundreds of copies of the same weekly event.
     */
     if (event.recurrence_rule) lines.push(`RRULE:${event.recurrence_rule}`);
+    /*
+      How a client knows the event changed rather than just re-arrived.
+      SEQUENCE is deliberately not sent: it has to increase on every edit,
+      and the hub keeps no revision counter — a fabricated one that ever
+      went backwards would make clients ignore real updates. For a
+      PUBLISH-method subscription LAST-MODIFIED is what clients actually
+      compare.
+    */
+    const modified = event.updated_at ? utcStamp(event.updated_at) : null;
+    if (modified) lines.push(`LAST-MODIFIED:${modified}`);
     lines.push('END:VEVENT');
   }
 

--- a/server/src/routes/calendar-feed.test.ts
+++ b/server/src/routes/calendar-feed.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+
+/*
+  The subscribe-by-URL calendar feed.
+
+  It is the second thing in this hub reachable without a session, so the
+  interesting tests are not "does it produce ICS" (lib/ics.test.ts covers
+  the format) but who can see what through it: the token addresses one
+  person's view, and a private calendar belonging to someone else must not
+  leak into it. A leak here would be silent — the feed lives in a phone,
+  where nobody reads it as a security surface.
+*/
+
+let h: Harness;
+let alice: { userId: string; cookie: string };
+let bob: { userId: string; cookie: string };
+
+beforeAll(async () => {
+  h = await buildTestApp();
+  alice = h.join('Alice');
+  bob = h.join('Bob');
+});
+
+async function tokenFor(cookie: string): Promise<string> {
+  const res = await h.as(cookie, 'POST', '/api/calendar/feed', {});
+  expect(res.statusCode).toBe(200);
+  return res.json<{ token: string }>().token;
+}
+
+/** The feed as an anonymous client — a calendar app has no session. */
+async function feed(token: string) {
+  return h.app.inject({ url: `/api/calendar/feed/${token}` });
+}
+
+async function makeCalendar(cookie: string, name: string, shared: boolean) {
+  const res = await h.as(cookie, 'POST', '/api/calendars', { name, shared });
+  expect(res.statusCode).toBeLessThan(300);
+  return res.json<{ id: string }>().id;
+}
+
+async function makeEvent(cookie: string, calendarId: string, title: string) {
+  const res = await h.as(cookie, 'POST', '/api/events', {
+    calendar_id: calendarId,
+    title,
+    starts_at: '2026-08-20T09:00',
+    ends_at: '2026-08-20T09:30',
+  });
+  expect(res.statusCode).toBeLessThan(300);
+  return res.json<{ id: string }>().id;
+}
+
+describe('calendar feed', () => {
+  it('serves ICS to a client with no session', async () => {
+    const shared = await makeCalendar(alice.cookie, 'Family things', true);
+    await makeEvent(alice.cookie, shared, 'Dentist');
+
+    const res = await feed(await tokenFor(alice.cookie));
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/calendar');
+    expect(res.body).toContain('BEGIN:VCALENDAR');
+    expect(res.body).toContain('SUMMARY:Dentist');
+  });
+
+  it('accepts the .ics suffix calendar apps like to append', async () => {
+    const token = await tokenFor(alice.cookie);
+    const res = await h.app.inject({ url: `/api/calendar/feed/${token}.ics` });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('BEGIN:VCALENDAR');
+  });
+
+  it("never leaks another person's private calendar", async () => {
+    const secret = await makeCalendar(bob.cookie, "Bob's therapy", false);
+    await makeEvent(bob.cookie, secret, 'Appointment');
+
+    // Alice's feed is Alice's view: shared calendars plus her own private ones
+    const res = await feed(await tokenFor(alice.cookie));
+    expect(res.body).toContain('SUMMARY:Dentist');
+    expect(res.body).not.toContain('Appointment');
+
+    // And Bob's own feed does show it — the filter is per viewer, not a blanket hide
+    const bobFeed = await feed(await tokenFor(bob.cookie));
+    expect(bobFeed.body).toContain('SUMMARY:Appointment');
+  });
+
+  it('hands back the same token when asked twice, so the link can be re-shown', async () => {
+    const first = await tokenFor(alice.cookie);
+    const second = await tokenFor(alice.cookie);
+    expect(second).toBe(first);
+
+    const shown = await h.as(alice.cookie, 'GET', '/api/calendar/feed');
+    expect(shown.json<{ token: string | null }>().token).toBe(first);
+  });
+
+  it('stops serving once revoked', async () => {
+    const token = await tokenFor(alice.cookie);
+    expect((await feed(token)).statusCode).toBe(200);
+
+    expect((await h.as(alice.cookie, 'DELETE', '/api/calendar/feed')).statusCode).toBe(200);
+    // Every subscribed device goes dark, which is the whole safety story
+    expect((await feed(token)).statusCode).toBe(404);
+    expect(
+      (await h.as(alice.cookie, 'GET', '/api/calendar/feed')).json<{ token: string | null }>().token,
+    ).toBeNull();
+  });
+
+  it('answers an unknown token with 404, not 401', async () => {
+    // There is nothing to sign in to, and a missing unguessable URL should
+    // look like any other missing page
+    expect((await feed('definitely-not-a-real-token')).statusCode).toBe(404);
+  });
+});

--- a/server/src/routes/calendar.ts
+++ b/server/src/routes/calendar.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import { randomBytes } from 'node:crypto';
 import { db, id, now } from '../db/index.js';
+import { buildCalendarFeed, type FeedEvent } from '../lib/ics.js';
 import { expandOccurrences, isValidRecurrence } from '../lib/recurrence.js';
 import { daysBetween, shiftDays } from '../lib/dates.js';
 
@@ -482,5 +484,85 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
       'INSERT OR IGNORE INTO event_exceptions (event_id, excluded_date) VALUES (?, ?)',
     ).run(eventId, date);
     return { ok: true };
+  });
+
+  /*
+    Subscribe-by-URL feed (#29 in part). Apple, Google and Outlook all
+    subscribe to an ICS URL, so this puts the family calendar next to the
+    work one on a phone without the hub having to become a CalDAV server.
+
+    The token addresses one person's view: calendars can be private, so
+    the feed shows exactly what its owner may see and nothing else. It is
+    read-only by construction — there is no write path here at all.
+  */
+
+  app.get('/api/calendar/feed', (req) => {
+    const row = db
+      .prepare('SELECT calendar_feed_token AS token FROM users WHERE id = ?')
+      .get(req.user!.id) as { token: string | null };
+    // Returned in the clear, deliberately: the point of this link is to be
+    // re-shown when a second device needs it (same reasoning as the
+    // wishlist token, migration 021).
+    return { token: row.token };
+  });
+
+  app.post('/api/calendar/feed', (req) => {
+    const existing = db
+      .prepare('SELECT calendar_feed_token AS token FROM users WHERE id = ?')
+      .get(req.user!.id) as { token: string | null };
+    if (existing.token) return { token: existing.token };
+
+    const token = randomBytes(24).toString('base64url');
+    db.prepare('UPDATE users SET calendar_feed_token = ? WHERE id = ?').run(token, req.user!.id);
+    return { token };
+  });
+
+  app.delete('/api/calendar/feed', (req) => {
+    // Revoking is the whole safety story for a link that lives in someone
+    // else's calendar app: every subscribed device stops getting data.
+    db.prepare('UPDATE users SET calendar_feed_token = NULL WHERE id = ?').run(req.user!.id);
+    return { ok: true };
+  });
+
+  app.get('/api/calendar/feed/:token', (req, reply) => {
+    // Clients like a .ics suffix; the token is the part before it
+    const raw = (req.params as { token: string }).token;
+    const token = raw.replace(/\.ics$/, '');
+
+    const user = db
+      .prepare('SELECT id FROM users WHERE calendar_feed_token = ? AND disabled_at IS NULL')
+      .get(token) as { id: string } | undefined;
+    // 404 rather than 401: an unguessable URL that does not exist should
+    // look like any other missing page, and there is nothing to log in to
+    if (!user) return reply.code(404).send({ error: 'Not found' });
+
+    /*
+      One-off events from a year back plus everything ahead; repeating
+      events always, since their rule travels as RRULE and the client
+      expands it. A year of history is what makes the calendar look
+      populated when it is first added, without shipping the archive.
+    */
+    const cutoff = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const events = db
+      .prepare(
+        `SELECT e.id, e.title, e.description, e.location, e.starts_at, e.ends_at,
+                e.all_day, e.recurrence_rule
+           FROM events e
+           JOIN calendars c ON c.id = e.calendar_id
+          WHERE ${CALENDAR_VISIBLE}
+            AND (e.recurrence_rule IS NOT NULL OR e.ends_at >= ?)
+          ORDER BY e.starts_at`,
+      )
+      .all(user.id, cutoff) as FeedEvent[];
+
+    const home = db
+      .prepare("SELECT value FROM settings WHERE key = 'home.name'")
+      .get() as { value: string } | undefined;
+
+    return reply
+      .type('text/calendar; charset=utf-8')
+      // Clients re-poll on their own schedule; nothing here is worth caching
+      .header('cache-control', 'no-store')
+      .send(buildCalendarFeed(home?.value?.trim() || 'Neiliro', events, new Date()));
   });
 }

--- a/server/src/routes/calendar.ts
+++ b/server/src/routes/calendar.ts
@@ -546,7 +546,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
     const events = db
       .prepare(
         `SELECT e.id, e.title, e.description, e.location, e.starts_at, e.ends_at,
-                e.all_day, e.recurrence_rule
+                e.all_day, e.recurrence_rule, e.updated_at
            FROM events e
            JOIN calendars c ON c.id = e.calendar_id
           WHERE ${CALENDAR_VISIBLE}

--- a/server/src/routes/email-verify 2.ts
+++ b/server/src/routes/email-verify 2.ts
@@ -1,0 +1,141 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { db, id, now } from '../db/index.js';
+import { env } from '../env.js';
+import { log } from '../lib/log.js';
+import { sendServiceEmail, serviceMailAvailable } from '../lib/mail.js';
+
+/*
+  Confirming that a person owns the address they sign in with.
+
+  The login has always been an address in shape only — nothing checked
+  ownership, and self-hosted installs legitimately use fictional ones. That
+  was fine while the address was just an identifier. It stopped being fine
+  when a forgotten password could be recovered through it: a typo at signup
+  would mail a working reset link to a stranger, and that stranger would be
+  one click from a family's data.
+
+  So this exists wherever the reset exists — hosted, with service mail
+  configured — and nowhere else. On a self-hosted hub an address is an
+  identifier again, and asking someone to prove a mailbox they invented on
+  purpose would be theatre.
+*/
+
+const VERIFY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function hashVerifyToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+/** Whether this process can ask anyone to confirm an address. */
+export function emailVerificationAvailable(): boolean {
+  return env.hostedMode && serviceMailAvailable();
+}
+
+/**
+ * Issue a confirmation link and mail it. Safe to call for any user: it is
+ * a no-op when the feature is off, so callers (signup, invite) do not need
+ * to know which mode they are in.
+ */
+export async function sendVerificationEmail(userId: string): Promise<void> {
+  if (!emailVerificationAvailable()) return;
+  try {
+    const user = db
+      .prepare('SELECT email, name, email_verified_at FROM users WHERE id = ?')
+      .get(userId) as { email: string; name: string; email_verified_at: string | null } | undefined;
+    if (!user || user.email_verified_at) return;
+
+    const token = randomBytes(32).toString('base64url');
+    db.transaction(() => {
+      // One live link per person: the newest request is the one they hold
+      db.prepare('DELETE FROM email_verifications WHERE user_id = ? AND used_at IS NULL').run(userId);
+      db.prepare(
+        `INSERT INTO email_verifications (id, user_id, email, token_hash, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(
+        id(),
+        userId,
+        user.email,
+        hashVerifyToken(token),
+        now(),
+        new Date(Date.now() + VERIFY_TTL_MS).toISOString(),
+      );
+    })();
+
+    // The host is the family's own subdomain: the link only has to work in
+    // a browser, and the session it may create belongs to that host.
+    const url = `${env.publicUrl || `https://${env.hostedDomain}`}/verify-email?token=${token}`;
+    await sendServiceEmail(
+      user.email,
+      'Confirm your Neiliro address',
+      [
+        `Hello, ${user.name}.`,
+        '',
+        'Confirm this address so it can be used to recover your account if',
+        'you ever forget your password:',
+        '',
+        url,
+        '',
+        'The link works for a week. Until it is used, password recovery by',
+        'email stays unavailable for this account — which is deliberate: an',
+        'unconfirmed address is not proof of anything.',
+      ].join('\n'),
+    );
+  } catch (err) {
+    // Never fails the flow that triggered it — signing up must not break
+    // because a mail provider hiccuped.
+    log.error('email verification: could not send the link', err);
+  }
+}
+
+export async function registerEmailVerifyRoutes(app: FastifyInstance): Promise<void> {
+  if (!emailVerificationAvailable()) return;
+
+  const strictRate = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
+
+  /*
+    Public on purpose: the link is opened wherever the mail was read, which
+    is often another browser with no session. The token is the
+    authorization, and it proves exactly one thing — that whoever holds it
+    reads that mailbox.
+  */
+  app.post('/api/auth/email-verify', strictRate, (req, reply) => {
+    const parsed = z.object({ token: z.string().min(1).max(200) }).safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'This link is not valid' });
+
+    const row = db
+      .prepare(
+        'SELECT id, user_id, email, expires_at, used_at FROM email_verifications WHERE token_hash = ?',
+      )
+      .get(hashVerifyToken(parsed.data.token)) as
+      | { id: string; user_id: string; email: string; expires_at: string; used_at: string | null }
+      | undefined;
+    if (!row || row.used_at || row.expires_at <= new Date().toISOString()) {
+      return reply.code(400).send({ error: 'This link has expired — request a new one' });
+    }
+
+    const user = db.prepare('SELECT email FROM users WHERE id = ?').get(row.user_id) as
+      | { email: string }
+      | undefined;
+    // The address moved since the link was issued: confirming the old one
+    // would mark the new one verified without anyone proving it.
+    if (!user || user.email !== row.email) {
+      return reply.code(400).send({ error: 'This link is not valid' });
+    }
+
+    db.transaction(() => {
+      db.prepare('UPDATE users SET email_verified_at = ? WHERE id = ?').run(now(), row.user_id);
+      db.prepare('UPDATE email_verifications SET used_at = ? WHERE id = ?').run(now(), row.id);
+    })();
+    return { ok: true };
+  });
+
+  /** Send it again, to the address on the account. Requires a session. */
+  app.post('/api/profile/email-verify', strictRate, async (req) => {
+    await sendVerificationEmail(req.user!.id);
+    // Same answer whether or not a mail went out: an already-verified
+    // account and a fresh link are not worth distinguishing here.
+    return { ok: true };
+  });
+}

--- a/server/src/routes/email-verify.test 2.ts
+++ b/server/src/routes/email-verify.test 2.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+/*
+  Confirming the login address (routes/email-verify.ts).
+
+  This exists to make the hosted password reset safe. The login was always
+  an address in shape only — nothing proved ownership — and that was
+  harmless until a forgotten password could be recovered through it: a
+  typo at signup would mail a working reset link to a stranger, one click
+  from a family's data. So the reset is gated on a confirmation, and the
+  cases below are the ones that gate has to get right.
+*/
+process.env.HOSTED_MODE = 'true';
+process.env.HOSTED_DOMAIN = 'neiliro.test';
+process.env.MAIL_DOMAIN = 'mail.neiliro.test';
+process.env.MAILGUN_SIGNING_KEY = 'test-signing-key';
+process.env.MAILGUN_API_KEY = 'test-api-key';
+
+interface Sent {
+  to: string;
+  subject: string;
+  text: string;
+}
+const sent: Sent[] = [];
+
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async (_url: string, init: { body: FormData }) => {
+    const f = (k: string) => String(init.body.get(k) ?? '');
+    sent.push({ to: f('to'), subject: f('subject'), text: f('text') });
+    return { ok: true, status: 200, json: async () => ({ id: '<x@mail.neiliro.test>' }) };
+  }),
+);
+
+const tenants = await import('../lib/tenants.js');
+const { buildApp } = await import('../app.js');
+
+const SLUG = 'smiths-v1w2';
+const HOST = `${SLUG}.neiliro.test`;
+const ADMIN = 'sam@smiths-v1w2.test';
+const MEMBER = 'dana@smiths-v1w2.test';
+
+afterAll(() => {
+  for (const k of ['HOSTED_MODE', 'HOSTED_DOMAIN', 'MAIL_DOMAIN', 'MAILGUN_SIGNING_KEY', 'MAILGUN_API_KEY'])
+    delete process.env[k];
+  vi.unstubAllGlobals();
+  tenants.shutdownHosted();
+});
+
+let app: FastifyInstance;
+let adminCookie: string;
+let memberId: string;
+
+/** Wait for the detached mail, then take the token out of the last one. */
+async function lastToken(subject: string): Promise<string | null> {
+  await new Promise((r) => setTimeout(r, 60));
+  const mail = [...sent].reverse().find((m) => m.subject === subject);
+  if (!mail) return null;
+  return new URL(mail.text.match(/https:\/\/\S+/)![0]).searchParams.get('token');
+}
+
+function requestReset(email: string) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/auth/password-reset',
+    headers: { host: HOST },
+    payload: { email },
+  });
+}
+
+beforeAll(async () => {
+  tenants.initHosted();
+  tenants.createFamily(SLUG);
+  app = await buildApp();
+
+  const created = await app.inject({
+    method: 'POST',
+    url: '/api/auth/setup',
+    headers: { host: HOST },
+    payload: { name: 'Sam', email: ADMIN, password: 'correct horse battery' },
+  });
+  expect(created.statusCode).toBe(201);
+  adminCookie = `hub_session=${created.cookies.find((c) => c.name === 'hub_session')?.value}`;
+
+  // A second account, joined by invite and left unconfirmed on purpose
+  const invited = await app.inject({
+    method: 'POST',
+    url: '/api/invites',
+    headers: { host: HOST, cookie: adminCookie },
+    payload: { role: 'member' },
+  });
+  const token = (invited.json() as { path: string }).path.split('token=')[1]!;
+  const joined = await app.inject({
+    method: 'POST',
+    url: '/api/auth/join',
+    headers: { host: HOST },
+    payload: { token, name: 'Dana', email: MEMBER, password: 'correct horse battery' },
+  });
+  expect(joined.statusCode).toBe(201);
+
+  const users = await app.inject({ url: '/api/users', headers: { host: HOST, cookie: adminCookie } });
+  memberId = (users.json() as { id: string; email: string }[]).find((u) => u.email === MEMBER)!.id;
+  sent.length = 0;
+});
+
+describe('address confirmation', () => {
+  it('does not mail a reset to an address nobody confirmed', async () => {
+    // The whole reason this feature exists. Dana never opened a
+    // confirmation link, so her address is not proof of anything — and a
+    // typo'd one would belong to a stranger.
+    const before = sent.length;
+    expect((await requestReset(MEMBER)).statusCode).toBe(202);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(sent).toHaveLength(before);
+  });
+
+  it('confirms an address once, and the reset starts working', async () => {
+    // Ask for the link the way the prompt in the UI does
+    const asked = await app.inject({
+      method: 'POST',
+      url: '/api/profile/email-verify',
+      headers: { host: HOST, cookie: adminCookie },
+      payload: {},
+    });
+    expect(asked.statusCode).toBe(200);
+
+    const token = await lastToken('Confirm your Neiliro address');
+    expect(token).toBeTruthy();
+
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/api/auth/email-verify',
+      headers: { host: HOST },
+      payload: { token },
+    });
+    expect(ok.statusCode).toBe(200);
+
+    // Single use
+    const again = await app.inject({
+      method: 'POST',
+      url: '/api/auth/email-verify',
+      headers: { host: HOST },
+      payload: { token },
+    });
+    expect(again.statusCode).toBe(400);
+
+    // ...and now a reset does go out
+    sent.length = 0;
+    expect((await requestReset(ADMIN)).statusCode).toBe(202);
+    expect(await lastToken('Reset your Neiliro password')).toBeTruthy();
+  });
+
+  it('un-confirms the address when an administrator changes it', async () => {
+    // The proof belonged to the address, not to the account
+    sent.length = 0;
+    const moved = await app.inject({
+      method: 'POST',
+      url: `/api/users/${memberId}/email`,
+      headers: { host: HOST, cookie: adminCookie },
+      payload: { email: 'dana.fixed@smiths-v1w2.test' },
+    });
+    expect(moved.statusCode).toBe(200);
+    await new Promise((r) => setTimeout(r, 60));
+
+    // The new address arrives unconfirmed, with a confirmation waiting
+    expect(
+      sent.some(
+        (m) => m.to === 'dana.fixed@smiths-v1w2.test' && m.subject === 'Confirm your Neiliro address',
+      ),
+    ).toBe(true);
+
+    // ...and the old address is nobody's login any more
+    const beforeReset = sent.length;
+    expect((await requestReset(MEMBER)).statusCode).toBe(202);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(sent).toHaveLength(beforeReset);
+  });
+
+  it('refuses a stale confirmation issued for a previous address', async () => {
+    // The link mailed to dana.fixed in the previous case, still unopened
+    const stale = await lastToken('Confirm your Neiliro address');
+    expect(stale).toBeTruthy();
+
+    // Move again before the link is opened
+    await app.inject({
+      method: 'POST',
+      url: `/api/users/${memberId}/email`,
+      headers: { host: HOST, cookie: adminCookie },
+      payload: { email: 'dana.final@smiths-v1w2.test' },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/email-verify',
+      headers: { host: HOST },
+      payload: { token: stale },
+    });
+    // Confirming the old address must not mark the new one proven
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('refuses an address another member already uses', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/users/${memberId}/email`,
+      headers: { host: HOST, cookie: adminCookie },
+      payload: { email: ADMIN },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('lets only an administrator move an address', async () => {
+    const memberLogin = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      headers: { host: HOST },
+      payload: { email: 'dana.final@smiths-v1w2.test', password: 'correct horse battery' },
+    });
+    const cookie = `hub_session=${memberLogin.cookies.find((c) => c.name === 'hub_session')?.value}`;
+
+    // A stolen session must not be able to move the account to another
+    // mailbox and then "recover" it from there
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/users/${memberId}/email`,
+      headers: { host: HOST, cookie },
+      payload: { email: 'attacker@elsewhere.test' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/src/routes/password-reset 2.ts
+++ b/server/src/routes/password-reset 2.ts
@@ -1,0 +1,159 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { currentTenant, db, id, now } from '../db/index.js';
+import { env } from '../env.js';
+import { destroyAllSessions } from '../lib/auth.js';
+import { log } from '../lib/log.js';
+import { sendServiceEmail, serviceMailAvailable } from '../lib/mail.js';
+import { hashPassword } from '../lib/password.js';
+import { familySlug } from '../lib/tenants.js';
+
+/*
+  Password reset by email — hosted only, on purpose.
+
+  A self-hosted family owns its machine, so the recovery door is ssh plus
+  scripts/admin-reset.mjs: stronger than an email flow, and it needs no
+  mail server at all. Registering this route there would add an attack
+  surface to replace a door that is already better.
+
+  Two properties shape the code:
+
+  - **It never reveals whether a login exists.** The answer is the same
+    202 either way, and the mail is sent without awaiting it, so the reply
+    is not slower when there is a mailbox to write to. An endpoint that
+    said "no such user" would be an account oracle on a service whose
+    whole design refuses to confirm that a family exists.
+  - **A reset changes the password and nothing else.** The second factor
+    stays on — otherwise a mailbox would be a way around TOTP — and a
+    member who deliberately turned password sign-in off does not get it
+    turned back on behind their back.
+*/
+
+const RESET_TTL_MS = 60 * 60 * 1000;
+
+function hashResetToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+interface ResetRow {
+  id: string;
+  user_id: string;
+  expires_at: string;
+  used_at: string | null;
+}
+
+export async function registerPasswordResetRoutes(app: FastifyInstance): Promise<void> {
+  // Hosted only, and only when the service can actually send. Absent
+  // rather than answering "not configured": a route that exists but never
+  // works is a promise the login screen would keep making.
+  if (!env.hostedMode || !serviceMailAvailable()) return;
+
+  const strictRate = { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } };
+
+  app.post('/api/auth/password-reset', strictRate, (req, reply) => {
+    const parsed = z
+      .object({ email: z.string().trim().toLowerCase().email().max(120) })
+      .safeParse(req.body);
+    // Even a malformed address gets the neutral answer: the shape of the
+    // error would otherwise separate "not an address" from "not a user".
+    if (parsed.success) void issue(parsed.data.email);
+    return reply.code(202).send({ ok: true });
+  });
+
+  app.post('/api/auth/password-reset/confirm', strictRate, async (req, reply) => {
+    const parsed = z
+      .object({
+        token: z.string().min(1).max(200),
+        password: z.string().min(10, 'Password must be at least 10 characters').max(200),
+      })
+      .safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+
+    const row = db
+      .prepare('SELECT id, user_id, expires_at, used_at FROM password_resets WHERE token_hash = ?')
+      .get(hashResetToken(parsed.data.token)) as ResetRow | undefined;
+    if (!row || row.used_at || row.expires_at <= new Date().toISOString()) {
+      return reply.code(400).send({ error: 'This link has expired — request a new one' });
+    }
+
+    const passwordHash = await hashPassword(parsed.data.password);
+    db.transaction(() => {
+      db.prepare(
+        'UPDATE users SET password_hash = ?, must_change_password = 0 WHERE id = ?',
+      ).run(passwordHash, row.user_id);
+      db.prepare('UPDATE password_resets SET used_at = ? WHERE id = ?').run(now(), row.id);
+      // Every other unused link for this person dies with it
+      db.prepare('DELETE FROM password_resets WHERE user_id = ? AND used_at IS NULL').run(row.user_id);
+    })();
+
+    // Whoever held the old password loses their sessions — a reset is
+    // also how someone evicts an intruder.
+    destroyAllSessions(row.user_id);
+    log.info('password reset completed');
+    return reply.code(204).send();
+  });
+
+  /**
+   * Issue a link and mail it. Runs detached from the response, so a
+   * missing mailbox and a real one take the same time to answer.
+   */
+  async function issue(email: string): Promise<void> {
+    try {
+      const user = db
+        .prepare(
+          `SELECT id, name, password_login_disabled, email_verified_at
+             FROM users WHERE email = ?`,
+        )
+        .get(email) as
+        | { id: string; name: string; password_login_disabled: number; email_verified_at: string | null }
+        | undefined;
+
+      // Three reasons to stay silent, and silence is the same for all of
+      // them: no such login; one that deliberately has no password to
+      // reset; and — the load-bearing one — an address nobody ever proved
+      // they own. Mailing a reset to an unconfirmed address would turn a
+      // signup typo into a stranger's way into a family.
+      if (!user || user.password_login_disabled || !user.email_verified_at) return;
+
+      const { familyId } = currentTenant();
+      const slug = familyId ? familySlug(familyId) : null;
+      if (!slug) return; // the ghost, or a single-family install: nothing to link to
+
+      const token = randomBytes(32).toString('base64url');
+      const expires = new Date(Date.now() + RESET_TTL_MS).toISOString();
+      db.transaction(() => {
+        // One live link per person: a mailbox must never hold two working
+        // resets, and the newest request is the one the person remembers
+        db.prepare('DELETE FROM password_resets WHERE user_id = ? AND used_at IS NULL').run(user.id);
+        db.prepare(
+          `INSERT INTO password_resets (id, user_id, token_hash, created_at, expires_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run(id(), user.id, hashResetToken(token), now(), expires);
+      })();
+
+      const url = `https://${slug}.${env.hostedDomain}/reset?token=${token}`;
+      await sendServiceEmail(
+        email,
+        'Reset your Neiliro password',
+        [
+          `Hello, ${user.name}.`,
+          '',
+          'Someone asked to reset the password for this address. If it was you,',
+          'open the link below within the next hour:',
+          '',
+          url,
+          '',
+          'The link works once. If it was not you, ignore this message —',
+          'nothing has changed, and your current password still works.',
+        ].join('\n'),
+      );
+    } catch (err) {
+      // The requester is told nothing either way, so a failure here has to
+      // be visible to the operator or it is invisible entirely.
+      log.error('password reset: could not issue a link', err);
+    }
+  }
+}

--- a/server/src/routes/password-reset.self-hosted.test 2.ts
+++ b/server/src/routes/password-reset.self-hosted.test 2.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildTestApp } from '../test-harness.js';
+
+/*
+  The reset-by-email flow must not exist on a self-hosted hub.
+
+  Not "must refuse" — must not be there at all. The family that runs the
+  machine already has a stronger recovery door: ssh plus
+  scripts/admin-reset.mjs, which needs no mail provider and cannot be
+  reached from the internet. Shipping an email flow next to it would add
+  attack surface to replace a better door, and would quietly require every
+  self-hoster to run a mail service to make their login screen honest.
+
+  This file carries no hosted flags on purpose: it is the default install.
+*/
+
+describe('password reset on a self-hosted hub', () => {
+  it('is not registered at all', async () => {
+    const { app } = await buildTestApp();
+
+    for (const url of ['/api/auth/password-reset', '/api/auth/password-reset/confirm']) {
+      const res = await app.inject({ method: 'POST', url, payload: { email: 'sam@example.test' } });
+      expect(res.statusCode, url).toBe(404);
+    }
+  });
+
+  it('does not offer the link on the sign-in screen', async () => {
+    const { app } = await buildTestApp();
+    const state = await app.inject({ url: '/api/auth/state' });
+    // The frontend hides "forgot password?" on this flag, so a hub that
+    // cannot send must not claim it can
+    expect(state.json()).toMatchObject({ password_reset: false });
+  });
+});

--- a/server/src/routes/password-reset.test 2.ts
+++ b/server/src/routes/password-reset.test 2.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import type { FastifyInstance } from 'fastify';
+
+/*
+  Password reset by email — hosted only (routes/password-reset.ts).
+
+  The happy path matters least. What this flow must get right is what it
+  refuses to say and what it refuses to change: it never reveals whether a
+  login exists, it does not resurrect password sign-in for someone who
+  turned it off, and it leaves the second factor alone — otherwise a
+  mailbox becomes a way around TOTP.
+*/
+process.env.HOSTED_MODE = 'true';
+process.env.HOSTED_DOMAIN = 'neiliro.test';
+process.env.MAIL_DOMAIN = 'mail.neiliro.test';
+process.env.MAILGUN_SIGNING_KEY = 'test-signing-key';
+process.env.MAILGUN_API_KEY = 'test-api-key';
+
+interface Sent {
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+}
+const sent: Sent[] = [];
+
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async (_url: string, init: { body: FormData }) => {
+    const f = (k: string) => String(init.body.get(k) ?? '');
+    sent.push({ from: f('from'), to: f('to'), subject: f('subject'), text: f('text') });
+    return { ok: true, status: 200, json: async () => ({ id: '<sent@mail.neiliro.test>' }) };
+  }),
+);
+
+const tenants = await import('../lib/tenants.js');
+const { buildApp } = await import('../app.js');
+const { env } = await import('../env.js');
+
+const SLUG = 'smiths-r1s2';
+const HOST = `${SLUG}.neiliro.test`;
+const EMAIL = 'sam@smiths-r1s2.test';
+const OLD_PASSWORD = 'correct horse battery';
+
+afterAll(() => {
+  for (const k of ['HOSTED_MODE', 'HOSTED_DOMAIN', 'MAIL_DOMAIN', 'MAILGUN_SIGNING_KEY', 'MAILGUN_API_KEY'])
+    delete process.env[k];
+  vi.unstubAllGlobals();
+  tenants.shutdownHosted();
+});
+
+let app: FastifyInstance;
+let familyId: string;
+
+function familyDb() {
+  return new Database(join(env.dataDir, 'families', familyId, 'hub.db'));
+}
+
+/** Ask for a reset and return the token out of the emailed link. */
+async function requestReset(email = EMAIL): Promise<string | null> {
+  const before = sent.length;
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/auth/password-reset',
+    headers: { host: HOST },
+    payload: { email },
+  });
+  // Always 202, whatever the address
+  expect(res.statusCode).toBe(202);
+  // The mail is sent detached from the response; give it a tick
+  await new Promise((r) => setTimeout(r, 60));
+  if (sent.length === before) return null;
+  return new URL(sent[sent.length - 1]!.text.match(/https:\/\/\S+/)![0]).searchParams.get('token');
+}
+
+function signIn(password: string) {
+  return app.inject({
+    method: 'POST',
+    url: '/api/auth/login',
+    headers: { host: HOST },
+    payload: { email: EMAIL, password },
+  });
+}
+
+beforeAll(async () => {
+  tenants.initHosted();
+  familyId = tenants.createFamily(SLUG).familyId;
+  app = await buildApp();
+  const created = await app.inject({
+    method: 'POST',
+    url: '/api/auth/setup',
+    headers: { host: HOST },
+    payload: { name: 'Sam', email: EMAIL, password: OLD_PASSWORD },
+  });
+  expect(created.statusCode).toBe(201);
+
+  /*
+    Signing up now also mails a confirmation, and a reset is only ever sent
+    to a confirmed address — an unproven one would turn a signup typo into
+    a stranger's way into the family. Walk that flow rather than writing the
+    column: it is the same path a person takes, and it keeps this file
+    honest about the precondition.
+  */
+  await new Promise((r) => setTimeout(r, 60));
+  const invite = sent[sent.length - 1]!;
+  expect(invite.subject).toBe('Confirm your Neiliro address');
+  const verifyToken = new URL(invite.text.match(/https:\/\/\S+/)![0]).searchParams.get('token');
+  const confirmed = await app.inject({
+    method: 'POST',
+    url: '/api/auth/email-verify',
+    headers: { host: HOST },
+    payload: { token: verifyToken },
+  });
+  expect(confirmed.statusCode).toBe(200);
+  sent.length = 0;
+});
+
+describe('password reset', () => {
+  it('mails a single-use link from the service address, and the new password works', async () => {
+    const token = await requestReset();
+    expect(token).toBeTruthy();
+
+    const mail = sent[sent.length - 1]!;
+    // A service sender, not the family's own address: a reset notice in the
+    // shared family inbox would tell everyone that someone is recovering
+    expect(mail.from).toContain('<no-reply@mail.neiliro.test>');
+    expect(mail.to).toBe(EMAIL);
+    expect(mail.text).toContain(`https://${SLUG}.neiliro.test/reset?token=`);
+
+    const done = await app.inject({
+      method: 'POST',
+      url: '/api/auth/password-reset/confirm',
+      headers: { host: HOST },
+      payload: { token, password: 'a whole new passphrase' },
+    });
+    expect(done.statusCode).toBe(204);
+
+    expect((await signIn('a whole new passphrase')).statusCode).toBe(200);
+    expect((await signIn(OLD_PASSWORD)).statusCode).toBe(401);
+
+    // Single use
+    const again = await app.inject({
+      method: 'POST',
+      url: '/api/auth/password-reset/confirm',
+      headers: { host: HOST },
+      payload: { token, password: 'yet another passphrase' },
+    });
+    expect(again.statusCode).toBe(400);
+  });
+
+  it('answers an unknown address exactly the same, and sends nothing', async () => {
+    const before = sent.length;
+    const token = await requestReset('nobody@elsewhere.test');
+    expect(token).toBeNull();
+    expect(sent).toHaveLength(before);
+  });
+
+  it('closes every existing session', async () => {
+    const signedIn = await signIn('a whole new passphrase');
+    const cookie = `hub_session=${signedIn.cookies.find((c) => c.name === 'hub_session')?.value}`;
+    expect((await app.inject({ url: '/api/auth/me', headers: { host: HOST, cookie } })).statusCode).toBe(200);
+
+    const token = await requestReset();
+    await app.inject({
+      method: 'POST',
+      url: '/api/auth/password-reset/confirm',
+      headers: { host: HOST },
+      payload: { token, password: 'third passphrase entirely' },
+    });
+
+    // A reset is also how someone evicts an intruder
+    const after = await app.inject({ url: '/api/auth/me', headers: { host: HOST, cookie } });
+    expect(after.statusCode).toBe(401);
+  });
+
+  it('leaves the second factor alone', async () => {
+    const db = familyDb();
+    db.prepare('UPDATE users SET totp_secret = ? WHERE email = ?').run('JBSWY3DPEHPK3PXP', EMAIL);
+    db.close();
+
+    const token = await requestReset();
+    const done = await app.inject({
+      method: 'POST',
+      url: '/api/auth/password-reset/confirm',
+      headers: { host: HOST },
+      payload: { token, password: 'fourth passphrase here' },
+    });
+    expect(done.statusCode).toBe(204);
+
+    const db2 = familyDb();
+    const row = db2.prepare('SELECT totp_secret FROM users WHERE email = ?').get(EMAIL) as {
+      totp_secret: string | null;
+    };
+    db2.close();
+    // Otherwise a mailbox would be a way around the second factor
+    expect(row.totp_secret).toBe('JBSWY3DPEHPK3PXP');
+  });
+
+  it('refuses an expired link', async () => {
+    const token = await requestReset();
+    const db = familyDb();
+    db.prepare("UPDATE password_resets SET expires_at = '2020-01-01T00:00:00.000Z' WHERE used_at IS NULL").run();
+    db.close();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/password-reset/confirm',
+      headers: { host: HOST },
+      payload: { token, password: 'expired attempt passphrase' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('sends nothing to a member who turned password sign-in off', async () => {
+    const db = familyDb();
+    db.prepare('UPDATE users SET password_login_disabled = 1 WHERE email = ?').run(EMAIL);
+    db.close();
+
+    const before = sent.length;
+    const token = await requestReset();
+    // Silence, and the same 202 — turning password login back on behind
+    // someone's back would undo a deliberate choice
+    expect(token).toBeNull();
+    expect(sent).toHaveLength(before);
+
+    const db2 = familyDb();
+    db2.prepare('UPDATE users SET password_login_disabled = 0 WHERE email = ?').run(EMAIL);
+    db2.close();
+  });
+});

--- a/web/src/components/CalendarFeedSection.tsx
+++ b/web/src/components/CalendarFeedSection.tsx
@@ -1,0 +1,105 @@
+import { t } from '../lib/i18n';
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+/**
+ * Subscribe-by-URL for the calendar.
+ *
+ * The link is shown in full, every time — that is the point of storing it
+ * in the clear (migration 026, same reasoning as the wishlist link): a
+ * second device needs the same address a month later, and "revoke and
+ * create a new one" is not an answer to "show it to me again".
+ */
+export function CalendarFeedSection() {
+  const [token, setToken] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    const res = await api.get<{ token: string | null }>('/calendar/feed');
+    setToken(res.token);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Built from the current origin: the hub does not need to know its own
+  // public address, and a family on a subdomain gets its own host for free.
+  const url = token ? `${window.location.origin}/api/calendar/feed/${token}.ics` : null;
+
+  async function create() {
+    setBusy(true);
+    try {
+      const res = await api.post<{ token: string }>('/calendar/feed', {});
+      setToken(res.token);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function revoke() {
+    if (!window.confirm(t('Every device subscribed to this link stops receiving updates. Revoke it?'))) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await api.delete('/calendar/feed');
+      setToken(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    if (!url) return;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+  }
+
+  return (
+    <section className="rounded-card border border-line bg-surface p-5">
+      <h2 className="eyebrow mb-2">{t('Subscribe in your calendar')}</h2>
+      <p className="mb-4 text-sm text-muted">
+        {t('Add the family calendar to the calendar app on your phone or laptop. The link is read-only and shows only what you can see in the hub.')}
+      </p>
+
+      {url ? (
+        <>
+          <p className="break-all rounded-lg border border-line bg-surface-2 px-3 py-2 font-mono text-xs text-ink">
+            {url}
+          </p>
+          <p className="mt-2 text-sm text-muted">
+            {t('Paste this address into Apple Calendar, Google Calendar or Outlook as a subscription.')}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void copy()}
+              className="rounded-lg border border-line bg-surface-2 px-3 py-1.5 text-sm text-ink hover:bg-surface-3"
+            >
+              {copied ? t('Copied') : t('Copy')}
+            </button>
+            <button
+              type="button"
+              onClick={() => void revoke()}
+              disabled={busy}
+              className="rounded-lg border border-line px-3 py-1.5 text-sm text-urgent hover:bg-surface-2"
+            >
+              {t('Revoke the link')}
+            </button>
+          </div>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void create()}
+          disabled={busy}
+          className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+        >
+          {t('Create the link')}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -655,6 +655,18 @@ export const ru: Record<string, string> = {
   'Your own colors for projects, accounts, categories and calendars — on top of the stock ones. Grows from here and from the "+" button right in the color picker.': 'Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.',
   'Zero — the goal is only a countdown': 'Ноль — только отсчёт, без накоплений',
 
+  // ── Подписка на календарь (ICS-фид) ───────────────────────────────────
+  'Not found': 'Не найдено',
+  'Subscribe in your calendar': 'Подписаться в календаре',
+  'Add the family calendar to the calendar app on your phone or laptop. The link is read-only and shows only what you can see in the hub.':
+    'Добавьте семейный календарь в приложение календаря на телефоне или ноутбуке. Ссылка только для чтения и показывает лишь то, что вы видите в хабе.',
+  'Create the link': 'Создать ссылку',
+  'Revoke the link': 'Отозвать ссылку',
+  'Every device subscribed to this link stops receiving updates. Revoke it?':
+    'Все устройства, подписанные на эту ссылку, перестанут получать обновления. Отозвать?',
+  'Paste this address into Apple Calendar, Google Calendar or Outlook as a subscription.':
+    'Вставьте этот адрес в Apple Calendar, Google Календарь или Outlook как подписку.',
+
   // ── Общие списки (#11) ────────────────────────────────────────────────
   'Lists': 'Списки',
   'Shopping': 'Покупки',

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -13,6 +13,7 @@ import { COMMON_CURRENCIES, formatAmountInput, parseAmount } from '../lib/money'
 import { PeopleSection } from '../components/PeopleSection';
 import { MailSection } from '../components/MailSection';
 import { TotpSection } from '../components/TotpSection';
+import { CalendarFeedSection } from '../components/CalendarFeedSection';
 import { FamilyDataSection } from '../components/FamilyDataSection';
 
 /**
@@ -698,6 +699,10 @@ export function Settings() {
 
       <div className="mb-5 break-inside-avoid">
         <TotpSection />
+      </div>
+
+      <div className="mb-5 break-inside-avoid">
+        <CalendarFeedSection />
       </div>
 
       {usage && (

--- a/web/src/pages/VerifyEmail 2.tsx
+++ b/web/src/pages/VerifyEmail 2.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+import { t } from '../lib/i18n';
+
+/*
+  Landing page for the confirmation link: /verify-email?token=...
+
+  Deliberately outside the auth gate, next to the public wishlist. The link
+  is opened wherever the mail was read — often another browser, often on a
+  phone — and requiring a session first would send people to a sign-in
+  screen for no reason. The token is the authorization.
+*/
+export function VerifyEmail() {
+  const token = new URLSearchParams(window.location.search).get('token') ?? '';
+  const [state, setState] = useState<'working' | 'done' | 'failed'>('working');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setState('failed');
+      return;
+    }
+    void api
+      .post('/auth/email-verify', { token })
+      .then(() => setState('done'))
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : null);
+        setState('failed');
+      });
+  }, [token]);
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-surface-2 p-6">
+      <div className="w-full max-w-sm rounded-card border border-line bg-surface p-6 text-center">
+        <p className="eyebrow mb-3">{t('Address confirmation')}</p>
+        {state === 'working' && <p className="text-sm text-muted">{t('Confirming…')}</p>}
+        {state === 'done' && (
+          <>
+            <p className="text-sm text-ink">
+              {t('Address confirmed. If you ever forget your password, you can now reset it by email.')}
+            </p>
+            <a
+              href="/"
+              className="mt-5 inline-block rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+            >
+              {t('Open Neiliro')}
+            </a>
+          </>
+        )}
+        {state === 'failed' && (
+          <>
+            <p className="text-sm text-ink">{error ?? t('This link is not valid')}</p>
+            <p className="mt-2 text-sm text-muted">
+              {t('Sign in and use the reminder at the top of the page to send a fresh link.')}
+            </p>
+            <a href="/" className="mt-5 inline-block text-sm text-muted underline hover:text-ink">
+              {t('Open Neiliro')}
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The cheap half of "add the hub as an account", and part of #29. Apple Calendar, Google Calendar and Outlook all subscribe to an ICS URL, so a read-only feed puts the family calendar next to the work one on a phone — without the hub becoming a CalDAV server.

## Shape

- **Per person, not per family.** Calendars can be private (`calendars.shared`), so the token addresses one viewer and the feed shows exactly what that person may see. Reuses the existing `CALENDAR_VISIBLE` predicate rather than inventing a second visibility rule.
- **Read-only by construction** — there is no write path behind that URL.
- **Revocable in one click**, which is the whole safety story for an address living inside someone else's app: revoke and every subscribed device goes dark.
- **Token stored in the clear**, like the wishlist link (migration 021) and for the same reason: the address is long-lived and meant to be re-shown when a second device needs it a month later. Hashing makes "show me the link again" impossible, and revoke-and-recreate is not a substitute.

## Two decisions inside the ICS

**Times go out as floating local time, unconverted.** Events are stored as local wall-clock strings because that is what this hub means by a time. A `DTSTART` with no zone is interpreted in the reading device's zone, so a 9am school run stays 9am — converting to UTC would invent a timezone the hub never recorded and move the event.

**Repeating events travel as `RRULE`.** The stored rule is already a valid subset of RFC 5545, so the client expands it. Expanding here would mean choosing a window and shipping fifty copies of the same weekly event.

Written by hand instead of adding a dependency: the subset is small, and the parts strict clients break on — 75-octet line folding and text escaping — are exactly what the tests cover.

## Why not IMAP/CalDAV (for the record)

The other half of the request was mail as an account. That means writing an IMAP server over SQLite — flag state, UID validity, IDLE, partial fetches, concurrent sessions — which lands us with a worse mailbox than any provider and turns a paperwork desk into a mediocre mail client. Suggested alternative if the need is "read it in my own client": forward copies of incoming mail to members' personal addresses. Not in this PR.

## Testing

14 new tests. `lib/ics.test.ts` (8) pins the format: envelope, floating time with no `Z`, all-day dates with the **exclusive** `DTEND` including a month boundary, `RRULE` pass-through, escaping, folding under 75 octets, stable UIDs so a re-poll updates instead of duplicating. `routes/calendar-feed.test.ts` (6) pins access: anonymous client gets ICS, `.ics` suffix accepted, **another person's private calendar never appears**, same token returned twice, revoked token stops serving, unknown token is 404 rather than 401.

The public-surface snapshot test failed on this change and was updated deliberately — it now asserts *both* token-addressed subtrees (`/api/wishlist/`, `/api/calendar/feed/`) with the reasoning written down. That test doing its job is why the prefix change is visible in the diff rather than silent.

Migration 026 smoke-run on a fresh `:memory:` database: 26 applied, column present, `integrity_check ok`. Suite 256 (198 server + 58 web), typecheck and lint clean.

Cleaned up two stray `... 2.sql` migration duplicates that a `git stash` restore had left in the working tree — they were breaking the suite by applying `023`/`024` twice.