### PR TITLE
ci: allow a run to be triggered by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [master, main]
   pull_request:
+  # Manual trigger, for when a run is lost rather than failed. An Actions
+  # incident on 2026-08-26 left the master run after #168 stuck in `queued`
+  # for sixteen hours: it never started, and it could be neither rerun
+  # ("already running") nor cancelled ("already completed"). Without this
+  # there was no way to ask for a fresh run — push to master is blocked by
+  # branch protection, which is correct and should stay that way.
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
Fixes the actual problem behind the stuck run, since the run itself cannot be fixed.

## What happened

Yesterday's Actions incident (`major_outage`, ~15:00–16:15 UTC) left CI **#250** — the master run after merging #168 — wedged:

- `queued` for **sixteen hours**, zero jobs, never started;
- `gh run rerun` refuses it: *"This workflow is already running"*;
- `gh run cancel` refuses the **same run**: *"Cannot cancel a workflow run that is completed"*.

GitHub's own state for it is inconsistent, so it is neither runnable nor clearable from our side.

## Why there was nothing to do about it

`ci.yml` triggers on push to `master` and on `pull_request`. Pushing to master is blocked by branch protection — correctly, and that stays. So the only way to get a fresh run of master was to invent a commit, which is a habit worth not building.

`workflow_dispatch` costs nothing and covers exactly this case: a run that was **lost** rather than failed. After this merges, the same situation is one click in the Actions tab.

## Is master actually fine?

Yes — verified independently of GitHub. On `d68598a` (the very commit #250 was meant to check), locally with a clean `npm ci`:

```
typecheck OK
lint OK
Tests  218 passed (server)
Tests   66 passed (web)
```

So the missing green tick was bookkeeping, not a real signal. This PR's own run is also the proof that Actions are working again.

## Note

#250 will probably stay listed as `queued` forever. Nothing to do about it, and worth recognising rather than re-investigating next time someone sees it in the list.