### PR TITLE
fix: tell Mailgun not to track opens or clicks, and say so in one place

### DIFF
--- a/server/src/lib/mail.ts
+++ b/server/src/lib/mail.ts
@@ -160,21 +160,39 @@ function serviceSender(address: string): Outgoing {
         form.set('h:References', message.inReplyTo);
       }
 
-      const auth = Buffer.from(`api:${env.mailgunApiKey}`).toString('base64');
-      const res = await fetch(`${env.mailgunApiBase}/v3/${env.mailDomain}/messages`, {
-        method: 'POST',
-        headers: { Authorization: `Basic ${auth}` },
-        body: form,
-      });
-      if (!res.ok) {
-        // The body names the actual reason — an unverified domain, a
-        // compliance hold — and the person pressing "send reply" is the
-        // one who needs to see it.
-        const detail = await res.text().catch(() => '');
-        throw new Error(`Mailgun refused the message (${res.status}) ${detail.slice(0, 200)}`.trim());
-      }
+      await postToMailgun(form);
     },
   };
+}
+
+/**
+ * The one place a message leaves for Mailgun. Every outbound path goes
+ * through here so that the delivery options are set once, not per sender.
+ *
+ * `o:tracking=no` is the privacy policy in code: it promises no open or
+ * click tracking. Today that holds by accident — everything we send is
+ * plain text, and Mailgun tracks opens with a pixel in the HTML part and
+ * clicks by rewriting HTML links, so there is nothing for it to touch. The
+ * day a message gains an HTML part, the domain's dashboard settings would
+ * silently decide for us. Sending the flag makes the promise hold
+ * regardless of what is configured on their side (#158).
+ */
+async function postToMailgun(form: FormData): Promise<void> {
+  form.set('o:tracking', 'no');
+
+  const auth = Buffer.from(`api:${env.mailgunApiKey}`).toString('base64');
+  const res = await fetch(`${env.mailgunApiBase}/v3/${env.mailDomain}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Basic ${auth}` },
+    body: form,
+  });
+  if (!res.ok) {
+    // The body names the actual reason — an unverified domain, a
+    // compliance hold — and the person pressing "send reply" is the
+    // one who needs to see it.
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Mailgun refused the message (${res.status}) ${detail.slice(0, 200)}`.trim());
+  }
 }
 
 /**
@@ -214,17 +232,7 @@ export async function sendServiceEmail(to: string, subject: string, text: string
   form.set('to', to);
   form.set('subject', subject);
   form.set('text', text);
-
-  const auth = Buffer.from(`api:${env.mailgunApiKey}`).toString('base64');
-  const res = await fetch(`${env.mailgunApiBase}/v3/${env.mailDomain}/messages`, {
-    method: 'POST',
-    headers: { Authorization: `Basic ${auth}` },
-    body: form,
-  });
-  if (!res.ok) {
-    const detail = await res.text().catch(() => '');
-    throw new Error(`Mailgun refused the message (${res.status}) ${detail.slice(0, 200)}`.trim());
-  }
+  await postToMailgun(form);
 }
 
 /**

--- a/server/src/routes/mail-hosted-send.test.ts
+++ b/server/src/routes/mail-hosted-send.test.ts
@@ -138,6 +138,9 @@ describe('hosted reply', () => {
     // angle-bracketed the way the header is stored
     expect(fields['h:In-Reply-To']).toBe('<consent-9@school.example>');
     expect(fields['h:References']).toBe('<consent-9@school.example>');
+    // The privacy policy promises no open or click tracking. Plain text
+    // makes that true by accident; the flag makes it true on purpose (#158)
+    expect(fields['o:tracking']).toBe('no');
   });
 
   it('encodes the display name, which is never plain ASCII', async () => {

--- a/server/src/routes/password-reset.test.ts
+++ b/server/src/routes/password-reset.test.ts
@@ -23,6 +23,7 @@ interface Sent {
   to: string;
   subject: string;
   text: string;
+  tracking: string;
 }
 const sent: Sent[] = [];
 
@@ -30,7 +31,7 @@ vi.stubGlobal(
   'fetch',
   vi.fn(async (_url: string, init: { body: FormData }) => {
     const f = (k: string) => String(init.body.get(k) ?? '');
-    sent.push({ from: f('from'), to: f('to'), subject: f('subject'), text: f('text') });
+    sent.push({ from: f('from'), to: f('to'), subject: f('subject'), text: f('text'), tracking: f('o:tracking') });
     return { ok: true, status: 200, json: async () => ({ id: '<sent@mail.neiliro.test>' }) };
   }),
 );
@@ -128,6 +129,9 @@ describe('password reset', () => {
     expect(mail.from).toContain('<no-reply@mail.neiliro.test>');
     expect(mail.to).toBe(EMAIL);
     expect(mail.text).toContain(`https://${SLUG}.neiliro.test/reset?token=`);
+    // Service mail rides the same Mailgun call as family replies, so the
+    // no-tracking promise has to hold here too (#158)
+    expect(mail.tracking).toBe('no');
 
     const done = await app.inject({
       method: 'POST',


### PR DESCRIPTION
Closes #158.

## Why

The privacy policy promises no email open or click tracking. That held by accident: every message we send is plain text, so Mailgun's open pixel and link rewriting had nothing to touch. Once messages gain an HTML part (HTML rendering is on #30), the domain's dashboard settings would silently decide for us.

## What

- Both Mailgun senders (family replies in `serviceSender`, service mail in `sendServiceEmail`) built the same form and made the same POST separately. They now share `postToMailgun()`, which sets `o:tracking=no` once for every outbound message, so the flag cannot go missing from one path on the next edit.
- The reply test and the password-reset test both assert the flag is in the request. Reverse-checked: removing the `form.set` line fails the reply test with `expected undefined to be 'no'`.

## Verification

Typecheck and lint clean; `mail-hosted-send.test.ts` and `password-reset.test.ts` pass locally. Full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)