### PR TITLE
chore: version 1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -12094,7 +12094,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -12119,7 +12119,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for the 1.8.2 release: root, `server` and `web` package.json plus the lockfile. No code changes.

QA on the candidate (master @ e6e5fd4): targeted pass on a local hosted stand under Node 22 plus unauthenticated production checks — no blockers, no majors. Report kept outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)