### PR TITLE
fix: the support footer must not guess which door it is

### DIFF
--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -282,8 +282,8 @@ export function AppShell() {
   const [moreOpen, setMoreOpen] = useState(false);
   const [settings, setSettings] = useState<Record<string, string>>({});
   const sidebarNav = [...NAV, ...SECONDARY];
-  const service = useServiceState();
-  const help = supportLink(service?.hosted ?? false, window.location.hostname);
+  const { state: service } = useServiceState();
+  const help = supportLink(service ? service.hosted : null, window.location.hostname);
 
   useEffect(() => {
     void api
@@ -372,14 +372,17 @@ export function AppShell() {
               >
                 {t('Source code')}
               </a>
-              <a
-                href={help.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline decoration-line underline-offset-2 hover:text-ink"
-              >
-                {help.label === 'Support' ? t('Support') : t('Report a bug')}
-              </a>
+              {/* Absent, not guessed, until the answer says which door this is */}
+              {help && (
+                <a
+                  href={help.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-line underline-offset-2 hover:text-ink"
+                >
+                  {help.label === 'Support' ? t('Support') : t('Report a bug')}
+                </a>
+              )}
             </span>
           </div>
         </div>

--- a/web/src/components/FamilyDataSection.tsx
+++ b/web/src/components/FamilyDataSection.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
+import { useServiceState } from '../lib/service';
 import { t } from '../lib/i18n';
 
 /*
@@ -184,14 +185,8 @@ function DangerZone() {
 
 export function FamilyDataSection() {
   const { user } = useAuth();
-  const [state, setState] = useState<{ demo: boolean; hosted: boolean } | null>(null);
-
-  useEffect(() => {
-    void api
-      .get<{ demo: boolean; hosted: boolean }>('/auth/state')
-      .then(setState)
-      .catch(() => {});
-  }, []);
+  // The same shared answer the sidebar and Settings read — one request
+  const { state } = useServiceState();
 
   // Demo sandboxes are throwaways: nothing worth archiving, nothing to
   // delete — the sandbox buries itself. Both cards disappear entirely.

--- a/web/src/lib/pwa.ts
+++ b/web/src/lib/pwa.ts
@@ -1,5 +1,5 @@
 import { registerSW } from 'virtual:pwa-register';
-import { api } from './api';
+import { serviceState } from './service';
 
 /*
   Service-worker registration and update detection (#9).
@@ -31,7 +31,8 @@ export async function setupPwa(onNeedRefresh: () => void): Promise<void> {
   started = true;
 
   try {
-    const state = await api.get<{ demo?: boolean }>('/auth/state');
+    // Shares the app's one lookup rather than adding a second (lib/service.ts)
+    const state = await serviceState();
     if (state.demo) return;
   } catch {
     // The server is unreachable — the cached shell may still be useful,

--- a/web/src/lib/service.ts
+++ b/web/src/lib/service.ts
@@ -29,21 +29,46 @@ function load(): Promise<ServiceState> {
   return pending;
 }
 
-/** Null until the answer arrives; callers render the neutral case meanwhile. */
-export function useServiceState(): ServiceState | null {
-  const [state, setState] = useState<ServiceState | null>(null);
+export interface ServiceAnswer {
+  /** What the process says about itself — null while that is still unknown. */
+  state: ServiceState | null;
+  /**
+   * False only while the request is in flight; true once it has succeeded
+   * *or* failed. A caller that must pick a safe default on failure needs to
+   * tell "not yet" from "never" — `state` alone cannot say which.
+   */
+  settled: boolean;
+}
+
+/**
+ * The shared answer. `state` is null until it arrives, so a caller renders
+ * nothing rather than guessing — guessing is how a footer link points at
+ * the wrong door for a round trip.
+ */
+export function useServiceState(): ServiceAnswer {
+  const [answer, setAnswer] = useState<ServiceAnswer>({ state: null, settled: false });
 
   useEffect(() => {
     let alive = true;
     load()
       .then((s) => {
-        if (alive) setState(s);
+        if (alive) setAnswer({ state: s, settled: true });
       })
-      .catch(() => {});
+      .catch(() => {
+        if (alive) setAnswer({ state: null, settled: true });
+      });
     return () => {
       alive = false;
     };
   }, []);
 
-  return state;
+  return answer;
+}
+
+/**
+ * The same answer outside React, sharing the same request. Callers that
+ * only need one flag still must not add a second round trip for it.
+ */
+export function serviceState(): Promise<ServiceState> {
+  return load();
 }

--- a/web/src/lib/support.test.ts
+++ b/web/src/lib/support.test.ts
@@ -4,14 +4,26 @@ import { supportLink } from './support';
 describe('supportLink', () => {
   it('sends a self-hosted family to the issue tracker', () => {
     const link = supportLink(false, 'hub.example.com');
-    expect(link.label).toBe('Report a bug');
-    expect(link.href).toContain('github.com');
+    expect(link?.label).toBe('Report a bug');
+    expect(link?.href).toContain('github.com');
   });
 
   it('sends a hosted family to the support site', () => {
     const link = supportLink(true, 'zgmnd.neiliro.com');
-    expect(link.label).toBe('Support');
-    expect(link.href).toBe('https://support.neiliro.com');
+    expect(link?.label).toBe('Support');
+    expect(link?.href).toBe('https://support.neiliro.com');
+  });
+
+  /*
+    The bug this pins was found on production: the footer rendered the
+    self-hoster's link — live, pointing at GitHub — for as long as
+    /auth/state was in flight, on the very screen a locked-out hosted
+    family reads it. "Not told yet" is not "not hosted", so there is
+    nothing honest to render until the answer lands.
+  */
+  it('offers no link at all while the answer is unknown', () => {
+    expect(supportLink(null, 'zgmnd.neiliro.com')).toBeNull();
+    expect(supportLink(null, 'hub.example.com')).toBeNull();
   });
 
   /*
@@ -20,12 +32,12 @@ describe('supportLink', () => {
     "Support" link would route their messages into our inbox.
   */
   it('does not send someone else’s hosted service to our help desk', () => {
-    expect(supportLink(true, 'smith.familyhub.example').label).toBe('Report a bug');
+    expect(supportLink(true, 'smith.familyhub.example')?.label).toBe('Report a bug');
   });
 
   /* A domain that merely ends in the same letters is not our domain. */
   it('is not fooled by a lookalike domain', () => {
-    expect(supportLink(true, 'evil-neiliro.com').label).toBe('Report a bug');
-    expect(supportLink(true, 'neiliro.com.attacker.example').label).toBe('Report a bug');
+    expect(supportLink(true, 'evil-neiliro.com')?.label).toBe('Report a bug');
+    expect(supportLink(true, 'neiliro.com.attacker.example')?.label).toBe('Report a bug');
   });
 });

--- a/web/src/lib/support.ts
+++ b/web/src/lib/support.ts
@@ -19,9 +19,16 @@ const SERVICE_DOMAIN = 'neiliro.com';
  * families' messages. Whose service this is, only the address says.
  */
 export function supportLink(
-  hosted: boolean,
+  hosted: boolean | null,
   hostname: string,
-): { href: string; label: 'Support' | 'Report a bug' } {
+): { href: string; label: 'Support' | 'Report a bug' } | null {
+  // Null is "we have not been told yet", and it is not the same as false.
+  // Collapsing the two would render the self-hoster's link — a live one,
+  // pointing at GitHub — to a hosted family for as long as the answer is
+  // in flight. The sign-in screen is exactly where a locked-out family
+  // reads this, so a wrong door for one round trip is a wrong door.
+  if (hosted === null) return null;
+
   const ours = hostname === SERVICE_DOMAIN || hostname.endsWith(`.${SERVICE_DOMAIN}`);
   return hosted && ours
     ? { href: SUPPORT_URL, label: 'Support' }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -31,8 +31,8 @@ function Frame({
     here and not only inside the app. The lookup is shared and cached
     (lib/service.ts); the answer cannot change while the tab is open.
   */
-  const service = useServiceState();
-  const help = supportLink(service?.hosted ?? false, window.location.hostname);
+  const { state: service } = useServiceState();
+  const help = supportLink(service ? service.hosted : null, window.location.hostname);
 
   useEffect(() => {
     if (displayName) document.title = displayName;
@@ -70,15 +70,20 @@ function Frame({
             >
               {t('Source code')}
             </a>
-            <span aria-hidden>·</span>
-            <a
-              href={help.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline decoration-line underline-offset-2 hover:text-ink"
-            >
-              {help.label === 'Support' ? t('Support') : t('Report a bug')}
-            </a>
+            {/* Absent, not guessed, until the answer says which door this is */}
+            {help && (
+              <>
+                <span aria-hidden>·</span>
+                <a
+                  href={help.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-line underline-offset-2 hover:text-ink"
+                >
+                  {help.label === 'Support' ? t('Support') : t('Report a bug')}
+                </a>
+              </>
+            )}
           </p>
         </div>
       </div>
@@ -107,22 +112,24 @@ export function Login() {
   // A ticket means the password passed and a TOTP code is owed
   const [mfaToken, setMfaToken] = useState<string | null>(null);
   const [mfaCode, setMfaCode] = useState('');
-  const [googleAvailable, setGoogleAvailable] = useState(false);
-  const [resetAvailable, setResetAvailable] = useState(false);
-  const [demo, setDemo] = useState(false);
-  // null — still finding out; false — empty DB, show the first-run setup
-  const [initialized, setInitialized] = useState<boolean | null>(null);
+  /*
+    Which doors exist is a property of the process, and the frame around
+    this form asks the same question for its help link — so both read the
+    one shared answer rather than each fetching it (lib/service.ts).
+  */
+  const { state: service, settled } = useServiceState();
+  const googleAvailable = service?.google ?? false;
+  const resetAvailable = Boolean(service?.password_reset);
+  const demo = Boolean(service?.demo);
+  /*
+    null — still finding out; false — empty DB, show the first-run setup.
+    A server that refused to answer is deliberately read as initialized:
+    offering to create an admin because a request failed would hand the
+    family's own hub to whoever reloads at the wrong moment.
+  */
+  const initialized = service ? service.initialized : settled ? true : null;
 
   useEffect(() => {
-    void api
-      .get<{ initialized: boolean; google: boolean; demo?: boolean; password_reset?: boolean }>('/auth/state')
-      .then((s) => {
-        setGoogleAvailable(s.google);
-        setResetAvailable(Boolean(s.password_reset));
-        setInitialized(s.initialized);
-        setDemo(Boolean(s.demo));
-      })
-      .catch(() => setInitialized(true));
     // The outcome of a Google sign-in arrives as a redirect with a code in the URL
     const code = new URLSearchParams(window.location.search).get('google');
     if (code && GOOGLE_MESSAGES[code]) {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -228,7 +228,8 @@ function SignInSection() {
   const { user, refresh } = useAuth();
   const dialogs = useDialogs();
   const [status, setStatus] = useState<string | null>(null);
-  const [googleAvailable, setGoogleAvailable] = useState(false);
+  // Shared with the rest of the page, so asking here costs no extra request
+  const googleAvailable = useServiceState().state?.google ?? false;
   const [sessions, setSessions] = useState<SessionInfo[] | null>(null);
   const [showSessions, setShowSessions] = useState(false);
   const sessionCount = sessions?.length ?? null;
@@ -240,10 +241,6 @@ function SignInSection() {
       .catch(() => {});
 
   useEffect(() => {
-    void api
-      .get<{ google: boolean }>('/auth/state')
-      .then((s) => setGoogleAvailable(s.google))
-      .catch(() => {});
     void loadSessions();
     const code = new URLSearchParams(window.location.search).get('google');
     if (code && LINK_MESSAGES[code]) {
@@ -459,8 +456,8 @@ export function Settings() {
   */
   const [goalTarget, setGoalTarget] = useState('');
   /* Same link as the sidebar footer, repeated for phones. */
-  const service = useServiceState();
-  const help = supportLink(service?.hosted ?? false, window.location.hostname);
+  const { state: service } = useServiceState();
+  const help = supportLink(service ? service.hosted : null, window.location.hostname);
 
   useEffect(() => {
     void api.get<Record<string, string>>('/settings').then((loaded) => {
@@ -744,14 +741,17 @@ export function Settings() {
           >
             {t('Source code')}
           </a>
-          <a
-            href={help.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent underline decoration-line underline-offset-2 hover:opacity-80"
-          >
-            {help.label === 'Support' ? t('Support') : t('Report a bug')}
-          </a>
+          {/* Absent, not guessed, until the answer says which door this is */}
+          {help && (
+            <a
+              href={help.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent underline decoration-line underline-offset-2 hover:opacity-80"
+            >
+              {help.label === 'Support' ? t('Support') : t('Report a bug')}
+            </a>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
Two findings from the post-1.8.0 QA pass against hosted production, both in #172, both with one root cause: the migration to the shared `lib/service.ts` lookup was left half-done.

## 1. The footer showed the wrong door while the page loaded

On any hosted host the footer rendered **Report a bug** → GitHub for one round trip, then became **Support**. Caught on production: a screenshot taken right after navigation reads "Report a bug"; the settled page has only "Support".

That is the sign-in screen — the surface `2dc05db` added this link to *precisely* so a locked-out hosted family could reach us. A family that clicks quickly gets sent to the door we had just moved them away from.

The cause is one expression, in **three** places (`Login.tsx:35`, `AppShell.tsx:286`, and `Settings.tsx:459`, the footer repeated for phones):

```ts
supportLink(service?.hosted ?? false, window.location.hostname)
```

`useServiceState()` answers `null` until the request lands, and `?? false` reads that as *"not hosted"* — which is not a neutral case but **the other branch**, rendered as a live link.

`supportLink()` had no third state to return, so every call site had to invent one and all three invented the same wrong one. It now takes `boolean | null` and answers `null` for "not told yet"; callers render nothing until they know.

**Why the four existing tests could not catch this:** with a `boolean` parameter the unknown state was unrepresentable. The fifth case pins it now.

## 2. `/api/auth/state` was fetched twice on the sign-in screen

#172's own description promised *"One request, not two"*. The shared loader was added and used for the new link, but the four existing call sites kept fetching on their own — so the screen went from one request to two.

`Login.tsx`, `Settings.tsx`, `FamilyDataSection.tsx` and the service-worker check in `pwa.ts` now read the one shared answer. `serviceState()` exposes the same promise outside React for `pwa.ts`.

### The state the hook had to grow

`Login` treats a **refused** answer as `initialized`, deliberately: offering to create an admin because a request failed would hand the family's hub to whoever reloads at the wrong moment. Both "no answer yet" and "no answer ever" are `null`, so the hook now reports `settled` alongside `state` and that default survives the move instead of being quietly dropped.

## Verified on the QA stand, not by argument

`scripts/qa-stack.sh` — the hub served as `*.neiliro.com`, which is the only place this link's real branch can be exercised at all. Driven with `playwright-core`, sampling the footer every 25 ms to catch a flicker rather than trusting a settled screenshot:

```
--- /api/auth/state requests: 1
--- footer states seen while loading: ["(none)","Support"]
--- settled footer: ["Support -> https://support.neiliro.com/"]
PASS  one request
PASS  the wrong door was never rendered
PASS  settles on Support
```

All three `initialized` branches, since this PR rewires that value:

```
PASS  smiths-qa01  initialized family   shows sign-in   help=["Support"]  state calls=1
PASS  jones-qa02   no admin yet         shows first-run help=["Support"]  state calls=1
PASS  nobody-qa99  the ghost            shows sign-in   help=["Support"]  state calls=1
```

The ghost still refuses to reveal itself — sign-in, not first run.

And the safe default, with `/auth/state` aborted at the network layer:

```
PASS  jones-qa02   state refused → heads=["Sign in"] password field=true help=[]
PASS  smiths-qa01  state refused → heads=["Sign in"] password field=true help=[]
```

`jones-qa02` genuinely has no admin, so it is the host that would wrongly offer the wizard if the failure were read as "not initialized". It does not. `help=[]` is also correct: we never learned which door this is, so we do not guess one.

`npm run typecheck`, `npm run lint`, `npm test --workspace=web` (71, +1 new case).

The server suite does not run on this machine — better-sqlite3 is built for `NODE_MODULE_VERSION 137` and the local Node 26 wants 147. Pre-existing; nothing here touches `server/`, and CI runs Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
