### PR TITLE
fix: the confirmation link has to land on the family, not the apex

### DIFF
--- a/server/src/routes/email-verify.test.ts
+++ b/server/src/routes/email-verify.test.ts
@@ -52,12 +52,17 @@ let app: FastifyInstance;
 let adminCookie: string;
 let memberId: string;
 
-/** Wait for the detached mail, then take the token out of the last one. */
-async function lastToken(subject: string): Promise<string | null> {
+/** Wait for the detached mail, then take the whole link out of the last one. */
+async function lastLink(subject: string): Promise<URL | null> {
   await new Promise((r) => setTimeout(r, 60));
   const mail = [...sent].reverse().find((m) => m.subject === subject);
   if (!mail) return null;
-  return new URL(mail.text.match(/https:\/\/\S+/)![0]).searchParams.get('token');
+  return new URL(mail.text.match(/https:\/\/\S+/)![0]);
+}
+
+/** Wait for the detached mail, then take the token out of the last one. */
+async function lastToken(subject: string): Promise<string | null> {
+  return (await lastLink(subject))?.searchParams.get('token') ?? null;
 }
 
 function requestReset(email: string) {
@@ -115,6 +120,29 @@ describe('address confirmation', () => {
     expect(sent).toHaveLength(before);
   });
 
+  /*
+    Found in production: the confirmation link was built from HOSTED_DOMAIN
+    alone, so it pointed at the apex. On our own service that is the
+    landing site — it has no such route, served its front page, and the
+    address stayed unconfirmed with nothing to say so.
+
+    The old tests parsed this same link and kept only the token, which is
+    why they passed throughout. The reset link is the same shape and is
+    pinned too, further down — either one landing off the family is a dead
+    end for whoever is holding the mail.
+  */
+  it('sends the confirmation link to the family, not to the apex', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/api/profile/email-verify',
+      headers: { host: HOST, cookie: adminCookie },
+      payload: {},
+    });
+    const confirm = await lastLink('Confirm your Neiliro address');
+    expect(confirm?.host).toBe(HOST);
+    expect(confirm?.pathname).toBe('/verify-email');
+  });
+
   it('confirms an address once, and the reset starts working', async () => {
     // Ask for the link the way the prompt in the UI does
     const asked = await app.inject({
@@ -148,7 +176,11 @@ describe('address confirmation', () => {
     // ...and now a reset does go out
     sent.length = 0;
     expect((await requestReset(ADMIN)).statusCode).toBe(202);
-    expect(await lastToken('Reset your Neiliro password')).toBeTruthy();
+    const reset = await lastLink('Reset your Neiliro password');
+    expect(reset?.searchParams.get('token')).toBeTruthy();
+    // Same rule as the confirmation link: it has to open on the family
+    expect(reset?.host).toBe(HOST);
+    expect(reset?.pathname).toBe('/reset');
   });
 
   it('un-confirms the address when an administrator changes it', async () => {

--- a/server/src/routes/email-verify.ts
+++ b/server/src/routes/email-verify.ts
@@ -1,10 +1,11 @@
 import { createHash, randomBytes } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { db, id, now } from '../db/index.js';
+import { currentTenant, db, id, now } from '../db/index.js';
 import { env } from '../env.js';
 import { log } from '../lib/log.js';
 import { sendServiceEmail, serviceMailAvailable } from '../lib/mail.js';
+import { familySlug } from '../lib/tenants.js';
 
 /*
   Confirming that a person owns the address they sign in with.
@@ -46,6 +47,20 @@ export async function sendVerificationEmail(userId: string): Promise<void> {
       .get(userId) as { email: string; name: string; email_verified_at: string | null } | undefined;
     if (!user || user.email_verified_at) return;
 
+    /*
+      The link has to open on the family's own subdomain, and the slug is
+      the only thing that knows which one that is. HOSTED_DOMAIN is the
+      apex — on our own service that is the landing site, which has no
+      such route and simply serves its front page, so the address never
+      gets confirmed. PUBLIC_URL is worse than useless here: one process
+      serves every family, so a single configured URL would send them all
+      to whichever family it names. Same shape as the reset link
+      (routes/password-reset.ts).
+    */
+    const { familyId } = currentTenant();
+    const slug = familyId ? familySlug(familyId) : null;
+    if (!slug) return; // the ghost, or a single-family install: nothing to link to
+
     const token = randomBytes(32).toString('base64url');
     db.transaction(() => {
       // One live link per person: the newest request is the one they hold
@@ -63,9 +78,7 @@ export async function sendVerificationEmail(userId: string): Promise<void> {
       );
     })();
 
-    // The host is the family's own subdomain: the link only has to work in
-    // a browser, and the session it may create belongs to that host.
-    const url = `${env.publicUrl || `https://${env.hostedDomain}`}/verify-email?token=${token}`;
+    const url = `https://${slug}.${env.hostedDomain}/verify-email?token=${token}`;
     await sendServiceEmail(
       user.email,
       'Confirm your Neiliro address',


### PR DESCRIPTION
Reported from production: the confirmation mail arrived, the link opened the **landing page**, and the address stayed unconfirmed.

## The line

```ts
// The host is the family's own subdomain: the link only has to work in
// a browser, and the session it may create belongs to that host.
const url = `${env.publicUrl || `https://${env.hostedDomain}`}/verify-email?token=${token}`;
```

The comment describes the right behaviour. The code never implemented it — the slug does not appear. `HOSTED_DOMAIN` is the **apex**, which on our own service is the marketing site on Cloudflare Pages: no `/verify-email` route, so it served its front page, and nothing anywhere reported that the confirmation had not happened.

`routes/password-reset.ts:137` has built its link from the slug since the day it was written. That is the shape copied here.

`PUBLIC_URL` is removed from this path rather than kept as a fallback: one process serves every family, so a single configured URL would send them all to whichever family it happens to name. Verification only ever runs in hosted mode, so that branch could not have been right here.

## The consequence is bigger than a wrong link

- `email-verify.ts:141` is the **only** place an address ever becomes `email_verified_at`.
- It is reachable only through this link.
- `password-reset.ts` refuses an unverified address — and refuses it **silently**, because the endpoint deliberately answers `202` whether or not mail goes out, so as not to be an account oracle.

So **password recovery on the hosted service has not worked for anyone since it shipped in 1.7.0.** The chain broke at its first link, and the feature's own discretion is what kept it quiet: a family asking for a reset got a normal-looking answer and no mail, with no signal anywhere.

Checked the neighbours for the same mistake — there was exactly one instance. `tenants.ts:319`, `password-reset.ts:137` and `google.ts:337` all build from the slug correctly, and the one remaining `env.publicUrl` (`google.ts:126`) is the self-hosted redirect_uri, where it is right.

## Why the tests passed throughout

They parsed this very URL and kept only the token:

```ts
return new URL(mail.text.match(/https:\/\/\S+/)![0]).searchParams.get('token');
```

The host was never looked at. Both service links now assert host **and** path — they are one shape, and either one landing off the family is a dead end for whoever is holding the mail.

**Verified by reverting the fix.** With the old line restored the new case fails with exactly the production symptom:

```
× address confirmation > sends the confirmation link to the family, not to the apex
  → expected 'neiliro.test' to be 'smiths-v1w2.neiliro.test'
```

## Testing

Server suite 225 passing, run on Node 22 in a container — better-sqlite3 on this machine is built for `NODE_MODULE_VERSION 137` and the local Node 26 wants 147, so the host cannot run it. `npm run typecheck`, `npm run lint`, and `npm test --workspace=web` (71) clean.

## Operationally

Families whose address is still unconfirmed need a fresh link after this deploys — the reminder in the header sends one. Anyone still holding an old mail can also just correct the host by hand: the token itself is valid and unused, only the door was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
