### PR TITLE
fix: redact every share token from the log, from the same list auth exempts

### DIFF
--- a/server/src/app.redact.test.ts
+++ b/server/src/app.redact.test.ts
@@ -13,6 +13,32 @@ describe('redactUrl', () => {
     expect(redactUrl('/api/wishlist/AbC123xyz/claim')).toBe('/api/wishlist/…/claim');
   });
 
+  it('masks every token-addressed surface, not only the first one built (#186)', () => {
+    // Three surfaces were added after the wishlist and each logged its
+    // live token on a 404 or a 429, because the mask named one prefix.
+    expect(redactUrl('/api/calendar/feed/FeedTok3n_-abc')).toBe('/api/calendar/feed/…');
+    expect(redactUrl('/api/event/Ev3ntTok3n')).toBe('/api/event/…');
+    expect(redactUrl('/api/event/Ev3ntTok3n/ics')).toBe('/api/event/…/ics');
+    expect(redactUrl('/api/list/L1stTok3n')).toBe('/api/list/…');
+    // The item id after the token is a plain uuid, not a secret — it stays
+    expect(redactUrl('/api/list/L1stTok3n/items/0b6d1c2e-1111-4222-8333-444455556666/toggle')).toBe(
+      '/api/list/…/items/0b6d1c2e-1111-4222-8333-444455556666/toggle',
+    );
+    // A token with a query string behind it: both halves masked
+    expect(redactUrl('/api/event/Ev3ntTok3n?lang=ru')).toBe('/api/event/…?lang=…');
+  });
+
+  it('does not touch the authenticated siblings that share a prefix root', () => {
+    // /api/calendar/feed (no trailing segment) creates and revokes the
+    // token behind auth; /api/lists (plural) and /api/events are the
+    // ordinary authenticated routes. None of them carries a token.
+    expect(redactUrl('/api/calendar/feed')).toBe('/api/calendar/feed');
+    expect(redactUrl('/api/lists/0b6d1c2e-1111-4222-8333-444455556666')).toBe(
+      '/api/lists/0b6d1c2e-1111-4222-8333-444455556666',
+    );
+    expect(redactUrl('/api/events?from=2026-09-01')).toBe('/api/events?from=…');
+  });
+
   it('still masks query values and leaves plain paths alone', () => {
     expect(redactUrl('/api/auth/invite?token=SECRET')).toBe('/api/auth/invite?token=…');
     expect(redactUrl('/api/tasks')).toBe('/api/tasks');

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -38,7 +38,7 @@ import { registerEmailVerifyRoutes } from './routes/email-verify.js';
 import { registerMoneyRoutes } from './routes/money.js';
 import { registerBudgetRoutes } from './routes/budgets.js';
 import { registerFamilyRoutes } from './routes/family.js';
-import { authenticate } from './lib/auth.js';
+import { TOKEN_PATH_PREFIXES, authenticate } from './lib/auth.js';
 import { log } from './lib/log.js';
 
 /*
@@ -58,12 +58,21 @@ import { log } from './lib/log.js';
   the secret ended up in the log by default. Parameter names are kept:
   for diagnostics "which parameter came in" matters, not "with which value".
 */
+/*
+  Share tokens travel in the PATH, not the query — a rate-limited or
+  mistyped guest request would otherwise write a live link into the log at
+  warn level (invites dodge this only because their token is a query
+  value). The prefixes come from the same list `authenticate` exempts, so
+  a token surface cannot be opened without also being masked here: when
+  the two were maintained separately, the calendar feed, the event link
+  and the shared list were all logged in clear (#186).
+*/
+const TOKEN_SEGMENT = new RegExp(
+  `^(${TOKEN_PATH_PREFIXES.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[^/?]+`,
+);
+
 export function redactUrl(url: string): string {
-  // The wishlist share token travels in the PATH, not the query — a
-  // rate-limited or mistyped request would otherwise write a live guest
-  // link into the log at warn level (invites dodge this only because
-  // their token is a query value).
-  const masked = url.replace(/^(\/api\/wishlist\/)[^/?]+/, '$1…');
+  const masked = url.replace(TOKEN_SEGMENT, '$1…');
   const q = masked.indexOf('?');
   if (q === -1) return masked;
   const params = new URLSearchParams(masked.slice(q + 1));

--- a/server/src/lib/auth.public-surface.test.ts
+++ b/server/src/lib/auth.public-surface.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildTestApp } from '../test-harness.js';
+import { TOKEN_PATH_PREFIXES } from './auth.js';
 
 /*
   The list of routes reachable without a session, pinned.
@@ -57,20 +58,25 @@ describe('public API surface', () => {
   it('exempts only the token-addressed subtrees', () => {
     /*
       A prefix exemption is broader than a path and deserves louder review.
-      Both entries here are the same shape: an unguessable token in the
-      path, read-only, addressing one person's data — the public wishlist
-      and the calendar subscription feed. Anything else appearing in this
-      list is a subtree opened to the internet, which is the point of
-      failing here.
+      Every entry is the same shape: an unguessable token in the path,
+      addressing one object, revocable. Anything else appearing here is a
+      subtree opened to the internet, which is the point of failing.
+
+      The list is the exported constant rather than a scrape of
+      `authenticate`: it is what the wall actually consults, and it is also
+      what redactUrl masks — so this one assertion pins both the door and
+      the log at once.
     */
-    const fn = source.slice(source.indexOf('export async function authenticate'));
-    const prefixes = [...fn.matchAll(/startsWith\('(\/api[^']*)'\)/g)].map((m) => m[1]!);
-    expect(prefixes.filter((p) => p !== '/api').sort()).toEqual([
+    expect([...TOKEN_PATH_PREFIXES].sort()).toEqual([
       '/api/calendar/feed/',
       '/api/event/',
       '/api/list/',
       '/api/wishlist/',
     ]);
+    // And authenticate really consults it, rather than a copy
+    const fn = source.slice(source.indexOf('export async function authenticate'));
+    expect(fn).toContain('TOKEN_PATH_PREFIXES.some(');
+    expect(fn.match(/startsWith\('\/api\//g)).toBeNull();
   });
 
   it('still refuses an anonymous request to a route outside the list', async () => {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -106,6 +106,45 @@ export function clearSessionCookie(reply: FastifyReply): void {
 
 // ── Route protection ──────────────────────────────────────────────────────
 
+/*
+  The token-addressed subtrees: paths whose next segment is an unguessable
+  token standing in for a session. A guest holding the link needs no
+  account, so `authenticate` lets these through — and because the secret
+  travels in the PATH rather than the query, `redactUrl` (app.ts) has to
+  mask that segment before a 404 or a 429 writes the live link into the
+  log. One list feeds both, so a fifth surface cannot be opened without
+  also being redacted; the two drifted apart once and three of four
+  tokens were logged in clear (#186).
+
+  All four share one shape — one token, one object, revocable — and the
+  public-surface snapshot test pins the list, so widening it is a
+  deliberate act with a diff to explain, never a side effect.
+
+  - /api/wishlist/    (#68) the hub's only anonymous content surface: one
+                      first name and wish titles, under a login-strength
+                      rate limit. The token is stored in the clear so the
+                      link can be re-sent (migration 021).
+  - /api/calendar/feed/  one person's view of the calendar, read-only by
+                      construction — a calendar app has no session to
+                      present. The sibling endpoints that create and
+                      revoke the token (/api/calendar/feed with no trailing
+                      segment) stay behind auth, which is why the prefix
+                      ends in a slash.
+  - /api/event/       a single shared event: one row, and deliberately
+                      not the calendar around it, whose name can itself be
+                      private.
+  - /api/list/        a shared list — the only public surface that accepts
+                      a write, ticking an item, because a shopping list
+                      nobody can tick off is a screenshot. The token scopes
+                      both the read and that write to one list.
+*/
+export const TOKEN_PATH_PREFIXES = [
+  '/api/wishlist/',
+  '/api/calendar/feed/',
+  '/api/event/',
+  '/api/list/',
+] as const;
+
 const PUBLIC_PATHS = new Set([
   '/api/health',
   // Home name for the sign-in screen; hosted mode answers the brand
@@ -147,33 +186,8 @@ export async function authenticate(req: FastifyRequest, reply: FastifyReply): Pr
   if (!req.url.startsWith('/api')) return;
   const path = req.url.split('?')[0] ?? '';
   if (PUBLIC_PATHS.has(path)) return;
-  // The public wishlist (#68) — the hub's only anonymous content surface.
-  // Token-addressed: the path carries an unguessable token stored hashed,
-  // the routes reveal one first name and wish titles, nothing else, under
-  // a login-strength rate limit. Everything under this prefix is designed
-  // for strangers; nothing else is.
-  if (path.startsWith('/api/wishlist/')) return;
-  /*
-    The calendar subscription feed. Same shape as the wishlist: an
-    unguessable token in the path, addressing one person's view, read-only
-    by construction. A calendar app has no session to present — and the
-    sibling endpoints that create and revoke the token (/api/calendar/feed
-    with no trailing segment) stay behind auth, which is why this prefix
-    ends in a slash.
-  */
-  if (path.startsWith('/api/calendar/feed/')) return;
-  /*
-    A single shared event, addressed by its own token. Same family as the
-    two above: unguessable, read-only, and scoped to one row — it reveals
-    one event and deliberately not the calendar around it.
-  */
-  if (path.startsWith('/api/event/')) return;
-  /*
-    A shared list. The only public surface that accepts a write — ticking
-    an item — because a shopping list nobody can tick off is a screenshot.
-    The token scopes both the read and that write to one list.
-  */
-  if (path.startsWith('/api/list/')) return;
+  // The token-addressed subtrees — what they are and why, at the list itself
+  if (TOKEN_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))) return;
 
   const token = req.cookies[SESSION_COOKIE];
   const user = token ? userForToken(token) : null;


### PR DESCRIPTION
Closes #186.

## The leak

`redactUrl` masked one path prefix — `/api/wishlist/`, the first token surface built. Three more were added after it (`/api/calendar/feed/:token`, `/api/event/:token`, `/api/list/:token`), each carrying its token in the path the same way, and none was added to the mask. The `onResponse` hook and the error handler log `${status} ${method} ${redactUrl(url)}`, so a guest request that ended in a 404, a 429 (the share rate limit) or a 500 wrote the live link into the log at warn level.

Share tokens are stored in the clear by design (migration 021) because the link is meant to be re-sent — which is precisely why the log line is the leak.

## The fix

The two lists had drifted because they were two lists. `TOKEN_PATH_PREFIXES` in `lib/auth.ts` is now the single source: `authenticate` exempts it, and `redactUrl` builds its mask from it. A fifth token surface cannot be opened to the internet without also being redacted.

The explanatory comments move with the entries. One of them stops claiming the wishlist token is "stored hashed" — it is stored in the clear, and always was.

## Tests

- `app.redact.test.ts`: all four surfaces, their sub-paths (`/claim`, `/ics`, `/items/:id/toggle` — the item id is a plain uuid and stays), a token followed by a query string, and the authenticated siblings that share a prefix root (`/api/calendar/feed` with no segment, `/api/lists/…`, `/api/events`) which must **not** be touched.
- `auth.public-surface.test.ts` used to scrape `startsWith` literals out of `authenticate`. It now asserts the exported list directly — what the wall actually consults — and checks that `authenticate` uses that list rather than a copy. Widening the surface still fails here with a diff to explain.

`npm run typecheck`, `npm run lint`, `npm test` all green — 362 tests (276 server + 86 web).