### PR TITLE
fix: one convention for inline destructive actions (#79)

### DIFF
--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -106,6 +106,25 @@ export const dialogGhost = 'px-2 py-2 text-sm text-muted hover:text-ink';
 export const dialogDanger =
   'rounded-lg border border-urgent px-4 py-2 text-sm font-medium text-urgent hover:bg-urgent/10';
 
+/*
+  A destructive action that sits inline, among other controls, rather than
+  in a dialog's footer (#79).
+
+  Which of the two to reach for is a question of position, not of severity:
+  `dialogDanger` is the bordered button that ends a dialog, where it is the
+  primary thing on the row. `inlineDanger` is for a delete that lives next
+  to unrelated controls — beside the toggles in the note header, in a row
+  of devices, under a list — where a bordered button would shout over its
+  neighbours. Both mean "this cannot be undone"; they differ in how much
+  room they are allowed to take.
+
+  Deliberately carries no font size. Call sites are `text-sm` in some rows
+  and `text-xs` in compact ones, and baking a size in here would silently
+  resize half of them — layout stays at the call site, the same way
+  `ml-auto` and `shrink-0` already do.
+*/
+export const inlineDanger = 'text-muted underline underline-offset-2 hover:text-urgent';
+
 // ── Context ───────────────────────────────────────────────────────────────
 
 interface PromptOptions {

--- a/web/src/components/EventDialog.tsx
+++ b/web/src/components/EventDialog.tsx
@@ -6,7 +6,7 @@ import { RECURRENCE_OPTIONS } from '../lib/tasks';
 import { onEnter } from '../lib/keys';
 import { clearBlankOnBlur } from '../lib/forms';
 import { timeOf } from '../lib/format';
-import { dialogGhost, Modal, useDialogs } from './Dialog';
+import { dialogGhost, inlineDanger, Modal, useDialogs } from './Dialog';
 
 const field =
   'w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent';
@@ -183,7 +183,7 @@ export function EventDialog({
             <button
               type="button"
               onClick={() => void removeAll()}
-              className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+              className={`${inlineDanger} text-sm`}
             >
               {occurrence.is_recurring ? t('Delete series') : t('Delete')}
             </button>
@@ -232,7 +232,7 @@ export function EventDialog({
                     <button
                       type="button"
                       onClick={() => void unshare()}
-                      className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+                      className={`${inlineDanger} text-sm`}
                     >
                       {t('Revoke the link')}
                     </button>

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../lib/api';
 import { Empty } from './Page';
 import { EntityDialog } from './EntityDialog';
-import { useDialogs } from './Dialog';
+import { inlineDanger, useDialogs } from './Dialog';
 import { reportFailure } from '../lib/failures';
 
 interface ManagedUser {
@@ -139,7 +139,7 @@ function InvitesBlock() {
                     .then(load)
                     .catch((err: Error) => reportFailure(err.message || t('Could not save')))
                 }
-                className="text-xs text-muted underline decoration-line hover:text-urgent"
+                className={`${inlineDanger} text-xs`}
               >
                 {t('Revoke')}
               </button>

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/tasks';
 import { dialogKeys, onEnter } from '../lib/keys';
 import { clearBlankOnBlur } from '../lib/forms';
-import { useDialogs, useScrollLock } from './Dialog';
+import { inlineDanger, useDialogs, useScrollLock } from './Dialog';
 
 const field =
   'w-full rounded-lg border border-line bg-surface-2 px-3 py-2 text-sm text-ink outline-none focus:border-accent';
@@ -256,7 +256,7 @@ export function TaskDetail({ task, members, onSaved, onClose }: Props) {
           <button
             type="button"
             onClick={() => void remove()}
-            className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+            className={`${inlineDanger} text-sm`}
           >
             {t('Delete')}
           </button>

--- a/web/src/lib/destructive-actions.test.ts
+++ b/web/src/lib/destructive-actions.test.ts
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { inlineDanger } from '../components/Dialog';
+
+/*
+  Destructive actions have exactly two shapes, and this keeps it that way
+  (#79).
+
+  The issue was not that the styling was wrong — it was that the same
+  decision had been re-made per file, five slightly different ways, until
+  nobody could tell which was the convention. Fixing the copies once does
+  not fix that; the next inline delete would start a sixth. So the rule
+  lives here, where adding a raw copy fails a test instead of passing
+  review unnoticed.
+
+  Icon-only controls are intentionally out of scope: a ✕ next to a receipt
+  or a bin glyph in a row is not competing with the text-link convention,
+  it is a different control.
+*/
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+/** Where the constant is defined — the one file allowed to hold the string. */
+const DEFINITION = join(SRC, 'components', 'Dialog.tsx');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+describe('destructive actions', () => {
+  const files = sourceFiles(SRC);
+
+  it('found the source tree at all', () => {
+    // Guards the walk itself: a broken path would make every check below
+    // pass by testing nothing
+    expect(files.length).toBeGreaterThan(20);
+    expect(files).toContain(DEFINITION);
+  });
+
+  it('has no hand-rolled copies of the inline style', () => {
+    const offenders = files
+      .filter((path) => path !== DEFINITION)
+      .filter((path) => {
+        const text = readFileSync(path, 'utf8');
+        // An underlined control that turns urgent on hover is the inline
+        // convention, whichever order the classes were written in
+        return /underline[^"'`]*hover:text-urgent|hover:text-urgent[^"'`]*underline/.test(text);
+      })
+      .map((path) => path.slice(SRC.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('is actually used, in more than one place', () => {
+    const users = files.filter((path) => readFileSync(path, 'utf8').includes('inlineDanger'));
+    // If this ever drops to just the definition, the constant has been
+    // quietly abandoned rather than adopted
+    expect(users.length).toBeGreaterThan(5);
+  });
+
+  it('carries no font size, so call sites keep their own', () => {
+    /*
+      This is the mistake the first attempt at #79 made: baking text-sm
+      into the constant silently grew the compact rows — the session
+      revoke button sat at text-xs beside a font-mono text-xs address and
+      a text-[0.625rem] badge, and became the largest thing in the row.
+    */
+    expect(inlineDanger).not.toMatch(/\btext-(xs|sm|base|lg|\[)/);
+    // And it still has to carry the decision it exists for
+    expect(inlineDanger).toContain('hover:text-urgent');
+    expect(inlineDanger).toContain('underline');
+  });
+});

--- a/web/src/pages/Family.tsx
+++ b/web/src/pages/Family.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { api, ApiError } from '../lib/api';
 import { useAuth } from '../lib/auth';
-import { useDialogs } from '../components/Dialog';
+import { inlineDanger, useDialogs } from '../components/Dialog';
 import { Empty, Page } from '../components/Page';
 import { reportFailure } from '../lib/failures';
 import { onEnter } from '../lib/keys';
@@ -546,7 +546,7 @@ function MemberDetail({ userId, onChanged }: { userId: string; onChanged: () => 
                   onClick={() =>
                     void run(() => api.delete(`/profiles/${userId}/wishlist-share`))
                   }
-                  className="text-xs text-muted underline underline-offset-2 hover:text-urgent"
+                  className={`${inlineDanger} text-xs`}
                 >
                   {t('Revoke')}
                 </button>

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../lib/api';
 import { Empty, Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
-import { useDialogs } from '../components/Dialog';
+import { inlineDanger, useDialogs } from '../components/Dialog';
 import { listTitle, type ListItem, type ListWithItems, type SharedList } from '../lib/lists';
 
 /*
@@ -232,7 +232,7 @@ export function Lists() {
             <button
               type="button"
               onClick={() => void removeList()}
-              className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+              className={`${inlineDanger} text-sm`}
             >
               {t('Delete the list')}
             </button>
@@ -261,7 +261,7 @@ export function Lists() {
                 <button
                   type="button"
                   onClick={() => void unshare()}
-                  className="text-sm text-muted underline underline-offset-2 hover:text-urgent"
+                  className={`${inlineDanger} text-sm`}
                 >
                   {t('Revoke the link')}
                 </button>

--- a/web/src/pages/Notes.tsx
+++ b/web/src/pages/Notes.tsx
@@ -10,7 +10,7 @@ import { useLatest } from '../lib/latest';
 import { Empty, Page } from '../components/Page';
 import { Editor, type UploadedFile } from '../components/Editor';
 import { EntityDialog } from '../components/EntityDialog';
-import { useDialogs } from '../components/Dialog';
+import { inlineDanger, useDialogs } from '../components/Dialog';
 
 interface Folder {
   id: string;
@@ -607,7 +607,7 @@ export function Notes() {
               <button
                 type="button"
                 onClick={() => void removeNote()}
-                className="ml-auto text-sm text-muted underline underline-offset-2 hover:text-urgent"
+                className={`${inlineDanger} ml-auto text-sm`}
               >
                 {t('Delete')}
               </button>
@@ -715,7 +715,7 @@ export function Notes() {
                     <button
                       type="button"
                       onClick={() => void removeAttachment(a)}
-                      className="text-xs text-muted underline underline-offset-2 hover:text-urgent"
+                      className={`${inlineDanger} text-xs`}
                     >
                       {t('Delete')}
                     </button>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -4,7 +4,7 @@ import { formatStamp, setWeekStart, weekStart } from '../lib/format';
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
-import { useDialogs } from '../components/Dialog';
+import { inlineDanger, useDialogs } from '../components/Dialog';
 import { plural } from '../lib/format';
 import { Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
@@ -418,7 +418,7 @@ function SignInSection() {
                       await loadSessions();
                     })
                   }
-                  className="shrink-0 text-xs text-muted underline underline-offset-2 hover:text-urgent"
+                  className={`${inlineDanger} shrink-0 text-xs`}
                 >
                   {t('Revoke')}
                 </button>


### PR DESCRIPTION
Closes #79. Picks up where [#82](https://github.com/neiliro/neiliro/pull/82) stopped — approach credit to @Garv978, who got the naming and the size-at-call-site decision right.

## The inventory was worse than the issue said

#79 listed four hand-rolled copies. Taking inventory again found **seven**, in five spellings — including one the issue missed (`PeopleSection` used `decoration-line` instead of `underline-offset-2`) and **two added this week** by the shared-lists work. That last part is the actual argument for doing this now: the convention was still spreading while the issue sat open.

## What lands

`inlineDanger` next to `dialogDanger`, with a comment on when to reach for which — and the answer is **position, not severity**:

- `dialogDanger` — the bordered button that ends a dialog, where it is the primary thing on the row;
- `inlineDanger` — a delete that lives among unrelated controls (beside the note header's toggles, in a device row, under a list), where a bordered button would shout over its neighbours.

**It carries no font size.** That was the regression in the first attempt: baking in `text-sm` grew the compact rows, and the session revoke button — `text-xs`, next to a `font-mono text-xs` address and a `text-[0.625rem]` badge — became the largest thing in a deliberately tight row. Layout stays at the call site, as `ml-auto` and `shrink-0` already did. **Every size in the diff is unchanged**; the only visual change anywhere is `decoration-line` → `underline-offset-2` in PeopleSection, which is the point of standardising.

## The part that actually closes the issue

Replacing seven copies does not stop an eighth. So the rule is a test: a hand-rolled copy of the style fails, and the constant is checked for not carrying a size.

Verified by breaking both on purpose — reintroducing the raw string in `Lists.tsx` fails with `expected [ 'pages/Lists.tsx' ] to deeply equal []`, naming the file.

## Out of scope, deliberately

Icon-only controls — the ✕ on a receipt, the bin glyphs in Family, the sign-out chip. They are a different control, not a competing spelling of this one, and the scanner ignores them by requiring `underline` alongside `hover:text-urgent`.

## Testing

4 new tests (62 web total, 275 with server), typecheck and lint clean.