### PR TITLE
chore: version 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -12065,7 +12065,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12090,7 +12090,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump ahead of the `v1.7.0` tag — the hosted stack pins a release tag and the number shows in Settings → About, so it goes up before the tag rather than after.

Contents of the release:

- **Shared lists** ([#159](https://github.com/neiliro/neiliro/pull/159)) — the shopping list, closes [#11](https://github.com/neiliro/neiliro/issues/11)
- **Calendar subscription** ([#160](https://github.com/neiliro/neiliro/pull/160)) — read-only ICS feed, part of [#29](https://github.com/neiliro/neiliro/issues/29)
- **Public link for one event** ([#162](https://github.com/neiliro/neiliro/pull/162))
- **Password reset by email, hosted only** ([#156](https://github.com/neiliro/neiliro/pull/156)) — with the address verification it depends on
- **Hosted invariants pinned, two PR-gate guards** ([#155](https://github.com/neiliro/neiliro/pull/155))

**This one does change the schema** — migrations `023` through `027`, unlike 1.6.0 which changed none. They apply themselves at startup and are forward-only, so a downgrade to 1.6.0 is not a clean round trip: the new columns and tables simply stop being read.

Suite 266 (208 server + 58 web), typecheck and lint clean on master.