### PR TITLE
chore: version 1.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -12028,7 +12028,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12053,7 +12053,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version goes up before the tag: it shows in Settings → About and at the foot of the sidebar, and the hosted stack pins a release tag.

Three `package.json` files plus the lockfile, `1.8.0` → `1.8.1`.

## Why a patch release rather than waiting

#176 is not a cosmetic fix. `email-verify.ts` is the only place an address becomes confirmed, it was reachable only through a link that pointed at the marketing site, and `password-reset` refuses an unconfirmed address — silently, by design. So password recovery on the hosted service had never worked for anyone since it shipped in 1.7.0, and every day it stays broken is a day a locked-out family has no way back in.

## What is in it

- **#176** — the confirmation link lands on the family's own subdomain, not the apex. Both service links now assert host and path in tests.
- **#175** — the support footer renders nothing until it knows which door this is, instead of showing the self-hoster's GitHub link to a hosted family mid-load. Also collapses four stray `/auth/state` fetches onto the shared lookup.

## No schema change

No migrations — the first release since 1.6.0 that touches none. Unlike 1.7.0 and 1.8.0 it goes back as cleanly as it goes forward, which matters here: a hub that takes this and hits trouble can return to 1.8.0 without stranding data.

Docs need no catch-up. `docs/features.md` already described the confirmation flow correctly — the code was what disagreed with it.

## Verified

`npm run typecheck`, `npm run lint`, `npm test --workspace=web` (71) clean. The server suite (225) was run on Node 22 in a container for #176; the host cannot run it — better-sqlite3 here is built for `NODE_MODULE_VERSION 137` and the local Node 26 wants 147. CI runs the full suite on every push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
