### PR TITLE
chore: pin GitHub Actions to commit SHAs, and put Dependabot on actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
+# Two ecosystems, one reason: a pin that nobody moves rots instead of
+# drifting. Dependabot proposes the bumps for a human to merge.
+#
 # Actions are pinned to commit SHAs (a floating major tag is mutable, and
-# this image reaches every self-hosted install). A pin that never moves
-# rots instead, so Dependabot proposes the bumps — SHA and the version
-# comment together — for a human to merge, weekly and grouped into one PR.
+# the release image reaches every self-hosted install); the bump moves the
+# SHA and its version comment together.
+#
+# npm: `npm audit` only knows advisories that were filed. The lockfile
+# once sat eight patch releases behind on imapflow and three behind on
+# nodemailer — hardening fixes in the address parser and the access
+# sandbox, none of them with a CVE — and a human had to notice. Weekly,
+# minor and patch grouped into one PR because they are semver-safe;
+# majors arrive one at a time, because zod 4 or vite 8 are migrations,
+# not bumps.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -11,3 +21,17 @@ updates:
     groups:
       actions:
         patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-and-patch:
+        update-types: [minor, patch]
+    ignore:
+      # The runtime image is node:22-bookworm-slim. Types above the
+      # runtime are an error, not an update — the major moves with the
+      # image, by hand.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Actions are pinned to commit SHAs (a floating major tag is mutable, and
+# this image reaches every self-hosted install). A pin that never moves
+# rots instead, so Dependabot proposes the bumps — SHA and the version
+# comment together — for a human to merge, weekly and grouped into one PR.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,11 @@ jobs:
     env:
       DEPLOY: ${{ secrets.DEPLOY_USER || 'root' }}@${{ secrets.DEPLOY_HOST }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Deploying code that fails types or tests is pointless; ci.yml runs
       # the same checks in parallel, these gate the deploy itself.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,22 +20,22 @@ jobs:
   image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/login-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v6
+      - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           build-args: BUILD_SHA=${{ github.sha }}


### PR DESCRIPTION
Addresses the supply-chain half of #189. Two commits.

## 1 — SHA-pin the actions

A floating major tag like `actions/checkout@v7` is mutable; whoever controls the tag controls what runs in CI and, through `release.yml`, what goes into the image every self-hosted install pulls. Every `uses:` across `ci.yml`, `deploy.yml`, `release.yml` is pinned to the commit its tag currently points at, version kept as a trailing comment. Ten pins, no floating tags left. Each SHA was resolved from the tag it replaces (annotated tags dereferenced), so the same commit runs — no behaviour change.

## 2 — Dependabot on both ecosystems

A pin nobody moves rots instead of drifting, so `.github/dependabot.yml` proposes the bumps for a human to merge.

- **github-actions**, weekly, grouped into one PR — moves the SHA and its version comment together.
- **npm**, weekly. `npm audit` only knows advisories that were filed; reviewing the lockfile by hand (see #197) found it eight patch releases behind on imapflow and three on nodemailer — a linear-time address parser, an access-sandbox fix, unhandled-rejection guards — none with a CVE, so no audit would have flagged them. Minor and patch grouped into one PR (semver-safe); majors arrive one at a time, because zod 4 or vite 8 are migrations, not bumps. `@types/node` is held at its major: the runtime is `node:22`, and types above the runtime move with the image, by hand.

## Verification

All YAML parses (`js-yaml`). Pins verified against the source tags.

## The other half of #189

The webhook parsing its body before the signature check is not fixable by reordering: Mailgun's `timestamp`/`token`/`signature` travel *inside* the same urlencoded body. What was in scope — bounding that pre-auth cost — is in #195: body capped at 40 MB, and the 25 MB raw-MIME cap now checked before `postal-mime` runs. Close #189 once this and #195 both land.