### PR TITLE
docs: a new language is two files, not one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,10 +178,23 @@ nothing will tell you that you forgot. Server-side strings are answered
 in English and translated on the client by exact match, so rewording a
 server message means updating the dictionary too.
 
-**A new language.** Copy `i18n.ru.ts`, translate the values, add a plural
-table if the language needs more forms than English, and wire it into
-`i18n.ts`. That is the whole job — the design goal was one file per
-language.
+**A new language** is two files, and the compiler tells you when you
+have forgotten the second one.
+
+1. *The interface.* Copy `web/src/lib/i18n.ru.ts`, translate the values,
+   add a plural table if the language needs more forms than English, and
+   add the code to `LANGS` in `i18n.ts`. Nothing else in the picker needs
+   wiring: a device that has never chosen a language takes the browser's
+   own preference, so a new dictionary is discovered on its own.
+2. *The demo family.* Add a column to `server/src/lib/demo.strings.ts`.
+   The sample family's content is seeded per language rather than
+   translated on read, so the table is typed (`DemoStrings`) and a missing
+   string is a compile error. `demo.strings.test.ts` also catches a value
+   copied across instead of translated — the few strings that are
+   deliberately identical in every language are listed in `SHARED`.
+
+The design goal was one file per language; the demo made it two, and the
+second one is guarded so that it cannot be half-done.
 
 **A migration.** Next number, descriptive name, and a comment at the top
 saying *why* the change is needed — the migration files are the closest

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -11,7 +11,9 @@ import { ru, ruPlurals } from './i18n.ru';
     but breaks nothing;
   — server errors are translated by the same t() in one place (lib/api.ts):
     the server sends English text, the client shows it in the UI language;
-  — a new language is one dictionary file away (see i18n.ru.ts).
+  — a new language is one dictionary file away (see i18n.ru.ts) — plus
+    a column in server/src/lib/demo.strings.ts, because the demo family's
+    content is seeded per language, not translated on read.
 
   Language is a device setting (localStorage), not an account one: a
   phone and a shared kiosk may speak different languages. A device that


### PR DESCRIPTION
Refs #15.

`CONTRIBUTING.md` ("A new language") and the header comment in `web/src/lib/i18n.ts` still said a language is one dictionary file. Since #179 the demo family is seeded per language from a typed table in `server/src/lib/demo.strings.ts`, so a new language is two files, and the second one is guarded: a missing column does not compile, and `demo.strings.test.ts` fails on a value copied instead of translated (the deliberately identical strings are listed in `SHARED`).

Also drops the "wire it into the picker" step: the device preference now discovers a dictionary on its own, so the code only has to be in `LANGS`.

Docs and a comment only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)