### PR TITLE
fix: renaming a seeded list, and items jumping on add

### DIFF
--- a/web/src/lib/lists.test.ts
+++ b/web/src/lib/lists.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { listTitle, SHOPPING_LIST_ID } from './lists';
+import { projectTitle } from './tasks';
+
+/*
+  Seeded names are stored in English and translated back by id. The trap —
+  hit in production on the shopping list — is doing that unconditionally:
+  the rename saves on the server, the helper then overwrites it on screen,
+  and the feature reads as "renaming does nothing".
+
+  calendarName had the guard from the start; these two did not. The rule is
+  translate the *seeded value*, never the row.
+*/
+
+const INBOX_ID = '00000000-0000-4000-8000-000000000001';
+
+describe('seeded name helpers', () => {
+  it('translates a list that still carries its seeded name', () => {
+    // No dictionary is loaded in tests, so t() passes the key through —
+    // what matters is that the seeded branch is taken at all
+    expect(listTitle(SHOPPING_LIST_ID, 'Shopping')).toBe('Shopping');
+  });
+
+  it('leaves a renamed list alone', () => {
+    expect(listTitle(SHOPPING_LIST_ID, 'Groceries')).toBe('Groceries');
+    // The bug as reported: the family renames it and sees no change
+    expect(listTitle(SHOPPING_LIST_ID, 'Продукты')).toBe('Продукты');
+  });
+
+  it('never touches a list it did not seed', () => {
+    expect(listTitle('11111111-2222-4333-8444-555555555555', 'Shopping')).toBe('Shopping');
+    expect(listTitle('11111111-2222-4333-8444-555555555555', 'Hardware')).toBe('Hardware');
+  });
+
+  it('applies the same rule to the Inbox project', () => {
+    // Inbox cannot be archived or deleted, but it can be renamed
+    expect(projectTitle(INBOX_ID, 'Inbox')).toBe('Inbox');
+    expect(projectTitle(INBOX_ID, 'Входящие')).toBe('Inbox');
+    expect(projectTitle(INBOX_ID, 'Triage')).toBe('Triage');
+    expect(projectTitle(null, 'Anything')).toBe('Anything');
+  });
+});

--- a/web/src/lib/lists.ts
+++ b/web/src/lib/lists.ts
@@ -8,7 +8,11 @@ import { t } from './i18n';
 export const SHOPPING_LIST_ID = '00000000-0000-4000-8000-000000000301';
 
 export function listTitle(id: string, title: string): string {
-  return id === SHOPPING_LIST_ID ? t('Shopping') : title;
+  // Guarded on the seeded value, the way calendarName already was and this
+  // did not copy: without it a rename saves on the server and is then
+  // overwritten on screen by the translation, which reads as "renaming
+  // does nothing".
+  return id === SHOPPING_LIST_ID && title === 'Shopping' ? t('Shopping') : title;
 }
 
 export interface ListItem {

--- a/web/src/lib/tasks.ts
+++ b/web/src/lib/tasks.ts
@@ -46,7 +46,10 @@ export const INBOX_ID = '00000000-0000-4000-8000-000000000001';
  * id — translate in place (English seed since migration 013).
  */
 export function projectTitle(id: string | null | undefined, title: string): string {
-  return id === INBOX_ID ? t('Inbox') : title;
+  // Same guard as calendarName: translate the seeded name, leave a renamed
+  // one alone. Inbox cannot be archived or deleted, but it can be renamed,
+  // so without this a rename looked like it had failed.
+  return id === INBOX_ID && (title === 'Inbox' || title === 'Входящие') ? t('Inbox') : title;
 }
 
 export interface TaskNode extends Task {

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -15,6 +15,32 @@ import { listTitle, type ListItem, type ListWithItems, type SharedList } from '.
   show the truth" rather than a spinner on every checkbox. The input keeps
   focus after adding, because the real gesture is three items in a row.
 */
+/** One row, so an open item and a checked one cannot drift apart. */
+function ListRow({ item, onToggle }: { item: ListItem; onToggle: () => void }) {
+  return (
+    <li className="border-b border-line last:border-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors active:bg-surface-2"
+      >
+        <span
+          className={`flex size-5 shrink-0 items-center justify-center rounded border ${
+            item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
+          }`}
+        >
+          {item.checked_at && (
+            <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
+              <path d="m5 13 4 4 10-10" />
+            </svg>
+          )}
+        </span>
+        <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
+      </button>
+    </li>
+  );
+}
+
 export function Lists() {
   const [lists, setLists] = useState<SharedList[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -72,13 +98,20 @@ export function Lists() {
     // The row shows immediately; the request follows
     setPending((p) => [...p, title]);
     try {
-      await api.post(`/lists/${activeId}/items`, { title });
-      await Promise.all([loadList(activeId), loadLists()]);
+      const created = await api.post<ListItem>(`/lists/${activeId}/items`, { title });
+      /*
+        Both updates in one tick, so React renders once: the real row in,
+        the placeholder out. Reloading the whole list here instead meant a
+        frame where the item existed twice — placeholder and row — which is
+        the other half of what looked like items jumping about.
+      */
+      setList((l) => (l ? { ...l, items: [...l.items, created] } : l));
+      setPending((p) => p.filter((x) => x !== title));
+      await loadLists();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('Something went wrong'));
-      void loadList(activeId);
-    } finally {
       setPending((p) => p.filter((x) => x !== title));
+      void loadList(activeId);
     }
   }
 
@@ -288,6 +321,12 @@ export function Lists() {
           </div>
         ) : (
           <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
+            {open.map((item) => (
+              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
+            ))}
+            {/* Between the open items and the checked pile — where the server
+                is about to put it. Rendered first, it appeared at the top and
+                then jumped to the end when the response arrived. */}
             {pending.map((title, i) => (
               <li key={`pending-${i}`} className="border-b border-line last:border-0">
                 <span className="flex items-center gap-3 px-4 py-3 text-muted">
@@ -296,29 +335,8 @@ export function Lists() {
                 </span>
               </li>
             ))}
-            {[...open, ...checked].map((item) => (
-              <li key={item.id} className="border-b border-line last:border-0">
-                <button
-                  type="button"
-                  onClick={() => void toggle(item)}
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors active:bg-surface-2"
-                >
-                  <span
-                    className={`flex size-5 shrink-0 items-center justify-center rounded border ${
-                      item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
-                    }`}
-                  >
-                    {item.checked_at && (
-                      <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
-                        <path d="m5 13 4 4 10-10" />
-                      </svg>
-                    )}
-                  </span>
-                  <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>
-                    {item.title}
-                  </span>
-                </button>
-              </li>
+            {checked.map((item) => (
+              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
             ))}
           </ul>
         )}


### PR DESCRIPTION
Both bugs are mine, from last week's lists work.

## 2. Renaming the first list did nothing visible

It **did** save. `listTitle` then overwrote it on screen, because it translated the seeded name unconditionally:

```ts
// before
return id === SHOPPING_LIST_ID ? t('Shopping') : title;
```

`calendarName` has guarded on the seeded *value* since the day it was written — I copied that helper's shape without copying its guard. Now a renamed list is left alone, with tests for both branches.

**The same bug was sitting in `projectTitle`**, older and unreported. Inbox cannot be archived or deleted, but it *can* be renamed — so a renamed Inbox also snapped back on screen. One class of bug, one line each, fixed together and tested.

## 1. Items jumping when added

Two causes, both in my optimistic render:

- **the placeholder rendered above everything**, while the server appends — so a new item flashed at the top and moved to the bottom when the response arrived. It now renders between the open items and the checked pile, which is where it is actually going to land;
- **the response triggered a full list reload** while the placeholder was still in state, so for one frame the item existed twice. The server's own row now replaces the placeholder in a single tick (React batches both updates), and only the sidebar counts are refetched.

Extracted `ListRow` while in there — open and checked items were two copies of the same markup, which is exactly how they drift apart later.

## Verified by using it

Renamed the seeded list to "Groceries": the heading and the chip both follow now. Then added `milk`, `bread`, ticked `milk`, added `eggs` — final order is `bread`, `eggs`, then the checked `milk` at the bottom, so a new item lands after the open ones and before the checked pile, with no double row in between.

## Testing

4 new tests on the seeded-name helpers (66 web, 279 total), typecheck and lint clean. The jumping itself is not unit-testable without DOM tooling the project does not carry — that one is verified in a browser and by the render order being explicit rather than incidental.