### PR TITLE
feat: sections inside a list

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -162,6 +162,10 @@ Items are deliberately plain text with no quantity, assignee or due date: a list
 
 One list ships with a fresh hub, so the feature works before anyone configures anything; more can be added, renamed and deleted. Adding is also one of the four one-tap actions on the phone home screen.
 
+Long lists can be split into **sections** — "Vegetables", "Dairy", "Household" — for the case several lists do not cover: one trip through one shop, read by aisle. Membership is optional and depth is one level: an item with no section is normal, not unfiled, and sits above the sections so that typing into the main field stays the fastest path. Each section has its own input, so putting something in one is a tap rather than a menu.
+
+Deleting a section keeps its items — they rise back to the top of the list. The items are the point; the grouping is a convenience, and the confirmation says so before you click.
+
 **A list can be handed to someone without an account** — typically whoever is going to the shop. Unlike the other share links in the hub, this one accepts a write: the guest can tick items off, because a shopping list nobody can tick off is a screenshot. That is the only thing they can do — no adding, no renaming, no deleting, and nothing beyond that single list is visible. Ticks land on the same list the family sees, since it is the same list and not a copy. The link is revocable, deleting the list revokes it too, and asking twice returns the same link so it can be re-sent.
 
 ## Mail

--- a/server/src/db/migrations/029_list_sections.sql
+++ b/server/src/db/migrations/029_list_sections.sql
@@ -1,0 +1,31 @@
+-- Sections inside a list: "Vegetables", "Dairy", "Household".
+--
+-- Why sections and not more lists: several lists already exist and are the
+-- right answer for separate errands ("Groceries" vs "Hardware"). Sections
+-- answer the other case — one trip through one supermarket, read by aisle.
+--
+-- Depth is one level, like money's subcategories (012), and for the same
+-- reason: a tree turns every render into recursion while a family gets by
+-- with "group → line". An item belongs to a section or to nothing; a
+-- section never belongs to a section.
+--
+-- Membership is optional, deliberately. #11 was about speed — typing an
+-- item must never require choosing where it goes — so an item with no
+-- section is normal, not unfiled: it simply sits above the sections.
+--
+-- Deleting a section does not delete its items (ON DELETE SET NULL): they
+-- rise to the top of the list, exactly as subcategories rise to the top
+-- level when their parent goes. The items are the point; the grouping is
+-- a convenience.
+
+CREATE TABLE list_sections (
+  id         TEXT PRIMARY KEY,
+  list_id    TEXT NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+  title      TEXT NOT NULL,
+  position   REAL NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX idx_list_sections_list ON list_sections(list_id, position);
+
+ALTER TABLE list_items ADD COLUMN section_id TEXT REFERENCES list_sections(id) ON DELETE SET NULL;
+CREATE INDEX idx_list_items_section ON list_items(section_id);

--- a/server/src/routes/lists.test.ts
+++ b/server/src/routes/lists.test.ts
@@ -223,6 +223,97 @@ describe('shared lists', () => {
     expect(guest.json<{ title: string }>().title).toBe('New name');
   });
 
+  it('groups items into sections, and leaves sectionless items alone', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Supermarket' });
+    const listId = made.json<{ id: string }>().id;
+    const veg = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/sections`, { title: 'Vegetables' }))
+      .json<{ id: string }>().id;
+
+    // An item with a section, and one without — the second is normal, not
+    // "unfiled": #11 says typing must never require choosing a place
+    await h.as(alice.cookie, 'POST', `/api/lists/${listId}/items`, { title: 'tomatoes', section_id: veg });
+    await h.as(alice.cookie, 'POST', `/api/lists/${listId}/items`, { title: 'batteries' });
+
+    const list = (await h.as(alice.cookie, 'GET', `/api/lists/${listId}`)).json<{
+      sections: { id: string; title: string }[];
+      items: { title: string; section_id: string | null }[];
+    }>();
+    expect(list.sections.map((s) => s.title)).toEqual(['Vegetables']);
+    expect(list.items.find((i) => i.title === 'tomatoes')!.section_id).toBe(veg);
+    expect(list.items.find((i) => i.title === 'batteries')!.section_id).toBeNull();
+  });
+
+  it('moves an item into a section and back out', async () => {
+    const made = await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Move test' });
+    const listId = made.json<{ id: string }>().id;
+    const dairy = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/sections`, { title: 'Dairy' }))
+      .json<{ id: string }>().id;
+    const itemId = await add(alice.cookie, 'cheese', listId);
+
+    const moved = await h.as(alice.cookie, 'PATCH', `/api/list-items/${itemId}/section`, {
+      section_id: dairy,
+    });
+    expect(moved.json<{ section_id: string | null }>().section_id).toBe(dairy);
+
+    const out = await h.as(alice.cookie, 'PATCH', `/api/list-items/${itemId}/section`, { section_id: null });
+    expect(out.json<{ section_id: string | null }>().section_id).toBeNull();
+  });
+
+  it('refuses a section belonging to another list', async () => {
+    const a = (await h.as(alice.cookie, 'POST', '/api/lists', { title: 'List A' })).json<{ id: string }>().id;
+    const b = (await h.as(alice.cookie, 'POST', '/api/lists', { title: 'List B' })).json<{ id: string }>().id;
+    const sectionInB = (await h.as(alice.cookie, 'POST', `/api/lists/${b}/sections`, { title: 'Elsewhere' }))
+      .json<{ id: string }>().id;
+
+    // Either way round this would make the item disappear from the list
+    // it belongs to, which reads as data loss
+    const onCreate = await h.as(alice.cookie, 'POST', `/api/lists/${a}/items`, {
+      title: 'stray',
+      section_id: sectionInB,
+    });
+    expect(onCreate.statusCode).toBe(400);
+
+    const itemInA = await add(alice.cookie, 'settled', a);
+    const onMove = await h.as(alice.cookie, 'PATCH', `/api/list-items/${itemInA}/section`, {
+      section_id: sectionInB,
+    });
+    expect(onMove.statusCode).toBe(400);
+  });
+
+  it('keeps the items when a section is deleted', async () => {
+    const listId = (await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Tidy up' })).json<{ id: string }>().id;
+    const section = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/sections`, { title: 'Bakery' }))
+      .json<{ id: string }>().id;
+    await h.as(alice.cookie, 'POST', `/api/lists/${listId}/items`, { title: 'sourdough', section_id: section });
+
+    expect((await h.as(alice.cookie, 'DELETE', `/api/list-sections/${section}`)).statusCode).toBe(200);
+
+    const list = (await h.as(alice.cookie, 'GET', `/api/lists/${listId}`)).json<{
+      sections: unknown[];
+      items: { title: string; section_id: string | null }[];
+    }>();
+    // The heading is gone; the bread is not
+    expect(list.sections).toEqual([]);
+    expect(list.items.map((i) => i.title)).toEqual(['sourdough']);
+    expect(list.items[0]!.section_id).toBeNull();
+  });
+
+  it('shows sections to a guest, who is usually the one in the shop', async () => {
+    const listId = (await h.as(alice.cookie, 'POST', '/api/lists', { title: 'Guest sections' })).json<{ id: string }>().id;
+    const aisle = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/sections`, { title: 'Frozen' }))
+      .json<{ id: string }>().id;
+    await h.as(alice.cookie, 'POST', `/api/lists/${listId}/items`, { title: 'peas', section_id: aisle });
+    const token = (await h.as(alice.cookie, 'POST', `/api/lists/${listId}/share`, {}))
+      .json<{ path: string }>().path.replace('/list/', '');
+
+    const guest = (await h.app.inject({ url: `/api/list/${token}` })).json<{
+      sections: { title: string }[];
+      items: { title: string; section_id: string | null }[];
+    }>();
+    expect(guest.sections.map((s) => s.title)).toEqual(['Frozen']);
+    expect(guest.items[0]!.section_id).toBe(aisle);
+  });
+
   it('refuses an empty name and an unknown list', async () => {
     expect((await h.as(alice.cookie, 'POST', '/api/lists', { title: '   ' })).statusCode).toBe(400);
     const ghostList = '00000000-0000-4000-8000-0000000009f9';

--- a/server/src/routes/lists.ts
+++ b/server/src/routes/lists.ts
@@ -69,7 +69,10 @@ export async function registerListRoutes(app: FastifyInstance): Promise<void> {
                    checked_at DESC`,
       )
       .all(listId);
-    return { ...list, items };
+    const sections = db
+      .prepare('SELECT id, title, position FROM list_sections WHERE list_id = ? ORDER BY position, title')
+      .all(listId);
+    return { ...list, items, sections };
   });
 
   app.patch('/api/lists/:id', (req, reply) => {
@@ -95,20 +98,38 @@ export async function registerListRoutes(app: FastifyInstance): Promise<void> {
   /** One tap: add an item. Position goes to the end — a list reads in the order it was written. */
   app.post('/api/lists/:id/items', (req, reply) => {
     const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
-    const parsed = titleInput.safeParse(req.body);
+    const parsed = titleInput
+      .extend({ section_id: z.string().uuid().nullable().optional() })
+      .safeParse(req.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
     }
     const exists = db.prepare('SELECT 1 FROM lists WHERE id = ?').get(listId);
     if (!exists) return reply.code(404).send({ error: 'List not found' });
 
+    // A section from another list would quietly move the item out of view
+    if (parsed.data.section_id) {
+      const section = db
+        .prepare('SELECT 1 FROM list_sections WHERE id = ? AND list_id = ?')
+        .get(parsed.data.section_id, listId);
+      if (!section) return reply.code(400).send({ error: 'Section not found in this list' });
+    }
+
     // Duplicates are allowed on purpose: "milk" twice means two bottles,
     // and a dedupe check would be a surprise mid-shop.
     const itemId = id();
     db.prepare(
-      `INSERT INTO list_items (id, list_id, title, position, created_by, created_at)
-       VALUES (?, ?, ?, (SELECT coalesce(max(position), 0) + 1 FROM list_items WHERE list_id = ?), ?, ?)`,
-    ).run(itemId, listId, parsed.data.title, listId, req.user!.id, now());
+      `INSERT INTO list_items (id, list_id, title, section_id, position, created_by, created_at)
+       VALUES (?, ?, ?, ?, (SELECT coalesce(max(position), 0) + 1 FROM list_items WHERE list_id = ?), ?, ?)`,
+    ).run(
+      itemId,
+      listId,
+      parsed.data.title,
+      parsed.data.section_id ?? null,
+      listId,
+      req.user!.id,
+      now(),
+    );
     return reply.code(201).send(db.prepare('SELECT * FROM list_items WHERE id = ?').get(itemId));
   });
 
@@ -144,6 +165,76 @@ export async function registerListRoutes(app: FastifyInstance): Promise<void> {
       .prepare('DELETE FROM list_items WHERE list_id = ? AND checked_at IS NOT NULL')
       .run(listId);
     return { cleared: result.changes };
+  });
+
+  // ── Sections ──────────────────────────────────────────────────────────
+
+  app.post('/api/lists/:id/sections', (req, reply) => {
+    const { id: listId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const parsed = titleInput.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    const exists = db.prepare('SELECT 1 FROM lists WHERE id = ?').get(listId);
+    if (!exists) return reply.code(404).send({ error: 'List not found' });
+
+    const sectionId = id();
+    db.prepare(
+      `INSERT INTO list_sections (id, list_id, title, position, created_at)
+       VALUES (?, ?, ?, (SELECT coalesce(max(position), 0) + 1 FROM list_sections WHERE list_id = ?), ?)`,
+    ).run(sectionId, listId, parsed.data.title, listId, now());
+    return reply
+      .code(201)
+      .send(db.prepare('SELECT id, title, position FROM list_sections WHERE id = ?').get(sectionId));
+  });
+
+  app.patch('/api/list-sections/:id', (req, reply) => {
+    const { id: sectionId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const parsed = titleInput.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    const result = db
+      .prepare('UPDATE list_sections SET title = ? WHERE id = ?')
+      .run(parsed.data.title, sectionId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'Section not found' });
+    return db.prepare('SELECT id, title, position FROM list_sections WHERE id = ?').get(sectionId);
+  });
+
+  /*
+    Deleting a section keeps its items — ON DELETE SET NULL sends them back
+    to the top of the list. The items are the point; the grouping is a
+    convenience, and losing "milk" because a heading was tidied away would
+    be the wrong trade (same reasoning as money's subcategories).
+  */
+  app.delete('/api/list-sections/:id', (req, reply) => {
+    const { id: sectionId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const result = db.prepare('DELETE FROM list_sections WHERE id = ?').run(sectionId);
+    if (result.changes === 0) return reply.code(404).send({ error: 'Section not found' });
+    return { ok: true };
+  });
+
+  /** Move an item into a section, or out of one with null. */
+  app.patch('/api/list-items/:id/section', (req, reply) => {
+    const { id: itemId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const parsed = z.object({ section_id: z.string().uuid().nullable() }).safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'Check the fields' });
+
+    const item = db.prepare('SELECT list_id FROM list_items WHERE id = ?').get(itemId) as
+      | { list_id: string }
+      | undefined;
+    if (!item) return reply.code(404).send({ error: 'Item not found' });
+
+    if (parsed.data.section_id) {
+      // Both belong to the same list, or the item would vanish from view
+      const section = db
+        .prepare('SELECT 1 FROM list_sections WHERE id = ? AND list_id = ?')
+        .get(parsed.data.section_id, item.list_id);
+      if (!section) return reply.code(400).send({ error: 'Section not found in this list' });
+    }
+
+    db.prepare('UPDATE list_items SET section_id = ? WHERE id = ?').run(parsed.data.section_id, itemId);
+    return db.prepare('SELECT * FROM list_items WHERE id = ?').get(itemId);
   });
 
   // ── The public link ───────────────────────────────────────────────────
@@ -194,13 +285,18 @@ export async function registerListRoutes(app: FastifyInstance): Promise<void> {
 
     const items = db
       .prepare(
-        `SELECT id, title, checked_at FROM list_items
+        `SELECT id, title, checked_at, section_id FROM list_items
           WHERE list_id = ?
           ORDER BY checked_at IS NOT NULL, CASE WHEN checked_at IS NULL THEN position END,
                    checked_at DESC`,
       )
       .all(list.id);
-    return { id: list.id, title: list.title, items };
+    // Sections travel with the guest view: reading by aisle is the reason
+    // they exist, and the person in the shop is usually the guest
+    const sections = db
+      .prepare('SELECT id, title FROM list_sections WHERE list_id = ? ORDER BY position, title')
+      .all(list.id);
+    return { id: list.id, title: list.title, items, sections };
   });
 
   /*

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -655,6 +655,16 @@ export const ru: Record<string, string> = {
   'Your own colors for projects, accounts, categories and calendars — on top of the stock ones. Grows from here and from the "+" button right in the color picker.': 'Свои цвета для проектов, счетов, категорий и календарей — поверх стандартных. Пополняется и отсюда, и кнопкой «+» прямо в выборе цвета.',
   'Zero — the goal is only a countdown': 'Ноль — только отсчёт, без накоплений',
 
+  // ── Разделы внутри списка ─────────────────────────────────────────────
+  'New section': 'Новый раздел',
+  'Name of the section': 'Название раздела',
+  'Delete the section': 'Удалить раздел',
+  '“{title}” will be removed. The items in it stay on the list.':
+    '«{title}» будет удалён. Пункты из него останутся в списке.',
+  'Add to “{section}”': 'Добавить в «{section}»',
+  'Section not found': 'Раздел не найден',
+  'Section not found in this list': 'В этом списке такого раздела нет',
+
   // ── Управление списком и ссылка на список ─────────────────────────────
   'Rename': 'Переименовать',
   'Rename the list': 'Переименовать список',

--- a/web/src/lib/lists.test.ts
+++ b/web/src/lib/lists.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { listTitle, SHOPPING_LIST_ID } from './lists';
+import { projectTitle } from './tasks';
+
+/*
+  Seeded names are stored in English and translated back by id. The trap —
+  hit in production on the shopping list — is doing that unconditionally:
+  the rename saves on the server, the helper then overwrites it on screen,
+  and the feature reads as "renaming does nothing".
+
+  calendarName had the guard from the start; these two did not. The rule is
+  translate the *seeded value*, never the row.
+*/
+
+const INBOX_ID = '00000000-0000-4000-8000-000000000001';
+
+describe('seeded name helpers', () => {
+  it('translates a list that still carries its seeded name', () => {
+    // No dictionary is loaded in tests, so t() passes the key through —
+    // what matters is that the seeded branch is taken at all
+    expect(listTitle(SHOPPING_LIST_ID, 'Shopping')).toBe('Shopping');
+  });
+
+  it('leaves a renamed list alone', () => {
+    expect(listTitle(SHOPPING_LIST_ID, 'Groceries')).toBe('Groceries');
+    // The bug as reported: the family renames it and sees no change
+    expect(listTitle(SHOPPING_LIST_ID, 'Продукты')).toBe('Продукты');
+  });
+
+  it('never touches a list it did not seed', () => {
+    expect(listTitle('11111111-2222-4333-8444-555555555555', 'Shopping')).toBe('Shopping');
+    expect(listTitle('11111111-2222-4333-8444-555555555555', 'Hardware')).toBe('Hardware');
+  });
+
+  it('applies the same rule to the Inbox project', () => {
+    // Inbox cannot be archived or deleted, but it can be renamed
+    expect(projectTitle(INBOX_ID, 'Inbox')).toBe('Inbox');
+    expect(projectTitle(INBOX_ID, 'Входящие')).toBe('Inbox');
+    expect(projectTitle(INBOX_ID, 'Triage')).toBe('Triage');
+    expect(projectTitle(null, 'Anything')).toBe('Anything');
+  });
+});

--- a/web/src/lib/lists.ts
+++ b/web/src/lib/lists.ts
@@ -21,6 +21,14 @@ export interface ListItem {
   title: string;
   checked_at: string | null;
   position: number;
+  /** Null is normal, not "unfiled": typing an item never requires a place */
+  section_id?: string | null;
+}
+
+export interface ListSection {
+  id: string;
+  title: string;
+  position: number;
 }
 
 export interface SharedList {
@@ -35,4 +43,5 @@ export interface SharedList {
 
 export interface ListWithItems extends SharedList {
   items: ListItem[];
+  sections: ListSection[];
 }

--- a/web/src/lib/lists.ts
+++ b/web/src/lib/lists.ts
@@ -8,7 +8,11 @@ import { t } from './i18n';
 export const SHOPPING_LIST_ID = '00000000-0000-4000-8000-000000000301';
 
 export function listTitle(id: string, title: string): string {
-  return id === SHOPPING_LIST_ID ? t('Shopping') : title;
+  // Guarded on the seeded value, the way calendarName already was and this
+  // did not copy: without it a rename saves on the server and is then
+  // overwritten on screen by the translation, which reads as "renaming
+  // does nothing".
+  return id === SHOPPING_LIST_ID && title === 'Shopping' ? t('Shopping') : title;
 }
 
 export interface ListItem {

--- a/web/src/lib/tasks.ts
+++ b/web/src/lib/tasks.ts
@@ -46,7 +46,10 @@ export const INBOX_ID = '00000000-0000-4000-8000-000000000001';
  * id — translate in place (English seed since migration 013).
  */
 export function projectTitle(id: string | null | undefined, title: string): string {
-  return id === INBOX_ID ? t('Inbox') : title;
+  // Same guard as calendarName: translate the seeded name, leave a renamed
+  // one alone. Inbox cannot be archived or deleted, but it can be renamed,
+  // so without this a rename looked like it had failed.
+  return id === INBOX_ID && (title === 'Inbox' || title === 'Входящие') ? t('Inbox') : title;
 }
 
 export interface TaskNode extends Task {

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -15,6 +15,32 @@ import { listTitle, type ListItem, type ListWithItems, type SharedList } from '.
   show the truth" rather than a spinner on every checkbox. The input keeps
   focus after adding, because the real gesture is three items in a row.
 */
+/** One row, so an open item and a checked one cannot drift apart. */
+function ListRow({ item, onToggle }: { item: ListItem; onToggle: () => void }) {
+  return (
+    <li className="border-b border-line last:border-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors active:bg-surface-2"
+      >
+        <span
+          className={`flex size-5 shrink-0 items-center justify-center rounded border ${
+            item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
+          }`}
+        >
+          {item.checked_at && (
+            <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
+              <path d="m5 13 4 4 10-10" />
+            </svg>
+          )}
+        </span>
+        <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
+      </button>
+    </li>
+  );
+}
+
 export function Lists() {
   const [lists, setLists] = useState<SharedList[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -72,13 +98,20 @@ export function Lists() {
     // The row shows immediately; the request follows
     setPending((p) => [...p, title]);
     try {
-      await api.post(`/lists/${activeId}/items`, { title });
-      await Promise.all([loadList(activeId), loadLists()]);
+      const created = await api.post<ListItem>(`/lists/${activeId}/items`, { title });
+      /*
+        Both updates in one tick, so React renders once: the real row in,
+        the placeholder out. Reloading the whole list here instead meant a
+        frame where the item existed twice — placeholder and row — which is
+        the other half of what looked like items jumping about.
+      */
+      setList((l) => (l ? { ...l, items: [...l.items, created] } : l));
+      setPending((p) => p.filter((x) => x !== title));
+      await loadLists();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('Something went wrong'));
-      void loadList(activeId);
-    } finally {
       setPending((p) => p.filter((x) => x !== title));
+      void loadList(activeId);
     }
   }
 
@@ -288,6 +321,12 @@ export function Lists() {
           </div>
         ) : (
           <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
+            {open.map((item) => (
+              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
+            ))}
+            {/* Between the open items and the checked pile — where the server
+                is about to put it. Rendered first, it appeared at the top and
+                then jumped to the end when the response arrived. */}
             {pending.map((title, i) => (
               <li key={`pending-${i}`} className="border-b border-line last:border-0">
                 <span className="flex items-center gap-3 px-4 py-3 text-muted">
@@ -296,29 +335,8 @@ export function Lists() {
                 </span>
               </li>
             ))}
-            {[...open, ...checked].map((item) => (
-              <li key={item.id} className="border-b border-line last:border-0">
-                <button
-                  type="button"
-                  onClick={() => void toggle(item)}
-                  className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors active:bg-surface-2"
-                >
-                  <span
-                    className={`flex size-5 shrink-0 items-center justify-center rounded border ${
-                      item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
-                    }`}
-                  >
-                    {item.checked_at && (
-                      <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
-                        <path d="m5 13 4 4 10-10" />
-                      </svg>
-                    )}
-                  </span>
-                  <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>
-                    {item.title}
-                  </span>
-                </button>
-              </li>
+            {checked.map((item) => (
+              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
             ))}
           </ul>
         )}

--- a/web/src/pages/Lists.tsx
+++ b/web/src/pages/Lists.tsx
@@ -4,7 +4,13 @@ import { api } from '../lib/api';
 import { Empty, Page } from '../components/Page';
 import { onEnter } from '../lib/keys';
 import { inlineDanger, useDialogs } from '../components/Dialog';
-import { listTitle, type ListItem, type ListWithItems, type SharedList } from '../lib/lists';
+import {
+  listTitle,
+  type ListItem,
+  type ListSection,
+  type ListWithItems,
+  type SharedList,
+} from '../lib/lists';
 
 /*
   Shared lists (#11) — the shopping list and its friends.
@@ -38,6 +44,62 @@ function ListRow({ item, onToggle }: { item: ListItem; onToggle: () => void }) {
         <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
       </button>
     </li>
+  );
+}
+
+/**
+ * One section: its heading, its items, and its own input.
+ *
+ * The input is per section rather than a "which section?" picker on the
+ * main one, because a picker would put a choice in front of every single
+ * add — the thing #11 was explicitly about not doing. Tapping the field
+ * under a heading is the choice, and only when you want it.
+ */
+function SectionBlock({
+  section,
+  items,
+  onToggle,
+  onAdd,
+  onDelete,
+}: {
+  section: ListSection;
+  items: ListItem[];
+  onToggle: (item: ListItem) => void;
+  onAdd: (value: string) => void;
+  onDelete: () => void;
+}) {
+  const [draft, setDraft] = useState('');
+
+  function submit() {
+    const value = draft.trim();
+    if (!value) return;
+    setDraft('');
+    onAdd(value);
+  }
+
+  return (
+    <section className="mt-5">
+      <div className="mb-2 flex items-baseline justify-between gap-3">
+        <h2 className="eyebrow">{section.title}</h2>
+        <button type="button" onClick={onDelete} className={`${inlineDanger} text-xs`}>
+          {t('Delete')}
+        </button>
+      </div>
+      {items.length > 0 && (
+        <ul className="overflow-hidden rounded-card border border-line bg-surface">
+          {items.map((item) => (
+            <ListRow key={item.id} item={item} onToggle={() => onToggle(item)} />
+          ))}
+        </ul>
+      )}
+      <input
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onEnter(submit)}
+        placeholder={t('Add to “{section}”', { section: section.title })}
+        className="mt-2 w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+      />
+    </section>
   );
 }
 
@@ -90,15 +152,18 @@ export function Lists() {
     }
   }, [list]);
 
-  async function addItem() {
-    const title = draft.trim();
+  async function addItem(sectionId: string | null = null, value?: string) {
+    const title = (value ?? draft).trim();
     if (!title || !activeId) return;
-    setDraft('');
+    if (value === undefined) setDraft('');
     setError(null);
     // The row shows immediately; the request follows
     setPending((p) => [...p, title]);
     try {
-      const created = await api.post<ListItem>(`/lists/${activeId}/items`, { title });
+      const created = await api.post<ListItem>(`/lists/${activeId}/items`, {
+        title,
+        section_id: sectionId,
+      });
       /*
         Both updates in one tick, so React renders once: the real row in,
         the placeholder out. Reloading the whole list here instead meant a
@@ -191,6 +256,34 @@ export function Lists() {
     await loadLists();
   }
 
+  async function newSection() {
+    if (!list) return;
+    const title = await dialogs.prompt({
+      title: t('New section'),
+      label: t('Name of the section'),
+      confirmLabel: t('Create'),
+    });
+    if (!title?.trim()) return;
+    await api.post(`/lists/${list.id}/sections`, { title: title.trim() });
+    await loadList(list.id);
+  }
+
+  async function removeSection(section: ListSection) {
+    const ok = await dialogs.confirm({
+      title: t('Delete the section'),
+      // Worth stating: this is not what "delete" usually implies, and the
+      // reassurance is the reason it is safe to click
+      message: t('“{title}” will be removed. The items in it stay on the list.', {
+        title: section.title,
+      }),
+      confirmLabel: t('Delete'),
+      danger: true,
+    });
+    if (!ok || !list) return;
+    await api.delete(`/list-sections/${section.id}`);
+    await loadList(list.id);
+  }
+
   async function share() {
     if (!list) return;
     const res = await api.post<{ path: string }>(`/lists/${list.id}/share`, {});
@@ -208,6 +301,15 @@ export function Lists() {
   // switch between, so the heading is the only place its name can show.
   const open = list?.items.filter((i) => !i.checked_at) ?? [];
   const checked = list?.items.filter((i) => i.checked_at) ?? [];
+  /*
+    Sectionless items come first, then each section. That order is on
+    purpose: typing into the main input must stay the fastest path, so what
+    it produces has to appear where the eye already is — not below three
+    headings. The checked pile stays one pile at the bottom regardless of
+    section: on the way home "what did we get" is one question, not four.
+  */
+  const loose = open.filter((i) => !i.section_id);
+  const sections = list?.sections ?? [];
 
   return (
     <Page
@@ -315,41 +417,69 @@ export function Lists() {
         />
         {error && <p className="mt-2 text-sm text-urgent">{error}</p>}
 
-        {open.length === 0 && checked.length === 0 && pending.length === 0 ? (
+        {open.length === 0 && checked.length === 0 && pending.length === 0 && sections.length === 0 ? (
           <div className="mt-4">
             <Empty>{t('Nothing here yet. Add the first item above.')}</Empty>
           </div>
         ) : (
-          <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
-            {open.map((item) => (
-              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
+          <>
+            {(loose.length > 0 || pending.length > 0) && (
+              <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
+                {loose.map((item) => (
+                  <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
+                ))}
+                {/* Where the server is about to put it: rendered above the
+                    rows, it appeared at the top and then jumped to the end */}
+                {pending.map((title, i) => (
+                  <li key={`pending-${i}`} className="border-b border-line last:border-0">
+                    <span className="flex items-center gap-3 px-4 py-3 text-muted">
+                      <span className="size-5 shrink-0 rounded border border-line" />
+                      {title}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {sections.map((section) => (
+              <SectionBlock
+                key={section.id}
+                section={section}
+                items={open.filter((i) => i.section_id === section.id)}
+                onToggle={(item) => void toggle(item)}
+                onAdd={(value) => void addItem(section.id, value)}
+                onDelete={() => void removeSection(section)}
+              />
             ))}
-            {/* Between the open items and the checked pile — where the server
-                is about to put it. Rendered first, it appeared at the top and
-                then jumped to the end when the response arrived. */}
-            {pending.map((title, i) => (
-              <li key={`pending-${i}`} className="border-b border-line last:border-0">
-                <span className="flex items-center gap-3 px-4 py-3 text-muted">
-                  <span className="size-5 shrink-0 rounded border border-line" />
-                  {title}
-                </span>
-              </li>
-            ))}
-            {checked.map((item) => (
-              <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
-            ))}
-          </ul>
+
+            {checked.length > 0 && (
+              <ul className="mt-4 overflow-hidden rounded-card border border-line bg-surface">
+                {checked.map((item) => (
+                  <ListRow key={item.id} item={item} onToggle={() => void toggle(item)} />
+                ))}
+              </ul>
+            )}
+          </>
         )}
 
-        {checked.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-4">
           <button
             type="button"
-            onClick={() => void clearChecked()}
-            className="mt-3 text-sm text-muted underline hover:text-ink"
+            onClick={() => void newSection()}
+            className="text-sm text-muted underline hover:text-ink"
           >
-            {t('Clear checked ({n})', { n: String(checked.length) })}
+            {t('New section')}
           </button>
-        )}
+          {checked.length > 0 && (
+            <button
+              type="button"
+              onClick={() => void clearChecked()}
+              className="text-sm text-muted underline hover:text-ink"
+            >
+              {t('Clear checked ({n})', { n: String(checked.length) })}
+            </button>
+          )}
+        </div>
       </div>
     </Page>
   );

--- a/web/src/pages/PublicList.tsx
+++ b/web/src/pages/PublicList.tsx
@@ -17,12 +17,54 @@ interface GuestItem {
   id: string;
   title: string;
   checked_at: string | null;
+  section_id: string | null;
+}
+
+interface GuestSection {
+  id: string;
+  title: string;
+}
+
+function GuestRows({
+  items,
+  onToggle,
+}: {
+  items: GuestItem[];
+  onToggle: (item: GuestItem) => void;
+}) {
+  return (
+    <ul className="overflow-hidden rounded-card border border-line bg-surface">
+      {items.map((item) => (
+        <li key={item.id} className="border-b border-line last:border-0">
+          <button
+            type="button"
+            onClick={() => onToggle(item)}
+            className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors active:bg-surface-2"
+          >
+            <span
+              className={`flex size-5 shrink-0 items-center justify-center rounded border ${
+                item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
+              }`}
+            >
+              {item.checked_at && (
+                <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
+                  <path d="m5 13 4 4 10-10" />
+                </svg>
+              )}
+            </span>
+            <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 export function PublicList() {
   const { token } = useParams<{ token: string }>();
   const [title, setTitle] = useState<string | null>(null);
   const [items, setItems] = useState<GuestItem[]>([]);
+  const [sections, setSections] = useState<GuestSection[]>([]);
   const [dead, setDead] = useState(false);
 
   const load = useCallback(async () => {
@@ -31,9 +73,14 @@ export function PublicList() {
       setDead(true);
       return;
     }
-    const body = (await res.json()) as { title: string; items: GuestItem[] };
+    const body = (await res.json()) as {
+      title: string;
+      items: GuestItem[];
+      sections: GuestSection[];
+    };
     setTitle(body.title);
     setItems(body.items);
+    setSections(body.sections ?? []);
   }, [token]);
 
   useEffect(() => {
@@ -63,6 +110,9 @@ export function PublicList() {
 
   const open = items.filter((i) => !i.checked_at);
   const checked = items.filter((i) => i.checked_at);
+  // Reading by aisle is why sections exist, and the guest is usually the
+  // one holding the phone in the shop — so the grouping travels here too
+  const loose = open.filter((i) => !i.section_id);
 
   return (
     <main className="mx-auto max-w-lg px-5 py-12">
@@ -73,30 +123,24 @@ export function PublicList() {
       {items.length === 0 ? (
         <p className="mt-8 text-sm text-muted">{t('This list is empty.')}</p>
       ) : (
-        <ul className="mt-6 overflow-hidden rounded-card border border-line bg-surface">
-          {[...open, ...checked].map((item) => (
-            <li key={item.id} className="border-b border-line last:border-0">
-              <button
-                type="button"
-                onClick={() => void toggle(item)}
-                className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors active:bg-surface-2"
-              >
-                <span
-                  className={`flex size-5 shrink-0 items-center justify-center rounded border ${
-                    item.checked_at ? 'border-accent bg-accent text-white' : 'border-line'
-                  }`}
-                >
-                  {item.checked_at && (
-                    <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="3">
-                      <path d="m5 13 4 4 10-10" />
-                    </svg>
-                  )}
-                </span>
-                <span className={item.checked_at ? 'text-muted line-through' : 'text-ink'}>{item.title}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
+        <>
+          {loose.length > 0 && <GuestRows items={loose} onToggle={(i) => void toggle(i)} />}
+          {sections.map((section) => {
+            const inSection = open.filter((i) => i.section_id === section.id);
+            if (inSection.length === 0) return null;
+            return (
+              <section key={section.id} className="mt-6">
+                <h2 className="eyebrow mb-2">{section.title}</h2>
+                <GuestRows items={inSection} onToggle={(i) => void toggle(i)} />
+              </section>
+            );
+          })}
+          {checked.length > 0 && (
+            <div className="mt-6">
+              <GuestRows items={checked} onToggle={(i) => void toggle(i)} />
+            </div>
+          )}
+        </>
       )}
     </main>
   );


### PR DESCRIPTION
**Depends on [#167](https://github.com/neiliro/neiliro/pull/167)** — same file, so this branches from there rather than master. Merge #167 first.

## Why sections and not more lists

Several lists already exist and are the right answer for separate errands ("Groceries" vs "Hardware"). Sections answer the other case: **one trip through one shop, read by aisle.** Doing both with lists would mean five lists for one supermarket run.

## The two constraints that shaped it

**Depth is one level**, like money's subcategories — a tree turns every render into recursion while a family gets by with "group → line".

**Membership is optional, and that is the load-bearing part.** #11 was about speed: typing an item must never require choosing where it goes. So an item with no section is *normal*, not "unfiled", and it renders **above** the sections — where the eye already is after typing into the main field. Each section owns its own input rather than the main field growing a section picker, because a picker puts a choice in front of every single add.

**Deleting a section keeps its items** — `ON DELETE SET NULL` sends them back to the top of the list. Same trade money's subcategories make: the items are the point, the grouping is a convenience. The confirmation says so out loud, since that is not what "delete" usually implies.

**The guest page groups too.** Reading by aisle is the whole reason sections exist, and the guest is usually the one holding the phone in the shop.

## Verified by using it

Created "Vegetables", added `tomatoes` through the section's own input and `batteries` through the main one — `batteries` sits at the top, `tomatoes` under the heading. Then deleted the section: the confirmation read *"Vegetables" will be removed. The items in it stay on the list*, and after it `tomatoes` was still there, back at the top. Screenshots in the branch history.

## Testing

5 new server tests (218 server, 284 total): grouping with a sectionless item alongside, moving an item in and out, **a section from another list refused both on create and on move** (either way round the item would vanish from its own list — that reads as data loss), items surviving a section delete, and the guest view carrying sections.

Migration 029 smoke-run on a fresh `:memory:`: 29 applied, table and column present, `integrity_check ok`. Typecheck and lint clean.

## Not in this PR

**Moving an existing item between sections from the UI.** The endpoint exists and is tested; the interface for it wants either drag-and-drop or a picker, and both deserve their own look rather than being bolted on here.