### PR TITLE
chore: raise nodemailer to 9.1.1 and imapflow to 1.7.8 for their hardening fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,13 +4580,13 @@
       }
     },
     "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.15.tgz",
-      "integrity": "sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA==",
+      "version": "5.4.16",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.16.tgz",
+      "integrity": "sha512-zQ9iXvlT3Wi/hazeC1MdI4rQc1UJwJ6IQ6QzSZ5KDxLZZWQSazWLOzImLFluXadKShJ9WJvI1xH+AyVS8b9azg==",
       "license": "(MIT OR EUPL-1.1+)",
       "dependencies": {
         "libbase64": "1.3.0",
-        "libmime": "5.4.2",
+        "libmime": "5.4.3",
         "libqp": "2.1.1"
       }
     },
@@ -5567,12 +5567,12 @@
       "license": "MIT"
     },
     "node_modules/encoding-japanese": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
-      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.3.0.tgz",
+      "integrity": "sha512-eQyh1vzHz13DUkZcJO+0IOAoKXRQwKV5IBffeuYsWZyRLGiSzfzXObCqWvqFXdX0UU8qOk+lBXbkUhMCpdJe4Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -6906,16 +6906,16 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.7.0.tgz",
-      "integrity": "sha512-wWs6g5SBC7OEobQ82T3Jou/KlKl2f37mTCCuGkBrUB0irvYUodkUYMe36GSq1TLs/FM+j/hLmmAgm3CBZkVMyQ==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.7.8.tgz",
+      "integrity": "sha512-dJoCIdZOJh26Rn2PdwEzwj0bRDgGBxxX38pio534FagIHVuR2l0SAfLr6sJo32YfuJHiSs/U2ntNDHnMg3/Hlg==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.15",
-        "encoding-japanese": "2.2.0",
+        "@zone-eu/mailsplit": "5.4.16",
+        "encoding-japanese": "2.3.0",
         "iconv-lite": "0.7.3",
         "libbase64": "1.3.0",
-        "libmime": "5.4.2",
+        "libmime": "5.4.3",
         "libqp": "2.1.1",
         "pino": "10.3.1",
         "socks": "2.8.9"
@@ -7657,12 +7657,12 @@
       "license": "MIT"
     },
     "node_modules/libmime": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.2.tgz",
-      "integrity": "sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.3.tgz",
+      "integrity": "sha512-di9BoDabBUMqjeD/wGj+hHpSgdqAph5ui7w6OdY6NpzU6O6VFLQsMOg9tqCjm/zf9OHzAM9EZxSOF7uIb8O8Hw==",
       "license": "MIT",
       "dependencies": {
-        "encoding-japanese": "2.2.0",
+        "encoding-japanese": "2.3.0",
         "iconv-lite": "0.7.3",
         "libbase64": "1.3.0",
         "libqp": "2.1.1"
@@ -8253,9 +8253,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
-      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -11911,8 +11911,8 @@
         "@fastify/static": "^10.1.3",
         "better-sqlite3": "^11.8.1",
         "fastify": "^5.2.1",
-        "imapflow": "^1.7.0",
-        "nodemailer": "^9.0.5",
+        "imapflow": "^1.7.8",
+        "nodemailer": "^9.1.1",
         "postal-mime": "^3.0.0",
         "zod": "^3.24.2"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -20,8 +20,8 @@
     "@fastify/static": "^10.1.3",
     "better-sqlite3": "^11.8.1",
     "fastify": "^5.2.1",
-    "imapflow": "^1.7.0",
-    "nodemailer": "^9.0.5",
+    "imapflow": "^1.7.8",
+    "nodemailer": "^9.1.1",
     "postal-mime": "^3.0.0",
     "zod": "^3.24.2"
   },


### PR DESCRIPTION
## Why

`npm audit` and the GitHub Advisory Database are clean for the versions we had pinned (nodemailer 9.0.5, imapflow 1.7.0), but both libraries shipped hardening fixes since then that matter for this hub:

- **nodemailer 9.0.6 → 9.1.1** — address lists parsed in linear time, domain terminated at an RFC 5322 comment, hardened copies of user-supplied keys and URL fetching, access policy applied consistently. The self-hosted reply path passes the *From* of an inbound letter as the recipient, so a hostile sender controls that input.
- **imapflow 1.7.1 → 1.7.8** — credential frames masked in the raw log; a stream error during a backpressure wait keeps its error forwarder instead of becoming an unhandled error. The IMAP poller runs inside the hub process, so an unhandled error there would take every family down.

Floors are raised in `server/package.json` so the requirement is recorded, not incidental to a lockfile refresh. Transitive moves: libmime 5.4.3, @zone-eu/mailsplit 5.4.16, encoding-japanese 2.3.0.

## Verification

- `npm run typecheck` (server) and `npm run lint` clean locally.
- Mail test files (`mail.test.ts`, `mail-inbound.test.ts`, `mail-hosted-send.test.ts`) pass locally.
- Full server suite left to CI: locally, better-sqlite3 11.x under Node 24 on macOS arm64 intermittently aborts in a GC finalizer ([WiseLibs/better-sqlite3#1515](https://github.com/WiseLibs/better-sqlite3/issues/1515)), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)