### PR TITLE
fix: qa-stack.sh provisions its families again, and says so when it cannot

### DIFF
--- a/scripts/qa-stack.sh
+++ b/scripts/qa-stack.sh
@@ -123,9 +123,22 @@ up)
     sleep 1
   done
 
+  # --no-invite: the stand hands the hub over locally, which is exactly the
+  # operator case that flag exists for (#157). And the result is checked
+  # rather than grepped for a happy line: when the CLI's signature changed
+  # the old `|| true` swallowed the usage error, and the banner below went
+  # on promising family URLs that all answered as ghosts (#190).
   for slug in "${FAMILIES[@]}"; do
-    docker exec "$CONTAINER" node server/dist/cli/create-family.js "$slug" 2>&1 |
-      grep -E 'Family created|already taken' || true
+    if out=$(docker exec "$CONTAINER" node server/dist/cli/create-family.js "$slug" --no-invite 2>&1); then
+      echo "$out" | grep -E 'Family created' || true
+    elif echo "$out" | grep -q 'already taken'; then
+      # A second `up` over kept data: the family is there, nothing to do
+      echo "  ${slug}: already provisioned"
+    else
+      echo "!! could not provision ${slug}:" >&2
+      echo "$out" | sed 's/^/   /' >&2
+      exit 1
+    fi
   done
 
   start_www


### PR DESCRIPTION
Closes #190.

The founder invitation (#157) changed `create-family.js` to require `--admin-email` or `--no-invite`, and `scripts/qa-stack.sh` kept calling it the old way. The usage error disappeared into `| grep … || true`, so the script printed its banner with four family URLs while every one of them answered as a ghost.

## Changes

- Pass `--no-invite` — the stand hands the hub over locally, which is exactly the operator case that flag exists for.
- Check the result instead of grepping for a happy line. "already taken" (a second `up` over kept data) is reported as already provisioned; any other failure stops the script and prints the CLI's own message, so the banner can no longer promise addresses that do not work.

## Verified

Brought the stand up on this branch:

- `smiths-qa01` and `jones-qa02` created — `/api/auth/state` reports `initialized:false` (real families, open first run), the ghost `nobody-qa99` still reports `true`.
- Re-provisioning an existing slug is tolerated as "already provisioned" rather than failing the run.