### PR TITLE
fix: make inbound mail ingest atomic, and retry transient failures

### DIFF
--- a/server/src/lib/mail.ts
+++ b/server/src/lib/mail.ts
@@ -3,7 +3,13 @@ import { ImapFlow } from 'imapflow';
 import nodemailer from 'nodemailer';
 import { currentTenant, db, id, now } from '../db/index.js';
 import { env } from '../env.js';
-import { saveMailAttachment } from '../routes/attachments.js';
+import {
+  attachmentBytesUsed,
+  discardStaged,
+  insertStagedAttachment,
+  stageMailAttachment,
+  type StagedAttachment,
+} from '../routes/attachments.js';
 import { log } from './log.js';
 import { familySlug } from './tenants.js';
 
@@ -221,62 +227,125 @@ export async function sendServiceEmail(to: string, subject: string, text: string
   }
 }
 
-/** Sanity cap: a message source larger than this is not household mail. */
-const MAX_MESSAGE_BYTES = 25 * 1024 * 1024;
+/**
+ * Sanity cap: a message source larger than this is not household mail.
+ * The IMAP fetch truncates at it; the webhook refuses past it — and does
+ * so before parsing, so an oversized delivery costs a length check rather
+ * than a run of postal-mime over 25 MB on the shared event loop (#189).
+ */
+export const MAX_MESSAGE_BYTES = 25 * 1024 * 1024;
+
+/**
+ * A message that can never be ingested, however many times it is retried:
+ * malformed beyond what postal-mime accepts, or over the size cap. The
+ * webhook answers these with a permanent refusal (406) and everything else
+ * — a full disk, a busy database — with a retryable one, because ingest
+ * is all-or-nothing and the next attempt can succeed (#187).
+ */
+export class UnparseableMail extends Error {
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, options);
+    this.name = 'UnparseableMail';
+  }
+}
 
 /**
  * Parses raw MIME and stores the message. Returns the new row id, or
  * null when the message is already known (same Message-ID) — ingest is
  * idempotent, so a re-poll or a restart never duplicates anything.
+ *
+ * All-or-nothing. Attachment files are staged first, then the message
+ * row and every attachment row commit in one transaction; if anything
+ * fails, the staged files are removed and nothing is left in the
+ * database. That is what makes a retry safe: a message that failed is
+ * not "known" on the next attempt, and one that succeeded is complete.
  */
 export async function ingestEmail(raw: Uint8Array | string): Promise<string | null> {
-  const email: Email = await PostalMime.parse(raw);
+  const size = typeof raw === 'string' ? Buffer.byteLength(raw) : raw.byteLength;
+  if (size > MAX_MESSAGE_BYTES) {
+    throw new UnparseableMail(`Message of ${size} bytes is over the ${MAX_MESSAGE_BYTES}-byte cap`);
+  }
+
+  let email: Email;
+  try {
+    email = await PostalMime.parse(raw);
+  } catch (err) {
+    throw new UnparseableMail('postal-mime could not parse the message', { cause: err });
+  }
 
   const messageId = email.messageId?.slice(0, 500) ?? null;
-  if (messageId) {
-    const known = db
-      .prepare('SELECT id FROM mail_messages WHERE message_id = ?')
-      .get(messageId);
-    if (known) return null;
+  const known = () =>
+    messageId !== null &&
+    db.prepare('SELECT 1 FROM mail_messages WHERE message_id = ?').get(messageId) !== undefined;
+  // Cheap exit before any disk work; checked again inside the transaction,
+  // where it is authoritative
+  if (known()) return null;
+
+  const staged: StagedAttachment[] = [];
+  try {
+    let used = attachmentBytesUsed();
+    for (const part of email.attachments ?? []) {
+      // Inline images of HTML signatures and the like are noise, not documents
+      if (part.disposition === 'inline' && !part.filename) continue;
+      // postal-mime yields string | ArrayBuffer | Uint8Array depending on encoding
+      const content =
+        typeof part.content === 'string'
+          ? Buffer.from(part.content)
+          : part.content instanceof ArrayBuffer
+            ? Buffer.from(new Uint8Array(part.content))
+            : Buffer.from(part.content);
+      const s = await stageMailAttachment(
+        {
+          filename: part.filename || 'attachment',
+          mime: part.mimeType || 'application/octet-stream',
+          content,
+        },
+        used,
+      );
+      if (s) {
+        staged.push(s);
+        used += s.size;
+      }
+    }
+
+    const rowId = id();
+    // `immediate`: take the write lock at BEGIN, so the duplicate check and
+    // the insert cannot interleave with another ingest of the same letter
+    const stored = db
+      .transaction((): string | null => {
+        if (known()) return null;
+        db.prepare(
+          `INSERT INTO mail_messages (id, message_id, kind, from_address, from_name, to_address,
+                                      subject, body_text, sent_at, received_at)
+           VALUES (?, ?, 'in', ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          rowId,
+          messageId,
+          email.from?.address?.slice(0, 300) ?? '(unknown)',
+          email.from?.name?.slice(0, 200) || null,
+          email.to?.[0]?.address?.slice(0, 300) ?? null,
+          (email.subject ?? '').slice(0, 500),
+          // The text part; when a message is HTML-only, fall back to a crude
+          // tag strip so the reader is never left with an empty body
+          (email.text ?? textFromHtml(email.html)).slice(0, 100_000),
+          email.date ? email.date.replace('T', ' ').slice(0, 19) : null,
+          now(),
+        );
+        for (const s of staged) insertStagedAttachment(rowId, s);
+        return rowId;
+      })
+      .immediate();
+
+    if (stored === null) {
+      // Lost the race to an identical delivery: its files are the ones that count
+      await discardStaged(staged);
+      return null;
+    }
+    return stored;
+  } catch (err) {
+    await discardStaged(staged);
+    throw err;
   }
-
-  const rowId = id();
-  db.prepare(
-    `INSERT INTO mail_messages (id, message_id, kind, from_address, from_name, to_address,
-                                subject, body_text, sent_at, received_at)
-     VALUES (?, ?, 'in', ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    rowId,
-    messageId,
-    email.from?.address?.slice(0, 300) ?? '(unknown)',
-    email.from?.name?.slice(0, 200) || null,
-    email.to?.[0]?.address?.slice(0, 300) ?? null,
-    (email.subject ?? '').slice(0, 500),
-    // The text part; when a message is HTML-only, fall back to a crude
-    // tag strip so the reader is never left with an empty body
-    (email.text ?? textFromHtml(email.html)).slice(0, 100_000),
-    email.date ? email.date.replace('T', ' ').slice(0, 19) : null,
-    now(),
-  );
-
-  for (const part of email.attachments ?? []) {
-    // Inline images of HTML signatures and the like are noise, not documents
-    if (part.disposition === 'inline' && !part.filename) continue;
-    // postal-mime yields string | ArrayBuffer | Uint8Array depending on encoding
-    const content =
-      typeof part.content === 'string'
-        ? Buffer.from(part.content)
-        : part.content instanceof ArrayBuffer
-          ? Buffer.from(new Uint8Array(part.content))
-          : Buffer.from(part.content);
-    await saveMailAttachment(rowId, {
-      filename: part.filename || 'attachment',
-      mime: part.mimeType || 'application/octet-stream',
-      content,
-    });
-  }
-
-  return rowId;
 }
 
 /** Last-resort readable text for HTML-only messages. Not a renderer. */

--- a/server/src/routes/attachments.ts
+++ b/server/src/routes/attachments.ts
@@ -105,40 +105,80 @@ interface UploadedInfo {
   url: string;
 }
 
-/**
- * Attachment arriving as a buffer (a MIME part of a family-mail
- * message) rather than a multipart upload. Same storage layout, same
- * budget; an oversized part or a full store skips the file rather than
- * failing the whole message — the text always lands.
- */
-export async function saveMailAttachment(
-  mailMessageId: string,
-  file: { filename: string; mime: string; content: Buffer },
-): Promise<void> {
-  if (file.content.length === 0 || file.content.length > MAX_FILE_BYTES) return;
+/*
+  Attachments arriving as MIME parts of a family-mail message, rather than
+  as a multipart upload. Same storage layout, same budget.
+
+  Split into "write the file" and "write the row" on purpose. A message
+  and its attachments have to land together or not at all: better-sqlite3
+  transactions are synchronous and cannot span an `await`, so the files
+  are staged first, then message row and attachment rows go into one
+  transaction, and a failure anywhere unlinks what was staged. Before this
+  split the message row committed on its own and a failed attachment left
+  it behind half-stored — and, being known by Message-ID from then on,
+  never repaired (#187).
+
+  An oversized part or a full store skips the file rather than failing the
+  message: the text always lands. That is a decision about the part, not a
+  failure, so it returns null rather than throwing.
+*/
+
+export interface StagedAttachment {
+  filename: string;
+  mime: string;
+  size: number;
+  /** Relative to the family's attachments directory, as stored in the row. */
+  storagePath: string;
+  absPath: string;
+}
+
+/** Bytes already on this family's tab — the budget is cumulative across parts. */
+export function attachmentBytesUsed(): number {
   const { used } = db
     .prepare('SELECT coalesce(sum(size_bytes), 0) AS used FROM attachments')
     .get() as { used: number };
-  if (used + file.content.length > BUDGET_BYTES) return;
+  return used;
+}
+
+/**
+ * Write one part to disk, or decide not to. `usedBytes` is the running
+ * total the caller keeps, so the budget holds across the parts of one
+ * message without re-reading the table per part.
+ */
+export async function stageMailAttachment(
+  file: { filename: string; mime: string; content: Buffer },
+  usedBytes: number,
+): Promise<StagedAttachment | null> {
+  if (file.content.length === 0 || file.content.length > MAX_FILE_BYTES) return null;
+  if (usedBytes + file.content.length > BUDGET_BYTES) return null;
 
   const storageName = storageNameFor(file.filename);
   const month = today().slice(0, 7);
   const folder = join(currentTenant().attachmentsDir, month);
   await mkdir(folder, { recursive: true });
-  await writeFile(join(folder, storageName), file.content);
+  const absPath = join(folder, storageName);
+  await writeFile(absPath, file.content);
 
+  return {
+    filename: file.filename.slice(0, 300),
+    mime: safeMime(file.mime),
+    size: file.content.length,
+    storagePath: join(month, storageName),
+    absPath,
+  };
+}
+
+/** The row for a staged part — synchronous, meant for the caller's transaction. */
+export function insertStagedAttachment(mailMessageId: string, staged: StagedAttachment): void {
   db.prepare(
     `INSERT INTO attachments (id, filename, mime, size_bytes, storage_path, mail_message_id, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    id(),
-    file.filename.slice(0, 300),
-    safeMime(file.mime),
-    file.content.length,
-    join(month, storageName),
-    mailMessageId,
-    now(),
-  );
+  ).run(id(), staged.filename, staged.mime, staged.size, staged.storagePath, mailMessageId, now());
+}
+
+/** Undo staging when the message did not land. Best effort: a file that is already gone is fine. */
+export async function discardStaged(staged: StagedAttachment[]): Promise<void> {
+  await Promise.all(staged.map((s) => unlink(s.absPath).catch(() => undefined)));
 }
 
 /**

--- a/server/src/routes/mail-inbound.test.ts
+++ b/server/src/routes/mail-inbound.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createHmac } from 'node:crypto';
-import { readdirSync } from 'node:fs';
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import type { FastifyInstance } from 'fastify';
@@ -25,6 +25,8 @@ process.env.MAILGUN_SIGNING_KEY = 'test-signing-key';
 const tenants = await import('../lib/tenants.js');
 const { buildApp } = await import('../app.js');
 const { env } = await import('../env.js');
+const { MAX_MESSAGE_BYTES } = await import('../lib/mail.js');
+const { today } = await import('../db/index.js');
 
 const SIGNING_KEY = 'test-signing-key';
 const INBOUND = '/api/mail/inbound/mime';
@@ -352,6 +354,92 @@ describe('inbound family mail', () => {
 
     const smiths = await mailbox(SMITHS, smithsCookie);
     expect(smiths.messages.map((m) => m.subject)).toContain('Your bill');
+  });
+
+  it('stores nothing and asks for a retry when the attachment store fails (#187)', async () => {
+    /*
+      Ingest used to commit the message row and then save attachments one
+      by one. A failure in between left a half-stored letter that was
+      "known" by Message-ID from then on and never repaired — and every
+      failure was answered 406, which told Mailgun to give up on it.
+
+      Its own family, so the half-stored / retried state cannot disturb a
+      sibling test's mailbox. The failure is real, not mocked: a regular
+      file where the month folder has to be created makes the attachment
+      write fail with EEXIST.
+    */
+    const FRAGILE = 'fragile-m5n6';
+    tenants.createFamily(FRAGILE);
+    const registry = new Database(join(env.dataDir, 'registry.db'), { readonly: true });
+    const fragileId = (registry.prepare('SELECT id FROM families WHERE slug = ?').get(FRAGILE) as { id: string }).id;
+    registry.close();
+    const monthDir = join(env.dataDir, 'families', fragileId, 'attachments', today().slice(0, 7));
+    mkdirSync(join(env.dataDir, 'families', fragileId, 'attachments'), { recursive: true });
+    writeFileSync(monthDir, 'not a directory');
+
+    const withAttachment = [
+      'Message-ID: <fragile-1@school.example>',
+      'From: office@school.example',
+      `To: ${FRAGILE}@mail.neiliro.test`,
+      'Subject: Permission slip',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/mixed; boundary="B"',
+      '',
+      '--B',
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      'Please sign.',
+      '--B',
+      'Content-Type: application/pdf',
+      'Content-Disposition: attachment; filename="slip.pdf"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      Buffer.from('%PDF-1.4 slip').toString('base64'),
+      '--B--',
+      '',
+    ].join('\r\n');
+    const send = () =>
+      post(delivery({ recipient: `${FRAGILE}@mail.neiliro.test`, 'body-mime': withAttachment }));
+
+    try {
+      const failed = await send();
+      // Retryable, not permanent
+      expect(failed.statusCode).toBe(500);
+      // And genuinely nothing was kept: no half-stored letter
+      const fragileDb = new Database(join(env.dataDir, 'families', fragileId, 'hub.db'), { readonly: true });
+      const rows = fragileDb.prepare("SELECT id FROM mail_messages WHERE subject = 'Permission slip'").all();
+      const files = fragileDb.prepare('SELECT id FROM attachments').all();
+      fragileDb.close();
+      expect(rows).toEqual([]);
+      expect(files).toEqual([]);
+    } finally {
+      rmSync(monthDir, { force: true });
+    }
+
+    // The retry Mailgun would make now succeeds, with the attachment
+    const retried = await send();
+    expect(retried.statusCode).toBe(200);
+    expect(retried.json()).toEqual({ ok: true, stored: true });
+    const fragileDb = new Database(join(env.dataDir, 'families', fragileId, 'hub.db'), { readonly: true });
+    const stored = fragileDb
+      .prepare(
+        `SELECT (SELECT count(*) FROM attachments a WHERE a.mail_message_id = m.id) AS n
+           FROM mail_messages m WHERE m.subject = 'Permission slip'`,
+      )
+      .get() as { n: number } | undefined;
+    fragileDb.close();
+    expect(stored?.n).toBe(1);
+  });
+
+  it('refuses an oversized letter for good, before parsing it (#189)', { timeout: 30_000 }, async () => {
+    // Over the raw-MIME cap: permanent, since a retry will not shrink it,
+    // and rejected on a length check rather than a run of postal-mime.
+    const huge = 'a'.repeat(MAX_MESSAGE_BYTES + 1);
+    const started = Date.now();
+    const res = await post(delivery({ recipient: `${SMITHS}@mail.neiliro.test`, 'body-mime': huge }));
+    expect(res.statusCode).toBe(406);
+    // Generous, but a parse of 25 MB of nothing would take far longer
+    expect(Date.now() - started).toBeLessThan(10_000);
   });
 
   it('routes a "+tag" address to the family that owns the local part', async () => {

--- a/server/src/routes/mail-inbound.ts
+++ b/server/src/routes/mail-inbound.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import { runWithTenant } from '../db/index.js';
 import { env } from '../env.js';
-import { ingestEmail } from '../lib/mail.js';
+import { UnparseableMail, ingestEmail } from '../lib/mail.js';
 import { log } from '../lib/log.js';
 import { tenantForSlug } from '../lib/tenants.js';
 
@@ -34,9 +34,14 @@ const INBOUND_PATH = '/api/mail/inbound/mime';
 
 /*
   A letter arrives percent-encoded inside a form field, which inflates it
-  well past the raw MIME cap ingestEmail enforces. Fastify's default body
-  limit is 1 MB — far too small for a scan of a utility bill, and it would
-  fail as a 413 that Mailgun retries for eight hours.
+  past the 25 MB raw-MIME cap ingestEmail enforces (MAX_MESSAGE_BYTES) —
+  hence the headroom here. Fastify's default body limit is 1 MB, far too
+  small for a scan of a utility bill, and it would fail as a 413 that
+  Mailgun retries for eight hours.
+
+  The signature lives in the same form as the letter, so the body has to
+  be parsed before it can be checked; that pre-auth cost is bounded by
+  this limit, and the raw-MIME cap is checked before any MIME parsing.
 */
 const MAX_INBOUND_BYTES = 40 * 1024 * 1024;
 
@@ -96,7 +101,9 @@ export async function registerInboundMailRoutes(app: FastifyInstance): Promise<v
     Response codes are a protocol here, not decoration: Mailgun retries
     for eight hours on anything that is not 200 or 406. Every permanent
     rejection below must therefore be 406 — a 500 on an unknown family
-    would turn one stray letter into hours of retries.
+    would turn one stray letter into hours of retries. The converse holds
+    too: a letter that failed for a reason that can pass tomorrow (a full
+    disk, a busy database) must NOT be 406, or it is dropped for good.
   */
   app.post(INBOUND_PATH, { bodyLimit: MAX_INBOUND_BYTES }, async (req, reply) => {
     const form = (req.body ?? {}) as Record<string, string | undefined>;
@@ -139,9 +146,16 @@ export async function registerInboundMailRoutes(app: FastifyInstance): Promise<v
       log.info(`mail inbound: ${rowId === null ? 'duplicate' : 'stored'} for "${slug}"`);
       return { ok: true, stored: rowId !== null };
     } catch (err) {
-      // Unparseable MIME is permanent — retrying it changes nothing.
-      log.error(`mail inbound: ingest failed for "${slug}"`, err);
-      return reply.code(406).send({ error: 'Could not parse the message' });
+      if (err instanceof UnparseableMail) {
+        // Malformed or oversized: permanent, retrying it changes nothing
+        log.error(`mail inbound: unparseable message for "${slug}"`, err);
+        return reply.code(406).send({ error: 'Could not parse the message' });
+      }
+      // Storage or database trouble. Ingest is all-or-nothing, so nothing
+      // of this letter was kept and the next attempt can succeed — and a
+      // 5xx is exactly what asks the provider to make one (#187).
+      log.error(`mail inbound: could not store a message for "${slug}", asking for a retry`, err);
+      return reply.code(500).send({ error: 'Could not store the message' });
     }
   });
 }


### PR DESCRIPTION
Closes #187.

## The bug

`ingestEmail` committed the `mail_messages` row and then saved attachments one at a time, outside any transaction. A failure in between (a full disk, a busy database, a hostile part) left the message row behind without its attachments — and because it was then "known" by `Message-ID`, the retry saw a duplicate and never repaired it.

`mail-inbound.ts` compounded it: every ingest error mapped to `406`. `406` is correct for unparseable MIME (a retry changes nothing) but wrong for a transient error — it tells Mailgun to abandon its eight-hour retry budget, and the letter is lost.

## The fix

**All-or-nothing.** better-sqlite3 transactions are synchronous and cannot span an `await`, so:

1. attachment parts are **staged** to disk,
2. the message row and every attachment row commit in one `immediate` transaction,
3. any failure unlinks the staged files and leaves nothing in the database.

A message that failed is not "known" next time; one that succeeded is complete. That is what makes a retry safe.

**Transient vs permanent.** Malformed or oversized MIME is an `UnparseableMail` and stays a permanent `406`. Everything else is a `5xx`, because ingest kept nothing and the next attempt can succeed — and a `5xx` is how you ask the provider to make one.

`saveMailAttachment` splits into `stageMailAttachment` / `insertStagedAttachment` / `discardStaged` so the caller owns the transaction. Row shape and the 2 GB budget are unchanged; the budget still holds across the parts of one message.

While here, the 25 MB raw-MIME cap is checked **before** `postal-mime` runs, so an oversized delivery costs a length check rather than a parse of 25 MB on the shared event loop — the parse-cost half of #189.

## Tests

Two new cases in `mail-inbound.test.ts`, both with real failures rather than mocks:

- **transient failure → retryable, nothing left behind.** A regular file is placed where the month folder must be created, so the attachment write fails with `EEXIST`. The delivery returns `500`, and the family DB holds no message row and no attachment. Then the same delivery (the retry Mailgun would make) returns `200` with the attachment stored — proving the half-stored state was truly absent, not merely deduplicated away. Runs in its own throwaway family so it cannot disturb a sibling test's mailbox.
- **oversized → permanent `406`, fast.** A body over the cap is refused in well under the time a 25 MB parse would take.

The IMAP poller is unaffected: it still marks `\Seen` only after a non-throwing ingest, and its fetch truncates at the cap, so the new throw paths behave exactly as the old parse-throw did.

`npm run typecheck`, `npm run lint`, `npm test` all green — 362 tests (276 server + 86 web).