### PR TITLE
feat: share, rename and delete a list — and a real dialog for naming one

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -160,7 +160,9 @@ The whole design is about speed on a phone, because that is where a shopping lis
 
 Items are deliberately plain text with no quantity, assignee or due date: a list item is a word, and every field added to it is a field to fill in while standing in a shop. Duplicates are allowed — two "milk" means two bottles, and a dedupe check would be a surprise at the worst moment.
 
-One list ships with a fresh hub, so the feature works before anyone configures anything; more can be added, and the seeded name is translated by id, so renaming it keeps your name. Adding is also one of the four one-tap actions on the phone home screen.
+One list ships with a fresh hub, so the feature works before anyone configures anything; more can be added, renamed and deleted. Adding is also one of the four one-tap actions on the phone home screen.
+
+**A list can be handed to someone without an account** — typically whoever is going to the shop. Unlike the other share links in the hub, this one accepts a write: the guest can tick items off, because a shopping list nobody can tick off is a screenshot. That is the only thing they can do — no adding, no renaming, no deleting, and nothing beyond that single list is visible. Ticks land on the same list the family sees, since it is the same list and not a copy. The link is revocable, deleting the list revokes it too, and asking twice returns the same link so it can be re-sent.
 
 ## Mail
 

--- a/server/src/db/migrations/028_list_share.sql
+++ b/server/src/db/migrations/028_list_share.sql
@@ -1,0 +1,15 @@
+-- A public link for one list (#11 follow-up).
+--
+-- The fourth token-addressed surface, after the wishlist (021), the
+-- calendar subscription (026) and a single event (027). The use case is
+-- the one the shopping list was built for: hand the list to whoever is
+-- going to the shop, including people with no account here.
+--
+-- Unlike the other three, a guest can *write* — but only one thing:
+-- ticking an item off. That is the whole point of sending someone a
+-- shopping list, and it is why this link is not simply read-only. A guest
+-- still cannot add, rename, delete or see anything but this one list.
+--
+-- Plaintext, like its siblings: the link is meant to be re-sent.
+ALTER TABLE lists ADD COLUMN share_token TEXT;
+CREATE UNIQUE INDEX idx_lists_share_token ON lists(share_token) WHERE share_token IS NOT NULL;

--- a/server/src/lib/auth.public-surface.test.ts
+++ b/server/src/lib/auth.public-surface.test.ts
@@ -68,6 +68,7 @@ describe('public API surface', () => {
     expect(prefixes.filter((p) => p !== '/api').sort()).toEqual([
       '/api/calendar/feed/',
       '/api/event/',
+      '/api/list/',
       '/api/wishlist/',
     ]);
   });

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -168,6 +168,12 @@ export async function authenticate(req: FastifyRequest, reply: FastifyReply): Pr
     one event and deliberately not the calendar around it.
   */
   if (path.startsWith('/api/event/')) return;
+  /*
+    A shared list. The only public surface that accepts a write — ticking
+    an item — because a shopping list nobody can tick off is a screenshot.
+    The token scopes both the read and that write to one list.
+  */
+  if (path.startsWith('/api/list/')) return;
 
   const token = req.cookies[SESSION_COOKIE];
   const user = token ? userForToken(token) : null;

--- a/server/src/routes/lists.test.ts
+++ b/server/src/routes/lists.test.ts
@@ -119,6 +119,110 @@ describe('shared lists', () => {
     expect((await h.as(alice.cookie, 'POST', `/api/list-items/${itemId}/toggle`)).statusCode).toBe(404);
   });
 
+  it('shares a list by link, and a guest sees only that list', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Hardware run' });
+    const listId = made.json<{ id: string }>().id;
+    await add(alice.cookie, 'screws', listId);
+
+    const shared = await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {});
+    expect(shared.statusCode).toBe(201);
+    const token = shared.json<{ path: string }>().path.replace('/list/', '');
+
+    // No session at all: this is a neighbour with a link
+    const guest = await h.app.inject({ url: `/api/list/${token}` });
+    expect(guest.statusCode).toBe(200);
+    const body = guest.json<{ title: string; items: { title: string }[] }>();
+    expect(body.title).toBe('Hardware run');
+    expect(body.items.map((i) => i.title)).toEqual(['screws']);
+    // The household does not travel with the link
+    expect(guest.body).not.toContain('Alice');
+    expect(guest.body).not.toContain('Shopping');
+  });
+
+  it('lets a guest tick an item off, and nothing else', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Market' });
+    const listId = made.json<{ id: string }>().id;
+    const itemId = await add(alice.cookie, 'apples', listId);
+    const token = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {}))
+      .json<{ path: string }>()
+      .path.replace('/list/', '');
+
+    const ticked = await h.app.inject({
+      method: 'POST',
+      url: `/api/list/${token}/items/${itemId}/toggle`,
+    });
+    expect(ticked.statusCode).toBe(200);
+    expect(ticked.json<{ checked_at: string | null }>().checked_at).toBeTruthy();
+    // Visible to the family too — one list, one state
+    expect((await items(alice.cookie, listId))[0]!.checked_at).toBeTruthy();
+
+    // But a guest cannot add, rename or delete
+    for (const [method, url, payload] of [
+      ['POST', `/api/lists/${listId}/items`, { title: 'sneaked in' }],
+      ['PATCH', `/api/lists/${listId}`, { title: 'renamed' }],
+      ['DELETE', `/api/lists/${listId}`, undefined],
+    ] as const) {
+      const res = await h.app.inject({ method, url, payload });
+      expect(res.statusCode, `${method} ${url}`).toBe(401);
+    }
+  });
+
+  it('scopes a guest write to the shared list only', async () => {
+    const mine = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Shared one' });
+    const sharedId = mine.json<{ id: string }>().id;
+    const token = (await h.as(alice.cookie, 'POST', `/api/lists/${sharedId}/share`, {}))
+      .json<{ path: string }>()
+      .path.replace('/list/', '');
+
+    // An item from a different list, reached through this token
+    const other = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Private one' });
+    const otherItem = await add(alice.cookie, 'not yours', other.json<{ id: string }>().id);
+
+    const res = await h.app.inject({
+      method: 'POST',
+      url: `/api/list/${token}/items/${otherItem}/toggle`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('kills the link when the list is deleted, and on revoke', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Temporary' });
+    const listId = made.json<{ id: string }>().id;
+    const token = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {}))
+      .json<{ path: string }>()
+      .path.replace('/list/', '');
+    expect((await h.app.inject({ url: `/api/list/${token}` })).statusCode).toBe(200);
+
+    // Revoke alone
+    await h.as(alice.cookie, 'DELETE', `/api/lists/${listId}/share`);
+    expect((await h.app.inject({ url: `/api/list/${token}` })).statusCode).toBe(404);
+
+    // And a deleted list takes any link with it
+    const again = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {}))
+      .json<{ path: string }>()
+      .path.replace('/list/', '');
+    await h.as(alice.cookie, 'DELETE', `/api/lists/${listId}`);
+    expect((await h.app.inject({ url: `/api/list/${again}` })).statusCode).toBe(404);
+  });
+
+  it('renames a list, keeping its items and its link', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Old name' });
+    const listId = made.json<{ id: string }>().id;
+    await add(alice.cookie, 'thing', listId);
+    const token = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {}))
+      .json<{ path: string }>()
+      .path.replace('/list/', '');
+
+    const renamed = await h.as(alice.cookie, 'PATCH', `/api/lists/${listId}`, { title: 'New name' });
+    expect(renamed.statusCode).toBe(200);
+    expect(renamed.json<{ title: string }>().title).toBe('New name');
+
+    // A rename is not a new list: items stay, and the link keeps working
+    expect((await items(alice.cookie, listId)).map((i) => i.title)).toEqual(['thing']);
+    const guest = await h.app.inject({ url: `/api/list/${token}` });
+    expect(guest.json<{ title: string }>().title).toBe('New name');
+  });
+
   it('refuses an empty name and an unknown list', async () => {
     expect((await h.as(alice.cookie, 'POST', '/api/lists', { title: '   ' })).statusCode).toBe(400);
     const ghostList = '00000000-0000-4000-8000-0000000009f9';

--- a/server/src/routes/lists.ts
+++ b/server/src/routes/lists.ts
@@ -1,6 +1,8 @@
+import { randomBytes } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { db, id, now } from '../db/index.js';
+import { env } from '../env.js';
 
 /*
   Shared lists (#11) — the shopping list and its friends.
@@ -142,5 +144,88 @@ export async function registerListRoutes(app: FastifyInstance): Promise<void> {
       .prepare('DELETE FROM list_items WHERE list_id = ? AND checked_at IS NOT NULL')
       .run(listId);
     return { cleared: result.changes };
+  });
+
+  // ── The public link ───────────────────────────────────────────────────
+
+  const shareRate = { config: { rateLimit: { max: 60, timeWindow: '1 minute' } } };
+
+  app.post('/api/lists/:id/share', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    // A public sandbox must not mint public URLs into the real world
+    if (env.demoMode) return reply.code(403).send({ error: 'Disabled in the demo' });
+
+    const list = db.prepare('SELECT id, share_token FROM lists WHERE id = ?').get(listId) as
+      | { id: string; share_token: string | null }
+      | undefined;
+    if (!list) return reply.code(404).send({ error: 'List not found' });
+
+    // Asking twice hands back the same link, so it can be re-sent
+    if (list.share_token) return { path: `/list/${list.share_token}` };
+
+    const token = randomBytes(24).toString('base64url');
+    db.prepare('UPDATE lists SET share_token = ? WHERE id = ?').run(token, listId);
+    return reply.code(201).send({ path: `/list/${token}` });
+  });
+
+  app.delete('/api/lists/:id/share', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const result = db.prepare('UPDATE lists SET share_token = NULL WHERE id = ?').run(listId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'List not found' });
+    return { ok: true };
+  });
+
+  const TOKEN = z.object({ token: z.string().min(10).max(200) });
+
+  const listByToken = (token: string) =>
+    db.prepare('SELECT id, title FROM lists WHERE share_token = ?').get(token) as
+      | { id: string; title: string }
+      | undefined;
+
+  /*
+    The guest view: this list and nothing else. No other lists, no family
+    names, nothing about who added what — a list handed to a neighbour
+    must not come with the household attached.
+  */
+  app.get('/api/list/:token', shareRate, (req, reply) => {
+    const { token } = TOKEN.parse(req.params);
+    const list = listByToken(token);
+    if (!list) return reply.code(404).send({ error: 'This link is no longer valid' });
+
+    const items = db
+      .prepare(
+        `SELECT id, title, checked_at FROM list_items
+          WHERE list_id = ?
+          ORDER BY checked_at IS NOT NULL, CASE WHEN checked_at IS NULL THEN position END,
+                   checked_at DESC`,
+      )
+      .all(list.id);
+    return { id: list.id, title: list.title, items };
+  });
+
+  /*
+    The one thing a guest may change. Sending someone a shopping list is
+    pointless if they cannot tick things off, so this is deliberately a
+    write — and deliberately the only one: no adding, no renaming, no
+    deleting, and the item must belong to the shared list.
+  */
+  app.post('/api/list/:token/items/:itemId/toggle', shareRate, (req, reply) => {
+    const { token } = TOKEN.parse(req.params);
+    const { itemId } = z.object({ itemId: z.string().uuid() }).parse(req.params);
+    const list = listByToken(token);
+    if (!list) return reply.code(404).send({ error: 'This link is no longer valid' });
+
+    const item = db
+      .prepare('SELECT id, checked_at FROM list_items WHERE id = ? AND list_id = ?')
+      .get(itemId, list.id) as { id: string; checked_at: string | null } | undefined;
+    // An item from another list is simply not found here — the token scopes
+    // the write as tightly as it scopes the read
+    if (!item) return reply.code(404).send({ error: 'Item not found' });
+
+    db.prepare('UPDATE list_items SET checked_at = ? WHERE id = ?').run(
+      item.checked_at ? null : now(),
+      itemId,
+    );
+    return db.prepare('SELECT id, title, checked_at FROM list_items WHERE id = ?').get(itemId);
   });
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { Lists } from './pages/Lists';
 import { Family } from './pages/Family';
 import { PublicWishlist } from './pages/PublicWishlist';
 import { PublicEvent } from './pages/PublicEvent';
+import { PublicList } from './pages/PublicList';
 import { VerifyEmail } from './pages/VerifyEmail';
 
 function Gate() {
@@ -55,6 +56,7 @@ export function App() {
                 hub's only page for people without an account (#68) */}
             <Route path="/wish/:token" element={<PublicWishlist />} />
             <Route path="/event/:token" element={<PublicEvent />} />
+            <Route path="/list/:token" element={<PublicList />} />
             {/* Same reason: the confirmation link is opened from a mail
                 client, often in a browser with no session (#156) */}
             <Route path="/verify-email" element={<VerifyEmail />} />

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -655,6 +655,22 @@ export const ru: Record<string, string> = {
   'Your own colors for projects, accounts, categories and calendars — on top of the stock ones. Grows from here and from the "+" button right in the color picker.': 'Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.',
   'Zero — the goal is only a countdown': 'Ноль — только отсчёт, без накоплений',
 
+  // ── Управление списком и ссылка на список ─────────────────────────────
+  'Rename': 'Переименовать',
+  'Rename the list': 'Переименовать список',
+  'Name of the list': 'Название списка',
+  'Delete the list': 'Удалить список',
+  '“{title}” and everything on it will be deleted.': '«{title}» и всё, что в нём, будет удалено.',
+  '“{title}” and everything on it will be deleted, and its public link will stop working.':
+    '«{title}» и всё, что в нём, будет удалено, а публичная ссылка перестанет работать.',
+  'Share this list by link': 'Поделиться списком по ссылке',
+  'Anyone with this link can see this list and tick items off — nothing else.':
+    'Любой, у кого есть ссылка, увидит этот список и сможет отмечать пункты — и ничего больше.',
+  'Shared list': 'Общий список',
+  'Tick things off as you go — the family sees it too.':
+    'Отмечайте по ходу — семья это тоже видит.',
+  'This list is empty.': 'Список пуст.',
+
   // ── Ссылка на одно событие (гостевая страница) ────────────────────────
   'Share this event by link': 'Поделиться событием по ссылке',
   'Anyone with this link sees this event only — not the calendar it is in.':

--- a/web/src/lib/lists.ts
+++ b/web/src/lib/lists.ts
@@ -25,6 +25,8 @@ export interface SharedList {
   position: number;
   open_items: number;
   checked_items: number;
+  /** Present when a public link exists; the family may see its own link */
+  share_token?: string | null;
 }
 
 export interface ListWithItems extends SharedList {

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../lib/api';
 import { Empty, Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
+import { useDialogs } from '../components/Dialog';
 import { listTitle, type ListItem, type ListWithItems, type SharedList } from '../lib/lists';
 
 /*
@@ -29,6 +30,9 @@ export function Lists() {
   */
   const [pending, setPending] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogs = useDialogs();
+  const [sharePath, setSharePath] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   const loadLists = useCallback(async () => {
     const all = await api.get<SharedList[]>('/lists');
@@ -37,7 +41,12 @@ export function Lists() {
   }, []);
 
   const loadList = useCallback(async (id: string) => {
-    setList(await api.get<ListWithItems>(`/lists/${id}`));
+    const loaded = await api.get<ListWithItems>(`/lists/${id}`);
+    setList(loaded);
+    // An existing link has to show up on open, not only right after it is
+    // created — otherwise the family cannot find the link they already sent
+    setSharePath(loaded.share_token ? `/list/${loaded.share_token}` : null);
+    setCopied(false);
   }, []);
 
   useEffect(() => {
@@ -103,11 +112,63 @@ export function Lists() {
   }
 
   async function newList() {
-    const title = window.prompt(t('Name of the new list')) ?? '';
-    if (!title.trim()) return;
+    const title = await dialogs.prompt({
+      title: t('New list'),
+      label: t('Name of the new list'),
+      confirmLabel: t('Create'),
+    });
+    if (!title?.trim()) return;
     const made = await api.post<SharedList>('/lists', { title: title.trim() });
     await loadLists();
     setActiveId(made.id);
+  }
+
+  async function rename() {
+    if (!list) return;
+    const title = await dialogs.prompt({
+      title: t('Rename the list'),
+      label: t('Name of the list'),
+      value: listTitle(list.id, list.title),
+      confirmLabel: t('Save'),
+    });
+    if (!title?.trim()) return;
+    await api.patch(`/lists/${list.id}`, { title: title.trim() });
+    await Promise.all([loadLists(), loadList(list.id)]);
+  }
+
+  async function removeList() {
+    if (!list) return;
+    const ok = await dialogs.confirm({
+      title: t('Delete the list'),
+      // Two consequences worth stating before the click, not after
+      message: sharePath
+        ? t('“{title}” and everything on it will be deleted, and its public link will stop working.', {
+            title: listTitle(list.id, list.title),
+          })
+        : t('“{title}” and everything on it will be deleted.', {
+            title: listTitle(list.id, list.title),
+          }),
+      confirmLabel: t('Delete'),
+      danger: true,
+    });
+    if (!ok) return;
+    await api.delete(`/lists/${list.id}`);
+    setActiveId(null);
+    setList(null);
+    await loadLists();
+  }
+
+  async function share() {
+    if (!list) return;
+    const res = await api.post<{ path: string }>(`/lists/${list.id}/share`, {});
+    setSharePath(res.path);
+    setCopied(false);
+  }
+
+  async function unshare() {
+    if (!list) return;
+    await api.delete(`/lists/${list.id}/share`);
+    setSharePath(null);
   }
 
   // The open list names the page: with a single list there are no chips to
@@ -146,6 +207,67 @@ export function Lists() {
               {l.open_items > 0 && <span className="ml-1.5 font-mono text-xs">{l.open_items}</span>}
             </button>
           ))}
+        </div>
+      )}
+
+      {list && (
+        <div className="mb-4 max-w-xl">
+          <div className="flex flex-wrap gap-4">
+            {!sharePath && (
+              <button
+                type="button"
+                onClick={() => void share()}
+                className="text-sm text-accent underline underline-offset-2"
+              >
+                {t('Share this list by link')}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => void rename()}
+              className="text-sm text-muted underline underline-offset-2 hover:text-ink"
+            >
+              {t('Rename')}
+            </button>
+            <button
+              type="button"
+              onClick={() => void removeList()}
+              className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+            >
+              {t('Delete the list')}
+            </button>
+          </div>
+
+          {sharePath && (
+            <div className="mt-3 rounded-lg border border-line bg-surface-2 p-3">
+              <p className="break-all font-mono text-xs text-ink">
+                {window.location.origin}
+                {sharePath}
+              </p>
+              <p className="mt-1.5 text-xs text-muted">
+                {t('Anyone with this link can see this list and tick items off — nothing else.')}
+              </p>
+              <div className="mt-2 flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(`${window.location.origin}${sharePath}`);
+                    setCopied(true);
+                  }}
+                  className="text-sm text-accent underline underline-offset-2"
+                >
+                  {copied ? t('Copied') : t('Copy')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void unshare()}
+                  className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+                >
+                  {t('Revoke the link')}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/web/src/pages/PublicList.tsx
+++ b/web/src/pages/PublicList.tsx
@@ -1,0 +1,103 @@
+import { t } from '../lib/i18n';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+/*
+  A shared list, for someone without an account — typically whoever is
+  standing in the shop.
+
+  Like the other guest screens it renders outside AppShell and uses fetch
+  rather than lib/api, so the signed-in app's 401 handling never fires
+  here. Unlike them it accepts one write: ticking an item off. A shopping
+  list you cannot tick off is a screenshot, and the family sees the ticks
+  because it is the same list, not a copy.
+*/
+
+interface GuestItem {
+  id: string;
+  title: string;
+  checked_at: string | null;
+}
+
+export function PublicList() {
+  const { token } = useParams<{ token: string }>();
+  const [title, setTitle] = useState<string | null>(null);
+  const [items, setItems] = useState<GuestItem[]>([]);
+  const [dead, setDead] = useState(false);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/list/${token}`);
+    if (!res.ok) {
+      setDead(true);
+      return;
+    }
+    const body = (await res.json()) as { title: string; items: GuestItem[] };
+    setTitle(body.title);
+    setItems(body.items);
+  }, [token]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function toggle(item: GuestItem) {
+    // Optimistic, then reconciled: a shop is exactly where a spinner per
+    // tap is worst
+    setItems((current) =>
+      current.map((i) => (i.id === item.id ? { ...i, checked_at: i.checked_at ? null : 'pending' } : i)),
+    );
+    const res = await fetch(`/api/list/${token}/items/${item.id}/toggle`, { method: 'POST' });
+    if (!res.ok) setDead(!res.ok && res.status === 404);
+    await load();
+  }
+
+  if (dead) {
+    return (
+      <main className="mx-auto max-w-lg px-5 py-16">
+        <h1 className="font-display text-2xl text-ink">Neiliro</h1>
+        <p className="mt-4 text-sm text-muted">{t('This link is no longer valid')}</p>
+      </main>
+    );
+  }
+  if (title === null) return null;
+
+  const open = items.filter((i) => !i.checked_at);
+  const checked = items.filter((i) => i.checked_at);
+
+  return (
+    <main className="mx-auto max-w-lg px-5 py-12">
+      <p className="eyebrow mb-2">{t('Shared list')}</p>
+      <h1 className="font-display text-3xl text-ink">{title}</h1>
+      <p className="mt-2 text-sm text-muted">{t('Tick things off as you go — the family sees it too.')}</p>
+
+      {items.length === 0 ? (
+        <p className="mt-8 text-sm text-muted">{t('This list is empty.')}</p>
+      ) : (
+        <ul className="mt-6 overflow-hidden rounded-card border border-line bg-surface">
+          {[...open, ...checked].map((item) => (
+            <li key={item.id} className="border-b border-line last:border-0">
+              <button
+                type="button"
+                onClick={() => void toggle(item)}
+                className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors active:bg-surface-2"
+              >
+                <span
+                  className={`flex size-5 shrink-0 items-center justify-center rounded border ${
+                    item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
+                  }`}
+                >
+                  {item.checked_at && (
+                    <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
+                      <path d="m5 13 4 4 10-10" />
+                    </svg>
+                  )}
+                </span>
+                <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
Four gaps found by using the feature on the phone it was built for.

## 4. `window.prompt` → the app's own dialog

Indefensible in an app that ships its own: `DialogProvider` with `prompt` and `confirm` has existed here far longer than lists have. Creating and renaming now go through the app's modal, deleting through its confirm — and the confirmation **says out loud** that a public link will stop working, when there is one.

| before | after |
|---|---|
| browser `prompt()` with the origin in the title | `NEW LIST` modal in the app's own style |

## 2, 3. Delete and rename

Both endpoints existed from the original PR — they simply had no way in from the UI. Now they do. A rename **keeps the list's items and its share link**: a rename is not a new list, and there is a test asserting exactly that.

## 1. Sharing — the fourth token-addressed surface

After the wishlist, the calendar feed and a single event. It differs from all three in one deliberate way: **a guest may write.** Exactly one write — ticking an item off — because a shopping list nobody can tick off is a screenshot, and the point of sending it is that someone in a shop uses it.

The tick lands on the family's own list, not a copy, so the state is shared the way it is inside the hub. What a guest still cannot do: add, rename, delete, or see anything beyond that one list. The token scopes the write as tightly as the read — an item id from a *different* list answers 404 through this token, and there is a test for it.

Also fixed while here: an existing link now appears when a list is opened, not only in the moment it was created. Otherwise the family cannot find the link they already sent — the same mistake the wishlist token corrected in migration 021.

## Verified by using it

Ran the whole path on a disposable instance: the new-list modal, adding an item, creating the link, opening it as a guest, ticking `screws` off, and confirming the family's own view then reports `open=0 checked=1` — same list, one state. Screenshots of the modal and the guest page in the branch history.

One thing the pass caught about my own testing rather than the code: my first click landed on `Delete the list` because the chips row had shifted the layout down. The delete confirmation appearing correctly was accidental good news.

## Testing

5 new tests (15 in the file): guest sees only that list and no household names, guest may tick but is refused add/rename/delete, a write scoped to the shared list only, revoke plus delete-kills-the-link, and rename keeping items and link. Migration 028 smoke-run on a fresh `:memory:`: 28 applied, column and partial unique index present, `integrity_check ok`. Suite 271 (213 server + 58 web), typecheck and lint clean.

The public-surface snapshot now pins four subtrees — `/api/list/` is the first one that is not read-only, which is exactly the kind of change that should be visible in a diff rather than silent.