### PR TITLE
chore: version 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ you touch the money or the privacy code. Start with a
 [good first issue](https://github.com/neiliro/neiliro/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) —
 they are written to be picked up cold.
 
-Coming up next: CSV bank-statement import and shared shopping lists.
+Coming up next: CSV bank-statement import, and reading the family mailbox
+from an ordinary mail app.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -1680,7 +1680,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1698,7 +1697,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1716,7 +1714,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1734,7 +1731,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1752,7 +1748,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1770,7 +1765,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1788,7 +1782,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1806,7 +1799,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1824,7 +1816,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1842,7 +1833,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1860,7 +1850,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1878,7 +1867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1896,7 +1884,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1914,7 +1901,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1932,7 +1918,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1950,7 +1935,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1968,7 +1952,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1986,7 +1969,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2004,7 +1986,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2022,7 +2003,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2040,7 +2020,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2058,7 +2037,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2076,7 +2054,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2094,7 +2071,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2112,7 +2088,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,7 +2105,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7920,7 +7894,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7942,7 +7915,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7964,7 +7936,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7986,7 +7957,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8008,7 +7978,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8030,7 +7999,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8052,7 +8020,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8074,7 +8041,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8096,7 +8062,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8118,7 +8083,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8140,7 +8104,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12065,7 +12028,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12090,7 +12053,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version goes up before the tag, not after: it shows in Settings → About and at the foot of the sidebar, and the hosted stack pins a release tag.

Three `package.json` files plus the lockfile, `1.7.0` → `1.8.0`.

## One line of README, which was wrong

> Coming up next: CSV bank-statement import and shared shopping lists.

Shared lists shipped **in 1.7.0**. The line now names what is actually next — CSV import (#10) and reading the family mailbox from an ordinary mail app (#161). The rest of the docs are already current: `features.md` covers sections, the guest tick and the administrator moving a login address, each landed with the code that introduced it.

## What is in the release

- shared lists gained sections, a guest link that accepts a tick, rename and delete (#164, #167, #168)
- one convention for inline destructive actions, enforced by a test (#166, closes #79)
- a support link for hosted families, the issue tracker for self-hosters (#172)
- an administrator can change a member's login address from Settings (#173)
- CI: manual trigger, Node 24 runtime, a released version handed to the control plane, repo-hygiene guards (#165, #169, #170, #171)

**Schema changes**: migrations `028_list_share` and `029_list_sections`, forward only.

## Verified

`npm run typecheck` and `npm run lint` clean, `npm test --workspace=web` 70 passing.

The server suite does not run on this machine — better-sqlite3 is built for `NODE_MODULE_VERSION 137` and the local Node 26 wants 147. Pre-existing and unrelated to a version bump; CI runs Node 22 and the full 290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)