### PR TITLE
feat: consent to the terms and privacy policy at account creation (hosted)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -10,6 +10,8 @@ A hub with an empty database offers to create the first account right in the bro
 
 Family members are added with invitations: the administrator creates a single-use link (valid for a week, shown once, stored as a hash), the person opens it and fills in their own name, login and password. This is the only way in — for a kid without their own device, the parent simply opens the link themselves. Each joining member automatically gets a distinct account color (the avatar is the first letter of the name, so color is what tells people apart).
 
+On the hosted service every account — the founder's and each invited member's — is created behind one checkbox naming the Terms of Service and the Privacy Policy, which open on the service's own domain; the moment of consent is recorded with the account. A self-hosted hub has no contract with anyone and never shows it.
+
 Day-to-day work happens under personal accounts. The administrator role manages the system; it has **no access to other people's private notes** — private queries filter by owner, and there is no "if admin, show everything" branch in the code.
 
 ### Lost password

--- a/server/src/db/migrations/031_terms_accepted.sql
+++ b/server/src/db/migrations/031_terms_accepted.sql
@@ -1,0 +1,12 @@
+-- Consent to the Terms of Service and Privacy Policy, on the hosted service.
+--
+-- Both legal pages promise that continued use is acceptance, but nothing
+-- recorded the moment a person actually agreed. On the hosted service every
+-- account is now created behind a checkbox naming both documents, and this
+-- column keeps when it was ticked. The documents are dated, so the
+-- timestamp says which version was on the table.
+--
+-- NULL on a self-hosted hub, by design: a family running its own server has
+-- no contract with the service, so the checkbox is not shown and there is
+-- nothing to record.
+ALTER TABLE users ADD COLUMN terms_accepted_at TEXT;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -113,7 +113,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
     // happens in sandboxes), but the initial setup screen must not be
     // shown, and there is one way in — the "Try the demo" button.
     if (env.demoMode) {
-      return { initialized: true, google: false, demo: true, hosted: false, password_reset: false };
+      return { initialized: true, google: false, demo: true, hosted: false, password_reset: false, apex: null };
     }
     // A hosted subdomain that doesn't exist claims to be set up: showing
     // the first-run screen only on real families would let anyone map
@@ -134,6 +134,7 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
         // "forgot password?" that appeared only on real subdomains would
         // enumerate families all by itself.
         password_reset: passwordResetAvailable(),
+        apex: env.hostedDomain,
       };
     }
     const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
@@ -150,6 +151,11 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       hosted: env.hostedMode,
       // Whether the login screen should offer "forgot password?"
       password_reset: passwordResetAvailable(),
+      // The service's apex, where the terms and privacy policy live — the
+      // account-creation forms link to them and ask for consent (migration
+      // 031). A property of the process, so the ghost states it too. Null
+      // on a self-hosted hub: there are no documents to agree to.
+      apex: env.hostedMode ? env.hostedDomain : null,
     };
   });
 

--- a/server/src/routes/email-verify.test.ts
+++ b/server/src/routes/email-verify.test.ts
@@ -83,7 +83,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: HOST },
-    payload: { name: 'Sam', email: ADMIN, password: 'correct horse battery' },
+    payload: { accept_terms: true, name: 'Sam', email: ADMIN, password: 'correct horse battery' },
   });
   expect(created.statusCode).toBe(201);
   adminCookie = `hub_session=${created.cookies.find((c) => c.name === 'hub_session')?.value}`;
@@ -100,7 +100,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/join',
     headers: { host: HOST },
-    payload: { token, name: 'Dana', email: MEMBER, password: 'correct horse battery' },
+    payload: { accept_terms: true, token, name: 'Dana', email: MEMBER, password: 'correct horse battery' },
   });
   expect(joined.statusCode).toBe(201);
 

--- a/server/src/routes/family-hosted.test.ts
+++ b/server/src/routes/family-hosted.test.ts
@@ -48,7 +48,7 @@ async function bringUpFamily(slug: string, name: string): Promise<Family> {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: `${slug}.neiliro.test` },
-    payload: { name, email, password: 'correct horse battery' },
+    payload: { accept_terms: true, name, email, password: 'correct horse battery' },
   });
   expect(setup.statusCode).toBe(201);
   const login = await app.inject({

--- a/server/src/routes/founder-invite.test.ts
+++ b/server/src/routes/founder-invite.test.ts
@@ -83,7 +83,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/setup',
       headers: onHost('founders-f1a1'),
-      payload: { name: 'Squatter', email: 'squatter@example.test', password: PASSWORD },
+      payload: { accept_terms: true, name: 'Squatter', email: 'squatter@example.test', password: PASSWORD },
     });
     expect(bare.statusCode).toBe(403);
     // Word-for-word what a ghost says — see the enumeration test below
@@ -103,7 +103,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('others-f1a2'),
-      payload: { token, name: 'Sam', email: 'sam@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token, name: 'Sam', email: 'sam@example.test', password: PASSWORD },
     });
     expect(elsewhere.statusCode).toBe(404);
     expect(familyDb(otherId).prepare('SELECT count(*) AS n FROM users').get()).toEqual({ n: 0 });
@@ -114,6 +114,7 @@ describe('the founder invitation', () => {
       url: '/api/auth/join',
       headers: onHost('founders-f1a1'),
       payload: {
+        accept_terms: true,
         token,
         name: 'Sam',
         email: 'sam@example.test',
@@ -146,7 +147,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('founders-f1a1'),
-      payload: { token, name: 'Sam II', email: 'sam2@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token, name: 'Sam II', email: 'sam2@example.test', password: PASSWORD },
     });
     expect(again.statusCode).toBe(404);
 
@@ -172,7 +173,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('movers-f2b1'),
-      payload: { token, name: 'Mo', email: 'other@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token, name: 'Mo', email: 'other@example.test', password: PASSWORD },
     });
     expect(joined.statusCode).toBe(201);
     await new Promise((r) => setTimeout(r, 60));
@@ -204,7 +205,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('latecomers-f3c1'),
-      payload: { token: second, name: 'Lee', email: 'second@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token: second, name: 'Lee', email: 'second@example.test', password: PASSWORD },
     });
     expect(joined.statusCode).toBe(201);
 
@@ -227,7 +228,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('sleepers-f4d1'),
-      payload: { token, name: 'Zed', email: 'zed@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token, name: 'Zed', email: 'zed@example.test', password: PASSWORD },
     });
     expect(expired.statusCode).toBe(404);
     // And the open first run stays closed — an expired invitation is
@@ -236,7 +237,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/setup',
       headers: onHost('sleepers-f4d1'),
-      payload: { name: 'Zed', email: 'zed@example.test', password: PASSWORD },
+      payload: { accept_terms: true, name: 'Zed', email: 'zed@example.test', password: PASSWORD },
     });
     expect(bare.statusCode).toBe(403);
 
@@ -248,7 +249,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('sleepers-f4d1'),
-      payload: { token: fresh, name: 'Zed', email: 'zed@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token: fresh, name: 'Zed', email: 'zed@example.test', password: PASSWORD },
     });
     expect(joined.statusCode).toBe(201);
     const cookie = joined.cookies.find((c) => c.name === 'hub_session')!.value;
@@ -280,7 +281,7 @@ describe('the founder invitation', () => {
         method: 'POST',
         url: '/api/auth/setup',
         headers: onHost(slug),
-        payload: { name: 'Squatter', email: 'squatter@example.test', password: PASSWORD },
+        payload: { accept_terms: true, name: 'Squatter', email: 'squatter@example.test', password: PASSWORD },
       });
 
     // 1. A family provisioned with an invitation, founder not yet arrived
@@ -299,7 +300,7 @@ describe('the founder invitation', () => {
       method: 'POST',
       url: '/api/auth/join',
       headers: onHost('parity-f5e1'),
-      payload: { token, name: 'Parity', email: 'parity@example.test', password: PASSWORD },
+      payload: { accept_terms: true, token, name: 'Parity', email: 'parity@example.test', password: PASSWORD },
     });
     expect(joined.statusCode).toBe(201);
     const claimed = await setup('parity-f5e1');

--- a/server/src/routes/google-hosted.test.ts
+++ b/server/src/routes/google-hosted.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: FAMILY },
-    payload: { name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
+    payload: { accept_terms: true, name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
   });
   expect(created.statusCode).toBe(201);
 
@@ -97,7 +97,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: OTHER },
-    payload: { name: 'Dana', email: 'dana@jones.test', password: 'correct horse battery' },
+    payload: { accept_terms: true, name: 'Dana', email: 'dana@jones.test', password: 'correct horse battery' },
   });
   expect(dana.statusCode).toBe(201);
 

--- a/server/src/routes/hosted.test.ts
+++ b/server/src/routes/hosted.test.ts
@@ -162,7 +162,7 @@ describe('suspension and deletion', () => {
           method: 'POST',
           url: '/api/auth/setup',
           headers: onHost('paused-p1q2.neiliro.test'),
-          payload: { name: 'Squatter', email: 'squatter@example.test', password: 'correct horse battery' },
+          payload: { accept_terms: true, name: 'Squatter', email: 'squatter@example.test', password: 'correct horse battery' },
         });
         // The ghost's decoy database may never grow an admin — whoever
         // "set it up" would own every unknown subdomain at once
@@ -200,7 +200,7 @@ describe('host routing', () => {
       method: 'POST',
       url: '/api/auth/setup',
       headers: onHost('smiths-a1b2.neiliro.test'),
-      payload: { name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
+      payload: { accept_terms: true, name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
     });
     expect(created.statusCode).toBe(201);
 
@@ -266,7 +266,7 @@ describe('host routing', () => {
       method: 'POST',
       url: '/api/auth/setup',
       headers: onHost('nosuch-x9y8.neiliro.test'),
-      payload: { name: 'Eve', email: 'eve@evil.test', password: 'longenoughpass' },
+      payload: { accept_terms: true, name: 'Eve', email: 'eve@evil.test', password: 'longenoughpass' },
     });
     expect(setup.statusCode).toBe(403);
   });

--- a/server/src/routes/mail-hosted-send.test.ts
+++ b/server/src/routes/mail-hosted-send.test.ts
@@ -73,7 +73,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: HOST },
-    payload: { name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
+    payload: { accept_terms: true, name: 'Sam', email: 'sam@smiths.test', password: 'correct horse battery' },
   });
   expect(created.statusCode).toBe(201);
   cookie = `hub_session=${created.cookies.find((c) => c.name === 'hub_session')?.value ?? ''}`;

--- a/server/src/routes/mail-inbound.test.ts
+++ b/server/src/routes/mail-inbound.test.ts
@@ -108,7 +108,7 @@ beforeAll(async () => {
       method: 'POST',
       url: '/api/auth/setup',
       headers: { host: `${slug}.neiliro.test` },
-      payload: { name, email: `${name.toLowerCase()}@${slug}.test`, password: 'correct horse battery' },
+      payload: { accept_terms: true, name, email: `${name.toLowerCase()}@${slug}.test`, password: 'correct horse battery' },
     });
     expect(res.statusCode).toBe(201);
     const cookie = res.cookies.find((c) => c.name === 'hub_session');

--- a/server/src/routes/password-reset.test.ts
+++ b/server/src/routes/password-reset.test.ts
@@ -93,7 +93,7 @@ beforeAll(async () => {
     method: 'POST',
     url: '/api/auth/setup',
     headers: { host: HOST },
-    payload: { name: 'Sam', email: EMAIL, password: OLD_PASSWORD },
+    payload: { accept_terms: true, name: 'Sam', email: EMAIL, password: OLD_PASSWORD },
   });
   expect(created.statusCode).toBe(201);
 

--- a/server/src/routes/setup.test.ts
+++ b/server/src/routes/setup.test.ts
@@ -36,4 +36,28 @@ describe('POST /api/auth/setup', () => {
     expect(USER_COLORS).toContain(row.color);
     expect(row.color).toBe(USER_COLORS[0]);
   });
+
+  it('asks for no consent on a self-hosted hub and records none, even if sent', async () => {
+    // No contract with the service: the checkbox is not shown, the field
+    // is ignored, the column stays NULL (migration 031).
+    const hub = await buildTestApp();
+    const state = await hub.app.inject({ url: '/api/auth/state' });
+    expect(state.json()).toMatchObject({ hosted: false, apex: null });
+
+    const res = await hub.app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      payload: {
+        name: 'Alex',
+        email: 'alex@hub.local',
+        password: 'correct horse battery staple',
+        accept_terms: true,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const row = hub.db.prepare('SELECT terms_accepted_at FROM users').get() as {
+      terms_accepted_at: string | null;
+    };
+    expect(row.terms_accepted_at).toBeNull();
+  });
 });

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -7,6 +7,7 @@ import { createSession, setSessionCookie } from '../lib/auth.js';
 import { hashPassword } from '../lib/password.js';
 import { sendVerificationEmail } from './email-verify.js';
 import { log } from '../lib/log.js';
+import { env } from '../env.js';
 
 /*
  * Distinct colors for joining members. Every visual identity in the hub
@@ -65,6 +66,22 @@ const ALREADY_SET_UP = 'The hub is already set up';
 const nameField = z.string().trim().min(1, 'The name cannot be empty').max(80);
 const emailField = z.string().trim().toLowerCase().email('Invalid login address').max(120);
 const passwordField = z.string().min(10, 'Password must be at least 10 characters').max(200);
+/*
+  Consent to the terms and the privacy policy (migration 031). On the hosted
+  service both account-creating routes refuse without it: a family that
+  never saw the documents cannot have agreed to them, whatever the terms say
+  about continued use. Self-hosted has no contract with the service, so the
+  field is ignored there and the column stays NULL. The error text is a
+  dictionary key on the client (i18n.ru.ts) — change both together.
+*/
+const acceptTermsField = z.boolean().optional();
+const TERMS_REQUIRED = 'Please accept the Terms of Service and Privacy Policy to continue';
+function termsRefused(accepted: boolean | undefined): boolean {
+  return env.hostedMode && accepted !== true;
+}
+function termsStamp(accepted: boolean | undefined): string | null {
+  return env.hostedMode && accepted === true ? now() : null;
+}
 
 export function hashInviteToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -153,14 +170,19 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
         // not the place for a 400-entry dropdown, and the browser already
         // knows the answer. Correctable later in Settings.
         timezone: z.string().max(64).optional(),
+        accept_terms: acceptTermsField,
       })
       .safeParse(req.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
     }
+    if (termsRefused(parsed.data.accept_terms)) {
+      return reply.code(400).send({ error: TERMS_REQUIRED });
+    }
 
     const passwordHash = await hashPassword(parsed.data.password);
     const userId = id();
+    const termsAcceptedAt = termsStamp(parsed.data.accept_terms);
 
     const created = db.transaction(() => {
       const n = (db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n;
@@ -170,9 +192,9 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       // invited members distinct colors never covered the admin, so a
       // two-person household still ended up with two look-alike avatars.
       db.prepare(
-        `INSERT INTO users (id, email, name, role, password_hash, color, must_change_password, created_at)
-         VALUES (?, ?, ?, 'admin', ?, ?, 0, ?)`,
-      ).run(userId, parsed.data.email, parsed.data.name, passwordHash, nextColor(), now());
+        `INSERT INTO users (id, email, name, role, password_hash, color, must_change_password, created_at, terms_accepted_at)
+         VALUES (?, ?, ?, 'admin', ?, ?, 0, ?, ?)`,
+      ).run(userId, parsed.data.email, parsed.data.name, passwordHash, nextColor(), now(), termsAcceptedAt);
       stampTimezone(parsed.data.timezone);
       return true;
     })();
@@ -276,10 +298,16 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
         // Sent by the browser for the founder, exactly as the open first
         // run does: the hub's clock is set by whoever sets the hub up
         timezone: z.string().max(64).optional(),
+        accept_terms: acceptTermsField,
       })
       .safeParse(req.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: parsed.error.issues[0]?.message ?? 'Check the fields' });
+    }
+    // Checked before the token is looked at: a refusal here must not burn
+    // a single-use invitation.
+    if (termsRefused(parsed.data.accept_terms)) {
+      return reply.code(400).send({ error: TERMS_REQUIRED });
     }
 
     const invite = liveInvite(parsed.data.token);
@@ -296,6 +324,7 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
 
     const passwordHash = await hashPassword(parsed.data.password);
     const userId = id();
+    const termsAcceptedAt = termsStamp(parsed.data.accept_terms);
     // The address the invitation was mailed to is proven by the arrival of
     // the link. Any other login the person types is unproven and gets the
     // ordinary confirmation ask.
@@ -312,8 +341,8 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
       // first: checked inside the transaction like the open first run is
       if (invite.role === 'admin' && userCount() > 0) return false;
       db.prepare(
-        `INSERT INTO users (id, email, name, role, password_hash, color, must_change_password, created_at, email_verified_at)
-         VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+        `INSERT INTO users (id, email, name, role, password_hash, color, must_change_password, created_at, email_verified_at, terms_accepted_at)
+         VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
       ).run(
         userId,
         parsed.data.email,
@@ -323,6 +352,7 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
         nextColor(),
         now(),
         proven ? now() : null,
+        termsAcceptedAt,
       );
       db.prepare('UPDATE invites SET used_by = ?, used_at = ? WHERE id = ?').run(
         userId,

--- a/server/src/routes/terms-consent.test.ts
+++ b/server/src/routes/terms-consent.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import type { FastifyInstance } from 'fastify';
+
+/*
+  Consent to the terms and the privacy policy (migration 031). On the hosted
+  service both account-creating routes refuse without it and record when it
+  was given; the login screen learns where the documents live from the apex
+  in /api/auth/state.
+
+  Same env dance as hosted.test.ts: env.ts reads the flags at import time.
+*/
+process.env.HOSTED_MODE = 'true';
+process.env.HOSTED_DOMAIN = 'neiliro.test';
+
+const tenants = await import('../lib/tenants.js');
+const { buildApp } = await import('../app.js');
+const { env } = await import('../env.js');
+
+const PASSWORD = 'correct horse battery';
+const onHost = (slug: string) => ({ host: `${slug}.neiliro.test` });
+const familyDb = (familyId: string) =>
+  new Database(join(env.dataDir, 'families', familyId, 'hub.db'), { readonly: true });
+
+let app: FastifyInstance;
+beforeAll(async () => {
+  tenants.initHosted();
+  app = await buildApp();
+  await app.ready();
+});
+afterAll(async () => {
+  await app.close();
+  delete process.env.HOSTED_MODE;
+  delete process.env.HOSTED_DOMAIN;
+  tenants.shutdownHosted();
+});
+
+describe('terms consent on the hosted service', () => {
+  it('tells the login screen where the documents live, on real families and ghosts alike', async () => {
+    tenants.createFamily('consent-apex');
+    const real = await app.inject({ url: '/api/auth/state', headers: onHost('consent-apex') });
+    expect(real.json()).toMatchObject({ hosted: true, apex: 'neiliro.test' });
+    const ghost = await app.inject({ url: '/api/auth/state', headers: onHost('nobody-here') });
+    expect(ghost.json()).toMatchObject({ hosted: true, apex: 'neiliro.test' });
+  });
+
+  it('refuses the open first run without consent and creates nobody', async () => {
+    const { familyId } = tenants.createFamily('consent-setup');
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('consent-setup'),
+      payload: { name: 'Sam', email: 'sam@example.test', password: PASSWORD },
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.json().error).toMatch(/Terms of Service and Privacy Policy/);
+    // `false` is not consent either
+    const unticked = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('consent-setup'),
+      payload: { name: 'Sam', email: 'sam@example.test', password: PASSWORD, accept_terms: false },
+    });
+    expect(unticked.statusCode).toBe(400);
+    const db = familyDb(familyId);
+    expect(db.prepare('SELECT count(*) AS n FROM users').get()).toEqual({ n: 0 });
+
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('consent-setup'),
+      payload: { name: 'Sam', email: 'sam@example.test', password: PASSWORD, accept_terms: true },
+    });
+    expect(ok.statusCode).toBe(201);
+    const row = db.prepare('SELECT terms_accepted_at FROM users').get() as { terms_accepted_at: string | null };
+    expect(row.terms_accepted_at).not.toBeNull();
+    db.close();
+  });
+
+  it('refuses an invitation without consent and leaves the link alive', async () => {
+    const { familyId } = tenants.createFamily('consent-join');
+    const admin = await app.inject({
+      method: 'POST',
+      url: '/api/auth/setup',
+      headers: onHost('consent-join'),
+      payload: { name: 'Sam', email: 'sam@example.test', password: PASSWORD, accept_terms: true },
+    });
+    const cookie = admin.cookies.find((c) => c.name === 'hub_session')!;
+    const invite = await app.inject({
+      method: 'POST',
+      url: '/api/invites',
+      headers: { ...onHost('consent-join'), cookie: `${cookie.name}=${cookie.value}` },
+      payload: { role: 'member' },
+    });
+    expect(invite.statusCode).toBe(201);
+    const token = (invite.json() as { path: string }).path.split('token=')[1]!;
+
+    const refused = await app.inject({
+      method: 'POST',
+      url: '/api/auth/join',
+      headers: onHost('consent-join'),
+      payload: { token, name: 'Dana', email: 'dana@example.test', password: PASSWORD },
+    });
+    expect(refused.statusCode).toBe(400);
+    expect(refused.json().error).toMatch(/Terms of Service and Privacy Policy/);
+
+    // The refusal did not burn the single-use link
+    const joined = await app.inject({
+      method: 'POST',
+      url: '/api/auth/join',
+      headers: onHost('consent-join'),
+      payload: { token, name: 'Dana', email: 'dana@example.test', password: PASSWORD, accept_terms: true },
+    });
+    expect(joined.statusCode).toBe(201);
+    const db = familyDb(familyId);
+    const dana = db
+      .prepare("SELECT terms_accepted_at FROM users WHERE email = 'dana@example.test'")
+      .get() as { terms_accepted_at: string | null };
+    expect(dana.terms_accepted_at).not.toBeNull();
+    db.close();
+  });
+});

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -100,6 +100,14 @@ export const ru: Record<string, string> = {
   'A transfer needs a destination account and the amount received': 'У перевода нужны счёт получателя и сумма зачисления',
   'A transfer to the same account makes no sense': 'Перевод на тот же счёт лишён смысла',
   'A user with this address already exists': 'Пользователь с таким адресом уже есть',
+  // Consent at account creation (hosted): the sentence is assembled around
+  // two links, so the parts must read as one line in this order.
+  'I agree to the': 'Я принимаю',
+  'Terms of Service': 'Условия использования',
+  'and the': 'и',
+  'Privacy Policy': 'Политику конфиденциальности',
+  'Please accept the Terms of Service and Privacy Policy to continue':
+    'Чтобы продолжить, примите Условия использования и Политику конфиденциальности',
   'A week before': 'За неделю',
   'About': 'О программе',
   'Account': 'Счёт',

--- a/web/src/lib/service.ts
+++ b/web/src/lib/service.ts
@@ -15,6 +15,8 @@ export interface ServiceState {
   demo: boolean;
   hosted: boolean;
   password_reset: boolean;
+  /** The hosted service's apex domain (terms and privacy live there); null when self-hosted. */
+  apex: string | null;
 }
 
 let pending: Promise<ServiceState> | null = null;

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -352,7 +352,56 @@ export function Login() {
  * First-run setup: the DB is empty, the first account being created is
  * the admin. Passwords are no longer printed in the server logs.
  */
+/**
+ * Consent to the terms and the privacy policy — hosted only (migration 031).
+ *
+ * Not a wall of legal text and not a modal: one checkbox naming both
+ * documents, which open in a new tab on the service's apex. The server
+ * refuses account creation without it, so the button below stays disabled
+ * until the box is ticked rather than round-tripping for the refusal.
+ * A self-hosted hub has no contract with the service: `apex` is null there,
+ * nothing renders, and the server ignores the field.
+ */
+function TermsConsent({
+  apex,
+  checked,
+  onChange,
+}: {
+  apex: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  const doc = (path: string, label: string) => (
+    <a
+      href={`https://${apex}/${path}`}
+      target="_blank"
+      rel="noopener"
+      className="underline decoration-[var(--c-border)] underline-offset-2 hover:text-accent"
+    >
+      {label}
+    </a>
+  );
+  return (
+    <label className="flex items-start gap-2.5 text-sm text-ink">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 size-4 shrink-0 accent-[var(--c-accent)]"
+      />
+      <span>
+        {t('I agree to the')} {doc('terms', t('Terms of Service'))} {t('and the')}{' '}
+        {doc('privacy', t('Privacy Policy'))}
+      </span>
+    </label>
+  );
+}
+
 function Setup() {
+  const { state: service } = useServiceState();
+  // Null when there is nothing to agree to (self-hosted)
+  const apex = service?.hosted ? service.apex : null;
+  const [agreed, setAgreed] = useState(false);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -372,6 +421,7 @@ function Setup() {
         // sets up from Chicago should not have to discover later why "today"
         // was flipping in the afternoon. Changeable in Settings.
         timezone: browserTimezone(),
+        ...(apex ? { accept_terms: agreed } : {}),
       });
       window.location.href = '/';
     } catch (err) {
@@ -405,8 +455,9 @@ function Setup() {
           />
           <span className="mt-1 block text-xs text-muted">{t('At least 10 characters')}</span>
         </label>
+        {apex && <TermsConsent apex={apex} checked={agreed} onChange={setAgreed} />}
         {error && <p className="text-sm text-urgent">{error}</p>}
-        <button type="submit" disabled={busy} className={buttonClass}>
+        <button type="submit" disabled={busy || (apex !== null && !agreed)} className={buttonClass}>
           {busy ? t('Creating') : t('Create and sign in')}
         </button>
       </form>
@@ -557,6 +608,9 @@ interface InviteCheck {
  */
 function Join() {
   const token = new URLSearchParams(window.location.search).get('token') ?? '';
+  const { state: service } = useServiceState();
+  const apex = service?.hosted ? service.apex : null;
+  const [agreed, setAgreed] = useState(false);
   // null — validating the link; then either the form or an explanation
   const [invite, setInvite] = useState<InviteCheck | false | null>(null);
   const [name, setName] = useState('');
@@ -593,6 +647,7 @@ function Join() {
         email,
         password,
         ...(founder ? { timezone: browserTimezone() } : {}),
+        ...(apex ? { accept_terms: agreed } : {}),
       });
       window.location.href = '/';
     } catch (err) {
@@ -646,8 +701,9 @@ function Join() {
           />
           <span className="mt-1 block text-xs text-muted">{t('At least 10 characters')}</span>
         </label>
+        {apex && <TermsConsent apex={apex} checked={agreed} onChange={setAgreed} />}
         {error && <p className="text-sm text-urgent">{error}</p>}
-        <button type="submit" disabled={busy} className={buttonClass}>
+        <button type="submit" disabled={busy || (apex !== null && !agreed)} className={buttonClass}>
           {busy ? t('Creating') : founder ? t('Create and sign in') : t('Join')}
         </button>
       </form>


### PR DESCRIPTION
Follows from #229: the legal pages promise that continued use is acceptance, but nothing put the documents in front of a person or recorded that they agreed.

**What changes on the hosted service**

- Both account-creating routes (`POST /api/auth/setup`, `POST /api/auth/join`) refuse with 400 unless the body carries `accept_terms: true`, and record the moment in `users.terms_accepted_at` (migration 031). The documents are dated, so the timestamp identifies the version.
- The join route checks consent **before** looking at the token, so a refusal never burns a single-use invitation.
- `/api/auth/state` gains `apex` (the hosted domain, null when self-hosted) — a property of the process, stated by the ghost too — so the forms link to `https://<apex>/terms` and `/privacy` without a hardcoded domain.
- The first-run and invitation forms show one checkbox naming both documents (links open in a new tab); the submit button stays disabled until it is ticked. Russian strings added.

**Self-hosted:** nothing changes. No checkbox, the field is ignored, the column stays NULL — a family on its own server has no contract with the service. Pinned by a test.

**Tests:** new `terms-consent.test.ts` (refusals on both routes, `false` is not consent, timestamp recorded, invite survives the refusal, apex on real and ghost hosts); every hosted test that creates accounts now sends the flag; `setup.test.ts` covers self-hosted. Server 282 / web 86 green, typecheck and lint clean.

**Not verified visually:** the checkbox renders only under `HOSTED_MODE`, which needs the Node 22 stand; the JSX is type-checked and the server side is covered by tests. Worth one look on the stand before release.

Docs: `docs/features.md` "First run" gets a sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
