### PR TITLE
feat: point families at support, self-hosters at the issue tracker

### DIFF
--- a/scripts/qa-stack.sh
+++ b/scripts/qa-stack.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Bring up the hosted QA stand: the hub in hosted mode, the support site,
+# and a browser that believes both of them are neiliro.com.
+#
+# Why this exists next to the `qa-hosted` configuration in launch.json:
+#
+#   1. That one runs the server with tsx on the host's Node. better-sqlite3
+#      is a native module, and a host Node newer than its prebuilds cannot
+#      load it — the process dies before it serves anything. The container
+#      carries its own Node and its own build.
+#   2. The support link only appears on our own apex (web/src/lib/support.ts:
+#      hosted mode alone is not enough, or someone else's service would send
+#      us their families' messages). On hub.localhost it is correctly
+#      invisible — so the flow that has to be tested cannot be reached.
+#
+# So this stand serves the hub as *.neiliro.com and points the browser at
+# it with --host-resolver-rules. No /etc/hosts, no sudo, and the mapping
+# lives in one throwaway browser profile rather than on the machine.
+#
+# It also puts Caddy in front, which is not decoration. The app's CSP
+# carries upgrade-insecure-requests, so over plain http a browser upgrades
+# the bundle to https and the page never boots — invisible on
+# *.hub.localhost only because browsers count those as trustworthy and skip
+# the upgrade. On a real-looking hostname the stand has to speak TLS, which
+# is also what production does.
+#
+#   ./scripts/qa-stack.sh up      # build, provision, start, print URLs
+#   ./scripts/qa-stack.sh browser # open a Chrome that resolves the stand
+#   ./scripts/qa-stack.sh down    # remove the container and the data
+#
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WWW="${WWW_REPO:-$HOME/Documents/neiliro-www}"
+DATA="${QA_DATA_DIR:-$HOME/.family-hub-qa-hosted}"
+PROFILE="${QA_BROWSER_PROFILE:-$HOME/.family-hub-qa-browser}"
+CONTAINER=neiliro-qa
+PROXY=neiliro-qa-caddy
+TMP="${TMPDIR:-/tmp}"
+TMP="${TMP%/}"
+IMAGE=neiliro:qa
+HUB_PORT=8787
+TLS_PORT=8443
+WWW_PORT=8788
+FAMILIES=(smiths-qa01 jones-qa02)
+CHROME='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+
+# support.neiliro.com must resolve to the support site and every other
+# subdomain to the hub, so the specific rule comes first. The apex is left
+# alone: the FAQ links to the real privacy policy and terms.
+#
+# The rules carry the port too, so the addresses in the browser are the
+# production ones — https://smiths-qa01.neiliro.com, no port to remember,
+# and the support link in the app is followed rather than read.
+RESOLVER="MAP support.neiliro.com 127.0.0.1:${WWW_PORT}, MAP *.neiliro.com 127.0.0.1:${TLS_PORT}"
+
+# Detached with all three descriptors closed: a background job still
+# holding the script's stdout keeps the caller waiting forever.
+start_www() {
+  echo "==> starting the support site on :${WWW_PORT}"
+  pkill -f "wrangler pages dev" >/dev/null 2>&1 || true
+  cd "$WWW"
+  npx --yes wrangler@latest d1 execute neiliro-waitlist --local --file=schema.sql >/dev/null 2>&1 || true
+  # https, because the app links to https://support.neiliro.com and a
+  # click has to actually arrive. The certificate is wrangler's own
+  # throwaway one, which is why the QA browser ignores certificate errors.
+  nohup npx --yes wrangler@latest pages dev --port "$WWW_PORT" --local-protocol https \
+    >"${TMP}/qa-www.log" 2>&1 </dev/null &
+  disown
+  cd "$REPO"
+  for _ in $(seq 1 40); do
+    curl -skf -o /dev/null "https://127.0.0.1:${WWW_PORT}/support" && break
+    sleep 1
+  done
+}
+
+case "${1:-up}" in
+up)
+  echo "==> building ${IMAGE} from $(git -C "$REPO" branch --show-current)"
+  docker build -q -t "$IMAGE" "$REPO" >/dev/null
+
+  echo "==> starting the hub on :${HUB_PORT}"
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  mkdir -p "$DATA"
+  # The API key is a placeholder, and that is the point: its presence is
+  # what makes the hub advertise password reset, so the screen exists to be
+  # tested. Nothing can actually be sent — the provider rejects the key, the
+  # attempt shows in `docker logs`, and the route answers the same either
+  # way by design. Inbound mail is genuinely testable: see `mail` below.
+  docker run -d --name "$CONTAINER" -p "${HUB_PORT}:8787" \
+    -e HOSTED_MODE=true -e HOSTED_DOMAIN=neiliro.com \
+    -e MAIL_DOMAIN=mail.neiliro.com -e MAILGUN_SIGNING_KEY=qa-signing-key \
+    -e MAILGUN_API_KEY=qa-cannot-send \
+    -e TRUST_PROXY=true -e SECURE_COOKIES=true \
+    -e LOG_LEVEL=info \
+    -v "${DATA}:/data" --user 0:0 "$IMAGE" >/dev/null
+
+  for _ in $(seq 1 40); do
+    curl -sf -o /dev/null "http://127.0.0.1:${HUB_PORT}/api/health" && break
+    sleep 1
+  done
+
+  echo "==> putting TLS in front on :${TLS_PORT}"
+  docker rm -f "$PROXY" >/dev/null 2>&1 || true
+  # A self-signed wildcard, made here rather than left to Caddy's internal
+  # CA: a site block with no hostname does not turn TLS on by itself, and
+  # naming the hosts would leave the ghost — whose whole point is being an
+  # arbitrary name — without a certificate.
+  if [ ! -f "${TMP}/qa-cert.pem" ]; then
+    openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+      -keyout "${TMP}/qa-key.pem" -out "${TMP}/qa-cert.pem" \
+      -subj "/CN=*.neiliro.com" \
+      -addext "subjectAltName=DNS:*.neiliro.com,DNS:neiliro.com" >/dev/null 2>&1
+  fi
+  printf '{\n  auto_https off\n  admin off\n}\n:8443 {\n  tls /etc/caddy/cert.pem /etc/caddy/key.pem\n  reverse_proxy host.docker.internal:%s\n}\n' "$HUB_PORT" >"${TMP}/qa-Caddyfile"
+  docker run -d --name "$PROXY" -p "${TLS_PORT}:8443" \
+    -v "${TMP}/qa-Caddyfile:/etc/caddy/Caddyfile:ro" \
+    -v "${TMP}/qa-cert.pem:/etc/caddy/cert.pem:ro" \
+    -v "${TMP}/qa-key.pem:/etc/caddy/key.pem:ro" \
+    caddy:2-alpine >/dev/null
+  for _ in $(seq 1 40); do
+    curl -skf -o /dev/null "https://127.0.0.1:${TLS_PORT}/api/health" && break
+    sleep 1
+  done
+
+  for slug in "${FAMILIES[@]}"; do
+    docker exec "$CONTAINER" node server/dist/cli/create-family.js "$slug" 2>&1 |
+      grep -E 'Family created|already taken' || true
+  done
+
+  start_www
+
+  cat <<EOF
+
+Stand is up. In the QA browser (./scripts/qa-stack.sh browser):
+
+  https://smiths-qa01.neiliro.com   → the family under test
+  https://jones-qa02.neiliro.com    → its neighbour, for isolation checks
+  https://nobody-qa99.neiliro.com   → the ghost
+  https://support.neiliro.com       → the support site, where the app's
+                                      footer link lands
+
+Ports live in the resolver rules, so these are the production addresses
+exactly — including the https, which the app's CSP requires.
+
+Inbound mail (no Mailgun involved), from a shell:
+  ${REPO}/scripts/qa-stack.sh mail smiths-qa01
+
+Data: ${DATA} — disposable, delete it for a clean run.
+EOF
+  ;;
+
+www)
+  start_www
+  echo "support site ready on :${WWW_PORT}"
+  ;;
+
+browser)
+  echo "==> Chrome with its own profile, resolving *.neiliro.com to the stand"
+  mkdir -p "$PROFILE"
+  # The certificate belongs to wrangler's local server; this profile talks
+  # to nothing but 127.0.0.1, which is what the resolver rules guarantee.
+  "$CHROME" --user-data-dir="$PROFILE" \
+    --host-resolver-rules="$RESOLVER" \
+    --ignore-certificate-errors \
+    "https://smiths-qa01.neiliro.com" >/dev/null 2>&1 &
+  ;;
+
+mail)
+  slug="${2:-smiths-qa01}"
+  ts=$(date +%s)
+  token=$(printf 'a%.0s' {1..50})
+  sig=$(printf '%s%s' "$ts" "$token" | openssl dgst -sha256 -hmac 'qa-signing-key' -hex | sed 's/.*= //')
+  mime=$(printf 'Message-ID: <qa-%s@school.example>\r\nFrom: office@school.example\r\nTo: %s@mail.neiliro.com\r\nSubject: QA letter\r\n\r\nBody.\r\n' "$ts" "$slug")
+  curl -sS -X POST "http://127.0.0.1:${HUB_PORT}/api/mail/inbound/mime" \
+    -H "Host: in.neiliro.com" \
+    --data-urlencode "timestamp=$ts" --data-urlencode "token=$token" \
+    --data-urlencode "signature=$sig" \
+    --data-urlencode "recipient=${slug}@mail.neiliro.com" \
+    --data-urlencode "body-mime=$mime"
+  echo
+  ;;
+
+down)
+  docker rm -f "$CONTAINER" "$PROXY" >/dev/null 2>&1 || true
+  pkill -f "wrangler pages dev" >/dev/null 2>&1 || true
+  rm -rf "$DATA"
+  echo "stand removed, ${DATA} deleted"
+  ;;
+
+*)
+  echo "usage: $0 {up|browser|mail [slug]|down}" >&2
+  exit 1
+  ;;
+esac

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { t } from '../lib/i18n';
-import { BUILD_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
+import { BUILD_SHA, REPO_URL, VERSION } from '../lib/build';
 import { homeName } from '../lib/home-name';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useEffect, useState, type ReactNode } from 'react';
@@ -10,6 +10,8 @@ import { clearFailure, useFailure } from '../lib/failures';
 import { QuickAdd } from './QuickAdd';
 import { GlobalSearch, SearchTrigger } from './GlobalSearch';
 import { applyTheme, initialDark, persistTheme } from '../lib/theme';
+import { useServiceState } from '../lib/service';
+import { supportLink } from '../lib/support';
 
 interface NavItem {
   to: string;
@@ -280,6 +282,8 @@ export function AppShell() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [settings, setSettings] = useState<Record<string, string>>({});
   const sidebarNav = [...NAV, ...SECONDARY];
+  const service = useServiceState();
+  const help = supportLink(service?.hosted ?? false, window.location.hostname);
 
   useEffect(() => {
     void api
@@ -347,8 +351,10 @@ export function AppShell() {
           {/* The app's footer. Which build is on screen — a stale bundle in
               a long-lived tab looks exactly like a fix that never deployed,
               and this is the cheapest way to tell those apart — and the two
-              links worth having within reach. Settings → About repeats it
-              for phones, where this sidebar does not exist. */}
+              links worth having within reach. Where the second one goes
+              depends on who runs this hub: see lib/support.ts. Settings →
+              About repeats it for phones, where this sidebar does not
+              exist. */}
           <div className="px-2 text-muted">
             <p
               className="font-mono text-xs"
@@ -367,12 +373,12 @@ export function AppShell() {
                 {t('Source code')}
               </a>
               <a
-                href={ISSUES_URL}
+                href={help.href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline decoration-line underline-offset-2 hover:text-ink"
               >
-                {t('Report a bug')}
+                {help.label === 'Support' ? t('Support') : t('Report a bug')}
               </a>
             </span>
           </div>

--- a/web/src/lib/build.ts
+++ b/web/src/lib/build.ts
@@ -23,3 +23,10 @@ export const BUILD_SHA = __BUILD_SHA__;
  */
 export const REPO_URL = 'https://github.com/neiliro/neiliro';
 export const ISSUES_URL = `${REPO_URL}/issues`;
+
+/**
+ * The hosted service's help desk — FAQ and a form that reaches a human.
+ * It lives outside the hub deliberately: the moments that send someone
+ * looking for support are the moments the hub is unreachable.
+ */
+export const SUPPORT_URL = 'https://support.neiliro.com';

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -544,6 +544,7 @@ export const ru: Record<string, string> = {
   'Subcategories roll up into the parent in the summary; the parent limit counts their spending': 'Подкатегории сворачиваются в родителя в сводке, лимит родителя считает их траты',
   'Subtask': 'Подзадача',
   'Sunday': 'Воскресенье',
+  'Support': 'Поддержка',
   'Switch to dark theme': 'Включить тёмную тему',
   'Switch to light theme': 'Включить светлую тему',
   'Table': 'Таблица',

--- a/web/src/lib/service.ts
+++ b/web/src/lib/service.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { api } from './api';
+
+/**
+ * What kind of install this is — hosted or not, which sign-in doors exist.
+ *
+ * These are properties of the process, not of the session: they cannot
+ * change while the tab is open, so the answer is fetched once and shared.
+ * Two components asking the same question must not cost two requests —
+ * that is how a footer link turns into a poll.
+ */
+export interface ServiceState {
+  initialized: boolean;
+  google: boolean;
+  demo: boolean;
+  hosted: boolean;
+  password_reset: boolean;
+}
+
+let pending: Promise<ServiceState> | null = null;
+
+function load(): Promise<ServiceState> {
+  // A failed answer is not cached: the next mount should ask again rather
+  // than inherit one bad moment for the life of the tab.
+  pending ??= api.get<ServiceState>('/auth/state').catch((err) => {
+    pending = null;
+    throw err;
+  });
+  return pending;
+}
+
+/** Null until the answer arrives; callers render the neutral case meanwhile. */
+export function useServiceState(): ServiceState | null {
+  const [state, setState] = useState<ServiceState | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    load()
+      .then((s) => {
+        if (alive) setState(s);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/web/src/lib/support.test.ts
+++ b/web/src/lib/support.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { supportLink } from './support';
+
+describe('supportLink', () => {
+  it('sends a self-hosted family to the issue tracker', () => {
+    const link = supportLink(false, 'hub.example.com');
+    expect(link.label).toBe('Report a bug');
+    expect(link.href).toContain('github.com');
+  });
+
+  it('sends a hosted family to the support site', () => {
+    const link = supportLink(true, 'zgmnd.neiliro.com');
+    expect(link.label).toBe('Support');
+    expect(link.href).toBe('https://support.neiliro.com');
+  });
+
+  /*
+    Hosted mode is in the open-source repo, so someone else can run a
+    service of their own. Their families are not our families: a hardcoded
+    "Support" link would route their messages into our inbox.
+  */
+  it('does not send someone else’s hosted service to our help desk', () => {
+    expect(supportLink(true, 'smith.familyhub.example').label).toBe('Report a bug');
+  });
+
+  /* A domain that merely ends in the same letters is not our domain. */
+  it('is not fooled by a lookalike domain', () => {
+    expect(supportLink(true, 'evil-neiliro.com').label).toBe('Report a bug');
+    expect(supportLink(true, 'neiliro.com.attacker.example').label).toBe('Report a bug');
+  });
+});

--- a/web/src/lib/support.ts
+++ b/web/src/lib/support.ts
@@ -1,0 +1,29 @@
+import { ISSUES_URL, SUPPORT_URL } from './build';
+
+/** The apex the hosted service runs on. See supportLink below. */
+const SERVICE_DOMAIN = 'neiliro.com';
+
+/**
+ * Where "I need help" leads, which is not the same answer for everyone.
+ *
+ * A self-hoster owns the machine: the fix is in the code, the answer helps
+ * the next person with the same problem, and we cannot see their hub
+ * anyway — so they go to GitHub issues.
+ *
+ * A family on the hosted service goes to the support site, which knows
+ * their questions and can take a message.
+ *
+ * The hostname check is not belt-and-braces. Hosted mode ships in the
+ * open-source repo and someone else can run a service of their own; a
+ * "Support" link hardcoded to our address would quietly hand us their
+ * families' messages. Whose service this is, only the address says.
+ */
+export function supportLink(
+  hosted: boolean,
+  hostname: string,
+): { href: string; label: 'Support' | 'Report a bug' } {
+  const ours = hostname === SERVICE_DOMAIN || hostname.endsWith(`.${SERVICE_DOMAIN}`);
+  return hosted && ours
+    ? { href: SUPPORT_URL, label: 'Support' }
+    : { href: ISSUES_URL, label: 'Report a bug' };
+}

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,5 +1,7 @@
 import { lang, setLang, t } from '../lib/i18n';
-import { ISSUES_URL, REPO_URL } from '../lib/build';
+import { REPO_URL } from '../lib/build';
+import { useServiceState } from '../lib/service';
+import { supportLink } from '../lib/support';
 import { useHomeName } from '../lib/home-name';
 import { useEffect, useState, type FormEvent } from 'react';
 import { api } from '../lib/api';
@@ -22,6 +24,15 @@ function Frame({
   children: React.ReactNode;
 }) {
   const displayName = useHomeName();
+  /*
+    Every auth screen hangs off this frame — sign in, first run, an invite,
+    both halves of a password reset. That makes its footer the one place a
+    locked-out family can still reach, so the help link has to be right
+    here and not only inside the app. The lookup is shared and cached
+    (lib/service.ts); the answer cannot change while the tab is open.
+  */
+  const service = useServiceState();
+  const help = supportLink(service?.hosted ?? false, window.location.hostname);
 
   useEffect(() => {
     if (displayName) document.title = displayName;
@@ -61,12 +72,12 @@ function Frame({
             </a>
             <span aria-hidden>·</span>
             <a
-              href={ISSUES_URL}
+              href={help.href}
               target="_blank"
               rel="noopener noreferrer"
               className="underline decoration-line underline-offset-2 hover:text-ink"
             >
-              {t('Report a bug')}
+              {help.label === 'Support' ? t('Support') : t('Report a bug')}
             </a>
           </p>
         </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { lang, setLang, t } from '../lib/i18n';
-import { BUILD_SHA, ISSUES_URL, REPO_URL, VERSION } from '../lib/build';
+import { BUILD_SHA, REPO_URL, VERSION } from '../lib/build';
 import { formatStamp, setWeekStart, weekStart } from '../lib/format';
 import { useEffect, useRef, useState } from 'react';
 import { api } from '../lib/api';
@@ -15,6 +15,8 @@ import { MailSection } from '../components/MailSection';
 import { TotpSection } from '../components/TotpSection';
 import { CalendarFeedSection } from '../components/CalendarFeedSection';
 import { FamilyDataSection } from '../components/FamilyDataSection';
+import { useServiceState } from '../lib/service';
+import { supportLink } from '../lib/support';
 
 /**
  * Own name and avatar colour, self-service (#64). Colour is the whole
@@ -456,6 +458,9 @@ export function Settings() {
     it: the field holds what was typed until save parses it.
   */
   const [goalTarget, setGoalTarget] = useState('');
+  /* Same link as the sidebar footer, repeated for phones. */
+  const service = useServiceState();
+  const help = supportLink(service?.hosted ?? false, window.location.hostname);
 
   useEffect(() => {
     void api.get<Record<string, string>>('/settings').then((loaded) => {
@@ -740,12 +745,12 @@ export function Settings() {
             {t('Source code')}
           </a>
           <a
-            href={ISSUES_URL}
+            href={help.href}
             target="_blank"
             rel="noopener noreferrer"
             className="text-accent underline decoration-line underline-offset-2 hover:opacity-80"
           >
-            {t('Report a bug')}
+            {help.label === 'Support' ? t('Support') : t('Report a bug')}
           </a>
         </div>
       </section>


### PR DESCRIPTION
The footer's "Report a bug" is the only door out of the app, and for a hosted family it is the wrong one: nobody wants to open a GitHub account to say the calendar looks odd. With the closed beta starting, they get [support.neiliro.com](https://support.neiliro.com) instead — FAQ first, a form when that is not enough. Companion PR: neiliro/www#6.

A self-hoster keeps the issue tracker. Their hub is theirs, we cannot see it, and an answer in the open helps the next person with the same problem.

## The hostname check

`lib/support.ts` requires **both** hosted mode and our own apex before showing the support link. Hosted mode ships in this repo, so someone else can run a service of their own; a "Support" link hardcoded to our address would quietly route their families' messages into our inbox. Whose service this is, only the address says. Four cases are covered by tests, including lookalike domains.

## One request, not two

`/api/auth/state` answers a property of the process, not of the session — it cannot change while the tab is open. `lib/service.ts` fetches it once and shares it, so the sidebar and Settings → About asking the same question do not cost two requests. A rejected answer is not cached: the next mount asks again rather than inheriting one bad moment for the life of the tab.

## Verified

`npm run typecheck`, `npm run lint`, and `npm test --workspace=web` (70 passing, including the new `support.test.ts` and the i18n coverage scan that now sees `Support`).

The server suite does not run on this machine: `better-sqlite3@11` cannot compile against the local Node 26, which is a pre-existing condition unrelated to this change — nothing here touches `server/`, and CI runs Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)