### PR TITLE
ci: hand a published release to the control plane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,27 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # Hand the released version to the control plane, which owns the
+      # hosted machine's credentials and does the actual deploy
+      # (neiliro/cloud, release-deploy.yml). Skipped when the token is
+      # absent — a fork, or before the token is configured — so a release
+      # still publishes its image either way.
+      - name: Tell the control plane to deploy it
+        env:
+          GH_TOKEN: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
+          # The git tag carries a "v", the image tag does not — registry
+          # convention, see the comment at the top of this file
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          # Checked in the shell rather than a step-level `if`: the secrets
+          # context is not dependable in conditionals, and a release must
+          # never fail because a deploy token is absent.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "no CLOUD_DISPATCH_TOKEN configured — image published, hosted deploy skipped"
+            exit 0
+          fi
+          gh api repos/neiliro/cloud/dispatches \
+            -f event_type=app-release \
+            -F client_payload[version]="$VERSION"
+


### PR DESCRIPTION
Companion to [cloud#5](https://github.com/neiliro/cloud/pull/5). After the multi-arch image is pushed, the release workflow tells `neiliro/cloud` that a version exists, and the deploy happens **there** — that repository owns the hosted machine's credentials, so nothing about the server has to be duplicated here.

## One step, two deliberate details

- **The guard is in the shell, not a step-level `if`.** The `secrets` context is not dependable in conditionals, and a release must never fail because a deploy token is absent. Without `CLOUD_DISPATCH_TOKEN` the image publishes exactly as before and the step prints why it stopped.
- **The version sent is the image tag**, not the git tag — `steps.meta.outputs.version`, which is already the `v`-stripped form. The registry convention (`v1.7.0` → `neiliro:1.7.0`) reads like a bug often enough that it is worth not re-deriving it by hand here.

## What this changes about the process

Before: mergeing landed changes on the **demo** machine automatically, and reaching the hosted machine took three manual steps after the tag — edit `.env`, pull, restart. Both production mishaps this week happened in those steps.

After: the tag is still a human decision and the release page is still written by hand. Everything after the tag is automatic and verified.

Deliberately **not** changed: no deploy to hosted on merge to `master`. Real families live there, including Denis's; a stream of unreviewed changes into production is not speed. Demo exists for that.

## Needs from you

A fine-grained token as `CLOUD_DISPATCH_TOKEN` in this repository — scoped to `neiliro/cloud` only, Contents: read and write, which is the minimum a `repository_dispatch` needs.

`CLAUDE.md` updated to describe the new path.