### PR TITLE
feat(web): client crypto module — KDF, envelopes, file format, key store

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ server/               Fastify + SQLite
   src/db/migrations/  Schema. The single source of truth
   src/routes/         API
 web/                  React + Vite + Tailwind
+  src/lib/crypto/     Client-side encryption (ADR 0001): key derivation, envelopes, key store
 scripts/              Certificates, backups, export/import, admin reset
 ```
 

--- a/web/src/lib/crypto/crypto.test.ts
+++ b/web/src/lib/crypto/crypto.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KeyStore,
+  MemoryBackend,
+  decryptField,
+  decryptFile,
+  deriveCredentialKeys,
+  encryptField,
+  encryptFile,
+  exportFamilyKey,
+  fromBase64url,
+  generateFamilyKey,
+  generateRecoveryCode,
+  importFamilyKey,
+  isEncrypted,
+  normalizeLogin,
+  normalizeRecoveryCode,
+  readField,
+  recoveryWrapKey,
+  toBase64url,
+  unwrapFamilyKey,
+  wrapFamilyKey,
+} from './index';
+
+/*
+  Node 24 ships WebCrypto as globalThis.crypto, so the module runs here
+  exactly as in a browser. The KDF vectors are the contract with the
+  server twin (server/src/lib/kdf.ts, #211): same password and address
+  must give the same authKey on both sides, or nobody can sign in.
+*/
+
+// Fast KDF for tests that do not test the KDF itself
+const FAST = 1_000;
+
+describe('kdf', () => {
+  it('pins the auth key for a known password and address (the server twin checks the same vector)', async () => {
+    const a = await deriveCredentialKeys('correct horse battery', 'Sam@Example.test ', FAST);
+    const b = await deriveCredentialKeys('correct horse battery', 'sam@example.test', FAST);
+    expect(a.authKey).toBe(b.authKey);
+    expect(a.kdfVersion).toBe(1);
+    expect(fromBase64url(a.authKey)).toHaveLength(32);
+    // Frozen: a change here locks every existing account out
+    expect(a.authKey).toBe('G5OP10cR6TUCBFrXL08VLqOGRCxufqPK7SpWGzrou7M');
+  });
+
+  it('pins the production vector at the real iteration count', async () => {
+    // ~1 s on purpose: this is the exact string a browser sends for this
+    // password, and the server twin must compute the very same one.
+    const k = await deriveCredentialKeys('correct horse battery', 'sam@example.test');
+    expect(k.authKey).toBe('gQWlfqTKxEE23jsPihnHil8499MP-gW40evaIaWZBn8');
+  }, 30_000);
+
+  it('produces different keys for a different address or password', async () => {
+    const base = await deriveCredentialKeys('correct horse battery', 'sam@example.test', FAST);
+    const other = await deriveCredentialKeys('correct horse battery', 'dana@example.test', FAST);
+    const wrong = await deriveCredentialKeys('correct horse batteru', 'sam@example.test', FAST);
+    expect(other.authKey).not.toBe(base.authKey);
+    expect(wrong.authKey).not.toBe(base.authKey);
+  });
+
+  it('keeps the wrap key non-extractable and separate from the auth key', async () => {
+    const k = await deriveCredentialKeys('correct horse battery', 'sam@example.test', FAST);
+    expect(k.wrapKey.extractable).toBe(false);
+    await expect(crypto.subtle.exportKey('raw', k.wrapKey)).rejects.toThrow();
+  });
+
+  it('normalises the login the way the server does', () => {
+    expect(normalizeLogin('  Sam@Example.TEST ')).toBe('sam@example.test');
+  });
+});
+
+describe('field envelope', () => {
+  const place = { table: 'notes', column: 'body_md', id: 'n1' };
+
+  it('round-trips and marks the value as encrypted', async () => {
+    const key = await generateFamilyKey();
+    const sealed = await encryptField(key, 'Молоко, хлеб, и 🥚', place);
+    expect(isEncrypted(sealed)).toBe(true);
+    expect(sealed.startsWith('e1:')).toBe(true);
+    expect(await decryptField(key, sealed, place)).toBe('Молоко, хлеб, и 🥚');
+  });
+
+  it('never reuses a nonce', async () => {
+    const key = await generateFamilyKey();
+    const a = await encryptField(key, 'same', place);
+    const b = await encryptField(key, 'same', place);
+    expect(a).not.toBe(b);
+  });
+
+  it('refuses a value moved to another row, column or table', async () => {
+    const key = await generateFamilyKey();
+    const sealed = await encryptField(key, 'secret', place);
+    await expect(decryptField(key, sealed, { ...place, id: 'n2' })).rejects.toThrow(/Cannot decrypt/);
+    await expect(decryptField(key, sealed, { ...place, column: 'title' })).rejects.toThrow(/Cannot decrypt/);
+    await expect(decryptField(key, sealed, { ...place, table: 'tasks' })).rejects.toThrow(/Cannot decrypt/);
+  });
+
+  it('refuses a tampered byte and another family key', async () => {
+    const key = await generateFamilyKey();
+    const sealed = await encryptField(key, 'secret', place);
+    const [p, nonce, ct] = sealed.split(':') as [string, string, string];
+    const bytes = fromBase64url(ct);
+    bytes[0] = bytes[0]! ^ 1;
+    await expect(decryptField(key, `${p}:${nonce}:${toBase64url(bytes)}`, place)).rejects.toThrow();
+    await expect(decryptField(await generateFamilyKey(), sealed, place)).rejects.toThrow();
+  });
+
+  it('passes legacy plaintext through and keeps null', async () => {
+    const key = await generateFamilyKey();
+    expect(await readField(key, 'plain old title', place)).toBe('plain old title');
+    expect(await readField(key, null, place)).toBeNull();
+    const sealed = await encryptField(key, 'new', place);
+    expect(await readField(key, sealed, place)).toBe('new');
+  });
+
+  it('fails loudly on an unknown version or a malformed envelope', async () => {
+    const key = await generateFamilyKey();
+    await expect(decryptField(key, 'e2:abc:def', place)).rejects.toThrow(/Not an encrypted/);
+    await expect(decryptField(key, 'e1:onlyonepart', place)).rejects.toThrow(/Malformed/);
+  });
+});
+
+describe('family key and envelopes', () => {
+  it('wraps for a member and unwraps with the same password, not another', async () => {
+    const family = await generateFamilyKey();
+    const sam = await deriveCredentialKeys('correct horse battery', 'sam@example.test', FAST);
+    const dana = await deriveCredentialKeys('another long password', 'dana@example.test', FAST);
+    const env = await wrapFamilyKey(family, sam.wrapKey, { kind: 'password', owner: 'u-sam' });
+    expect(env.startsWith('w1:')).toBe(true);
+
+    const opened = await unwrapFamilyKey(env, sam.wrapKey, { kind: 'password', owner: 'u-sam' });
+    expect(await exportFamilyKey(opened)).toEqual(await exportFamilyKey(family));
+    // The unwrapped key must itself be wrappable (invites, re-admission)
+    expect(opened.extractable).toBe(true);
+    await expect(wrapFamilyKey(opened, dana.wrapKey, { kind: 'password', owner: 'u-dana' })).resolves.toMatch(/^w1:/);
+
+    await expect(unwrapFamilyKey(env, dana.wrapKey, { kind: 'password', owner: 'u-sam' })).rejects.toThrow(
+      /does not open/,
+    );
+    // Re-labelled as someone else's envelope: refused
+    await expect(unwrapFamilyKey(env, sam.wrapKey, { kind: 'password', owner: 'u-dana' })).rejects.toThrow();
+  });
+
+  it('a wrapped key is not a field and a field is not a wrapped key', async () => {
+    const family = await generateFamilyKey();
+    const sam = await deriveCredentialKeys('correct horse battery', 'sam@example.test', FAST);
+    const env = await wrapFamilyKey(family, sam.wrapKey, { kind: 'password', owner: 'u' });
+    expect(isEncrypted(env)).toBe(false);
+    await expect(unwrapFamilyKey('e1:a:b', sam.wrapKey, { kind: 'password', owner: 'u' })).rejects.toThrow(
+      /Not a key envelope/,
+    );
+  });
+
+  it('imports only 32-byte keys', async () => {
+    await expect(importFamilyKey(new Uint8Array(16))).rejects.toThrow(/32 bytes/);
+    const raw = await exportFamilyKey(await generateFamilyKey());
+    expect(await exportFamilyKey(await importFamilyKey(raw))).toEqual(raw);
+  });
+});
+
+describe('recovery code', () => {
+  it('looks like 26 grouped symbols from the unambiguous alphabet', () => {
+    const code = generateRecoveryCode();
+    expect(code).toMatch(/^([0-9A-HJKMNP-TV-Z]{4}-){6}[0-9A-HJKMNP-TV-Z]{2}$/);
+    expect(generateRecoveryCode()).not.toBe(code);
+  });
+
+  it('forgives case, separators and look-alike letters', () => {
+    const code = generateRecoveryCode();
+    const sloppy = code.toLowerCase().replace(/-/g, ' ').replace(/0/g, 'o').replace(/1/g, 'l');
+    expect(normalizeRecoveryCode(sloppy)).toBe(code.replace(/-/g, ''));
+    expect(() => normalizeRecoveryCode('too short')).toThrow(/does not look like/);
+    expect(() => normalizeRecoveryCode(code.replace(/-/g, '') + 'A')).toThrow();
+  });
+
+  it('opens the envelope it wrapped, and no other code does', async () => {
+    const family = await generateFamilyKey();
+    const code = generateRecoveryCode();
+    const env = await wrapFamilyKey(family, await recoveryWrapKey(code), { kind: 'recovery', owner: 'family' });
+    const back = await unwrapFamilyKey(env, await recoveryWrapKey(code.toLowerCase()), {
+      kind: 'recovery',
+      owner: 'family',
+    });
+    expect(await exportFamilyKey(back)).toEqual(await exportFamilyKey(family));
+    await expect(
+      unwrapFamilyKey(env, await recoveryWrapKey(generateRecoveryCode()), { kind: 'recovery', owner: 'family' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('file envelope', () => {
+  const bytes = (n: number, seed = 7) => Uint8Array.from({ length: n }, (_, i) => (i * seed + 3) & 0xff);
+
+  it('round-trips empty, one-chunk, exact-multiple and ragged files', async () => {
+    const key = await generateFamilyKey();
+    for (const n of [0, 1, 1000, 2048, 2049, 5000]) {
+      const plain = bytes(n);
+      const sealed = await encryptFile(key, plain, 'f1', 1024);
+      expect(sealed.length).toBe(15 + Math.max(1, Math.ceil(n / 1024)) * 16 + n);
+      expect(await decryptFile(key, sealed, 'f1')).toEqual(plain);
+    }
+  });
+
+  it('refuses a truncated file, a swapped chunk and another file id', async () => {
+    const key = await generateFamilyKey();
+    const sealed = await encryptFile(key, bytes(3000), 'f1', 1024);
+    // Drop the last chunk entirely: what remains is chunks 0 and 1, and
+    // chunk 1 was sealed as "more", not "last"
+    await expect(decryptFile(key, sealed.subarray(0, 15 + 2 * (1024 + 16)), 'f1')).rejects.toThrow();
+    // Cut mid-chunk
+    await expect(decryptFile(key, sealed.subarray(0, sealed.length - 5), 'f1')).rejects.toThrow();
+    // Swap chunks 0 and 1
+    const swapped = new Uint8Array(sealed);
+    swapped.set(sealed.subarray(15 + 1040, 15 + 2 * 1040), 15);
+    swapped.set(sealed.subarray(15, 15 + 1040), 15 + 1040);
+    await expect(decryptFile(key, swapped, 'f1')).rejects.toThrow();
+    await expect(decryptFile(key, sealed, 'f2')).rejects.toThrow();
+    await expect(decryptFile(key, new Uint8Array([1, 2, 3]), 'f1')).rejects.toThrow(/Not an encrypted/);
+  });
+});
+
+describe('keystore', () => {
+  it('holds the key for its own scope only, and forgets it on lock', async () => {
+    const backend = new MemoryBackend();
+    const store = new KeyStore(backend, 'smiths.neiliro.test');
+    expect(await store.load()).toBeNull();
+    const key = await generateFamilyKey();
+    await store.save(key);
+    expect(await store.load()).toBe(key);
+    // Same browser profile, another family's hostname: not their key
+    expect(await new KeyStore(backend, 'jones.neiliro.test').load()).toBeNull();
+    await store.lock();
+    expect(await store.load()).toBeNull();
+  });
+
+  it('degrades to "locked" when storage refuses', async () => {
+    const broken = {
+      get: async () => {
+        throw new Error('blocked');
+      },
+      put: async () => {
+        throw new Error('blocked');
+      },
+      clear: async () => {
+        throw new Error('blocked');
+      },
+    };
+    const store = new KeyStore(broken, 'x');
+    await expect(store.save(await generateFamilyKey())).resolves.toBeUndefined();
+    expect(await store.load()).toBeNull();
+    await expect(store.lock()).resolves.toBeUndefined();
+  });
+});

--- a/web/src/lib/crypto/encoding.ts
+++ b/web/src/lib/crypto/encoding.ts
@@ -1,0 +1,53 @@
+/*
+  Byte/string plumbing for the crypto module. Kept apart so the algorithms
+  read as algorithms, and so the server twin (lib/kdf.ts) can copy exactly
+  these conventions: base64url without padding, UTF-8 text.
+*/
+
+/** Bytes backed by a real ArrayBuffer — what WebCrypto's BufferSource accepts. */
+export type Bytes = Uint8Array<ArrayBuffer>;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export const utf8 = (s: string): Bytes => new Uint8Array(encoder.encode(s));
+export const fromUtf8 = (b: Uint8Array): string => decoder.decode(b);
+
+export function toBase64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function fromBase64url(s: string): Bytes {
+  if (!/^[A-Za-z0-9_-]*$/.test(s)) throw new Error('Not base64url');
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (s.length % 4)) % 4);
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export function concat(...parts: Uint8Array[]): Bytes {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+export function randomBytes(n: number): Bytes {
+  const out = new Uint8Array(n);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+/** Constant-time equality for short secrets (auth keys, codes). */
+export function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i]! ^ b[i]!;
+  return diff === 0;
+}

--- a/web/src/lib/crypto/envelope.ts
+++ b/web/src/lib/crypto/envelope.ts
@@ -1,0 +1,156 @@
+import { fromBase64url, fromUtf8, randomBytes, toBase64url, utf8, type Bytes } from './encoding';
+
+/*
+  The field envelope — what an encrypted column value looks like (#214).
+
+    e1:<base64url nonce>:<base64url ciphertext+tag>
+
+  - `e1` is the format version. A future algorithm is `e2`, and a reader
+    that meets an unknown prefix fails loudly rather than guessing.
+  - AES-256-GCM, 96-bit random nonce per value. The family key encrypts a
+    few million values over its life at most, far below the nonce-collision
+    horizon; still, never reuse a nonce by construction — always fresh.
+  - Additional authenticated data binds the ciphertext to its place:
+    table, column and row id. Someone editing the database cannot move a
+    note body into another note, or a transaction comment into a title,
+    without the decryption failing. The AAD is not stored — both sides
+    know where the value lives.
+
+  A value without the prefix is plaintext from before its module was
+  migrated (ADR 0001, rollout). `readField` passes it through; the first
+  edit rewrites it encrypted. `isEncrypted` is how the UI knows which.
+*/
+
+export const FIELD_PREFIX = 'e1:';
+const NONCE_BYTES = 12;
+
+export interface FieldPlace {
+  table: string;
+  column: string;
+  id: string;
+}
+
+export function fieldAad(place: FieldPlace): Bytes {
+  // Slash-joined: ids are ULID-like and columns are identifiers, neither
+  // contains a slash, so the encoding is unambiguous.
+  return utf8(`${place.table}/${place.column}/${place.id}`);
+}
+
+export function isEncrypted(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.startsWith(FIELD_PREFIX);
+}
+
+export async function encryptField(key: CryptoKey, plaintext: string, place: FieldPlace): Promise<string> {
+  const nonce = randomBytes(NONCE_BYTES);
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: nonce, additionalData: fieldAad(place) },
+    key,
+    utf8(plaintext),
+  );
+  return `${FIELD_PREFIX}${toBase64url(nonce)}:${toBase64url(new Uint8Array(ct))}`;
+}
+
+export class EnvelopeError extends Error {}
+
+export async function decryptField(key: CryptoKey, value: string, place: FieldPlace): Promise<string> {
+  if (!value.startsWith(FIELD_PREFIX)) throw new EnvelopeError('Not an encrypted field');
+  const parts = value.slice(FIELD_PREFIX.length).split(':');
+  if (parts.length !== 2) throw new EnvelopeError('Malformed envelope');
+  const nonce = fromBase64url(parts[0]!);
+  if (nonce.length !== NONCE_BYTES) throw new EnvelopeError('Malformed envelope');
+  try {
+    const pt = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: nonce, additionalData: fieldAad(place) },
+      key,
+      fromBase64url(parts[1]!),
+    );
+    return fromUtf8(new Uint8Array(pt));
+  } catch {
+    // WebCrypto says only "OperationError" — a wrong key, a moved value
+    // and a corrupted byte all look the same, on purpose.
+    throw new EnvelopeError('Cannot decrypt this value here');
+  }
+}
+
+/**
+ * What a module reads: encrypted values are opened, legacy plaintext
+ * passes through, null stays null.
+ */
+export async function readField(
+  key: CryptoKey,
+  value: string | null,
+  place: FieldPlace,
+): Promise<string | null> {
+  if (value === null) return null;
+  return isEncrypted(value) ? decryptField(key, value, place) : value;
+}
+
+/*
+  Key wrapping shares the envelope shape with a different prefix, so a
+  wrapped key never parses as a field and vice versa:
+
+    w1:<base64url nonce>:<base64url wrapped key>
+
+  The AAD names what the envelope is for (`kind` and `owner`, see #210):
+  a member's envelope cannot be re-labelled as another member's.
+*/
+export const WRAP_PREFIX = 'w1:';
+
+export interface WrapPlace {
+  kind: string;
+  owner: string;
+}
+
+const wrapAad = (place: WrapPlace): Bytes => utf8(`envelope/${place.kind}/${place.owner}`);
+
+export async function wrapFamilyKey(familyKey: CryptoKey, wrapKey: CryptoKey, place: WrapPlace): Promise<string> {
+  const nonce = randomBytes(NONCE_BYTES);
+  const wrapped = await crypto.subtle.wrapKey('raw', familyKey, wrapKey, {
+    name: 'AES-GCM',
+    iv: nonce,
+    additionalData: wrapAad(place),
+  });
+  return `${WRAP_PREFIX}${toBase64url(nonce)}:${toBase64url(new Uint8Array(wrapped))}`;
+}
+
+export async function unwrapFamilyKey(envelope: string, wrapKey: CryptoKey, place: WrapPlace): Promise<CryptoKey> {
+  if (!envelope.startsWith(WRAP_PREFIX)) throw new EnvelopeError('Not a key envelope');
+  const parts = envelope.slice(WRAP_PREFIX.length).split(':');
+  if (parts.length !== 2) throw new EnvelopeError('Malformed envelope');
+  const nonce = fromBase64url(parts[0]!);
+  try {
+    return await crypto.subtle.unwrapKey(
+      'raw',
+      fromBase64url(parts[1]!),
+      wrapKey,
+      { name: 'AES-GCM', iv: nonce, additionalData: wrapAad(place) },
+      { name: 'AES-GCM', length: 256 },
+      // Extractable on purpose: the member who invites or re-admits
+      // someone must be able to wrap this key for them, and wrapKey()
+      // refuses a non-extractable source. Non-extractable would buy little
+      // anyway — a script that can use the key can decrypt everything.
+      true,
+      FAMILY_KEY_USAGES,
+    );
+  } catch (err) {
+    if (err instanceof EnvelopeError) throw err;
+    throw new EnvelopeError('This envelope does not open with that key');
+  }
+}
+
+export const FAMILY_KEY_USAGES: KeyUsage[] = ['encrypt', 'decrypt'];
+
+/** A fresh family key — generated once, in the browser of whoever sets the hub up. */
+export async function generateFamilyKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, FAMILY_KEY_USAGES);
+}
+
+/** Only for tests and the export path: the raw bytes of a family key. */
+export async function exportFamilyKey(key: CryptoKey): Promise<Bytes> {
+  return new Uint8Array(await crypto.subtle.exportKey('raw', key));
+}
+
+export async function importFamilyKey(raw: Bytes): Promise<CryptoKey> {
+  if (raw.length !== 32) throw new EnvelopeError('A family key is 32 bytes');
+  return crypto.subtle.importKey('raw', raw, { name: 'AES-GCM', length: 256 }, true, FAMILY_KEY_USAGES);
+}

--- a/web/src/lib/crypto/files.ts
+++ b/web/src/lib/crypto/files.ts
@@ -1,0 +1,101 @@
+import { concat, randomBytes, utf8, type Bytes } from './encoding';
+
+/*
+  The file envelope — attachments, receipts, mail parts (#214, #222).
+
+  Layout, all big-endian:
+
+    "NE1"            3 bytes   magic + version
+    chunkSize        4 bytes   plaintext bytes per chunk (last may be shorter)
+    noncePrefix      8 bytes   random, one per file
+    chunk[i]         chunkSize + 16 bytes of AES-GCM ciphertext+tag
+
+  Each chunk's nonce is noncePrefix || counter(4 bytes), so no two chunks
+  of a file share a nonce and no chunk can be swapped, dropped or
+  replayed: the AAD carries the file id, the chunk index and whether it is
+  the last one. A truncated file fails on its last chunk rather than
+  passing as a shorter file.
+
+  One megabyte chunks: a 20 MB photo is never held twice in memory, and
+  the per-chunk overhead (16 bytes) is noise. The chunk size is written in
+  the header so it can change without a format bump.
+*/
+
+const MAGIC = utf8('NE1');
+export const DEFAULT_CHUNK = 1024 * 1024;
+const TAG = 16;
+const HEADER = 3 + 4 + 8;
+
+export class FileEnvelopeError extends Error {}
+
+function nonce(prefix: Bytes, index: number): Bytes {
+  const n = new Uint8Array(12);
+  n.set(prefix, 0);
+  new DataView(n.buffer).setUint32(8, index, false);
+  return n;
+}
+
+const aad = (fileId: string, index: number, last: boolean): Bytes =>
+  utf8(`file/${fileId}/${index}/${last ? 'last' : 'more'}`);
+
+export async function encryptFile(
+  key: CryptoKey,
+  plain: Bytes,
+  fileId: string,
+  chunkSize: number = DEFAULT_CHUNK,
+): Promise<Bytes> {
+  if (chunkSize < 1 || chunkSize > 0xffffffff) throw new FileEnvelopeError('Bad chunk size');
+  const prefix = randomBytes(8);
+  const header = new Uint8Array(HEADER);
+  header.set(MAGIC, 0);
+  new DataView(header.buffer).setUint32(3, chunkSize, false);
+  header.set(prefix, 7);
+
+  // An empty file is one empty chunk, so it still authenticates as "the
+  // whole file" rather than as nothing.
+  const count = Math.max(1, Math.ceil(plain.length / chunkSize));
+  const parts: Uint8Array[] = [header];
+  for (let i = 0; i < count; i++) {
+    const slice = plain.subarray(i * chunkSize, Math.min((i + 1) * chunkSize, plain.length));
+    const ct = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: nonce(prefix, i), additionalData: aad(fileId, i, i === count - 1) },
+      key,
+      slice,
+    );
+    parts.push(new Uint8Array(ct));
+  }
+  return concat(...parts);
+}
+
+export async function decryptFile(key: CryptoKey, sealed: Bytes, fileId: string): Promise<Bytes> {
+  if (sealed.length < HEADER || sealed[0] !== MAGIC[0] || sealed[1] !== MAGIC[1] || sealed[2] !== MAGIC[2]) {
+    throw new FileEnvelopeError('Not an encrypted file');
+  }
+  const view = new DataView(sealed.buffer, sealed.byteOffset, sealed.byteLength);
+  const chunkSize = view.getUint32(3, false);
+  if (chunkSize < 1) throw new FileEnvelopeError('Malformed file envelope');
+  const prefix = sealed.subarray(7, 15);
+  const body = sealed.subarray(HEADER);
+  const sealedChunk = chunkSize + TAG;
+  // Every chunk but the last is exactly chunkSize+16; the last is at least
+  // a tag. Anything else is a truncated or padded file.
+  const count = Math.max(1, Math.ceil(body.length / sealedChunk));
+  const lastLen = body.length - (count - 1) * sealedChunk;
+  if (lastLen < TAG) throw new FileEnvelopeError('Truncated file envelope');
+
+  const out: Uint8Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const slice = body.subarray(i * sealedChunk, Math.min((i + 1) * sealedChunk, body.length));
+    try {
+      const pt = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: nonce(prefix, i), additionalData: aad(fileId, i, i === count - 1) },
+        key,
+        slice,
+      );
+      out.push(new Uint8Array(pt));
+    } catch {
+      throw new FileEnvelopeError('Cannot decrypt this file here');
+    }
+  }
+  return concat(...out);
+}

--- a/web/src/lib/crypto/index.ts
+++ b/web/src/lib/crypto/index.ts
@@ -1,0 +1,21 @@
+/*
+  Client-side encryption of what people write — ADR 0001, epic #208.
+
+  Nothing here talks to the server or to React. The pieces:
+
+    kdf.ts       password → authKey (to the server) + wrapKey (stays here)
+    envelope.ts  the `e1:` field format, the `w1:` wrapped-key format, the family key
+    files.ts     the chunked file format for attachments
+    recovery.ts  the recovery code and its wrap key
+    keystore.ts  the family key between page loads (IndexedDB), and "Lock"
+
+  The server never holds a wrapKey, the family key, or a recovery code.
+  It stores envelopes it cannot open and ciphertext it cannot read, and
+  computes with the columns that stay in the clear.
+*/
+export * from './encoding';
+export * from './kdf';
+export * from './envelope';
+export * from './files';
+export * from './recovery';
+export * from './keystore';

--- a/web/src/lib/crypto/kdf.ts
+++ b/web/src/lib/crypto/kdf.ts
@@ -1,0 +1,110 @@
+import { concat, fromBase64url, toBase64url, utf8, type Bytes } from './encoding';
+
+/*
+  From one password, two keys that cannot be turned into each other
+  (ADR 0001, #211).
+
+  Today the password travels to the server and is verified there. If the
+  same password also unlocked the family key, the server would hold enough
+  at login time to read everything. So the browser stretches the password
+  once, then splits the result with HKDF:
+
+    master  = PBKDF2-SHA256(password, salt(email), 600 000)
+    authKey = HKDF(master, info "neiliro/auth/v1")   → sent instead of the password
+    wrapKey = HKDF(master, info "neiliro/wrap/v1")   → never leaves the browser
+
+  HKDF is a one-way expansion: knowing authKey says nothing about wrapKey.
+  The server scrypt-hashes authKey exactly as it hashed the password, so a
+  database leak still yields no credential.
+
+  Decisions worth defending:
+
+  - PBKDF2 rather than Argon2. Argon2 in a browser is WASM, and WASM needs
+    a hole in the strict CSP (`'wasm-unsafe-eval'`) plus a dependency to
+    audit. PBKDF2-SHA256 at OWASP's 600 000 iterations is native WebCrypto,
+    zero bytes of bundle, and what Bitwarden ships by default. The version
+    tag below exists so this can change without guessing later.
+  - The salt is derived from the login address, not handed out by the
+    server. A per-user salt fetched before login is a pre-login endpoint,
+    and a pre-login endpoint that answers differently for existing and
+    unknown addresses is an account oracle — the thing the password reset
+    goes to lengths to avoid. The address is unique per hub and the domain
+    string keeps the result specific to Neiliro; with 600 000 iterations a
+    precomputed table per address is not a realistic attack.
+  - The address is normalised the way the server normalises it (trim +
+    lowercase, see emailField in routes/setup.ts). A change on one side
+    silently locks everyone out — the test vectors are there to catch it.
+*/
+
+export const KDF_VERSION = 1;
+export const PBKDF2_ITERATIONS = 600_000;
+const SALT_DOMAIN = 'neiliro/kdf-salt/v1';
+const AUTH_INFO = 'neiliro/auth/v1';
+const WRAP_INFO = 'neiliro/wrap/v1';
+
+export function normalizeLogin(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+async function saltFor(email: string): Promise<Bytes> {
+  const digest = await crypto.subtle.digest('SHA-256', concat(utf8(SALT_DOMAIN), utf8(normalizeLogin(email))));
+  return new Uint8Array(digest);
+}
+
+async function hkdfBits(master: Bytes, info: string): Promise<Bytes> {
+  const key = await crypto.subtle.importKey('raw', master, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: utf8(info) },
+    key,
+    256,
+  );
+  return new Uint8Array(bits);
+}
+
+export interface CredentialKeys {
+  /** Sent to the server in place of the password; base64url of 32 bytes. */
+  authKey: string;
+  /** Opens this member's key envelope; stays in the browser. */
+  wrapKey: CryptoKey;
+  kdfVersion: number;
+}
+
+/**
+ * The one slow step at sign-in and account creation. `iterations` is a
+ * parameter only so tests can run the algorithm quickly; production callers
+ * never pass it.
+ */
+export async function deriveCredentialKeys(
+  password: string,
+  email: string,
+  iterations: number = PBKDF2_ITERATIONS,
+): Promise<CredentialKeys> {
+  const salt = await saltFor(email);
+  const pw = await crypto.subtle.importKey('raw', utf8(password), 'PBKDF2', false, ['deriveBits']);
+  const master = new Uint8Array(
+    await crypto.subtle.deriveBits({ name: 'PBKDF2', hash: 'SHA-256', salt, iterations }, pw, 256),
+  );
+  const authKey = toBase64url(await hkdfBits(master, AUTH_INFO));
+  const wrapKey = await importWrapKey(await hkdfBits(master, WRAP_INFO));
+  master.fill(0);
+  return { authKey, wrapKey, kdfVersion: KDF_VERSION };
+}
+
+/**
+ * A wrap key from 32 bytes of key material. Non-extractable: nothing in
+ * the page can read it back, only use it. Shared with the recovery code
+ * (recovery.ts), which is key material of full entropy and skips PBKDF2.
+ */
+export async function importWrapKey(material: Bytes): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', material, { name: 'AES-GCM', length: 256 }, false, [
+    'wrapKey',
+    'unwrapKey',
+  ]);
+}
+
+/** Derived wrap-key material for a full-entropy secret (recovery codes). */
+export async function expandSecret(secret: Bytes, info: string): Promise<Bytes> {
+  return hkdfBits(secret, info);
+}
+
+export const authKeyBytes = (authKey: string): Bytes => fromBase64url(authKey);

--- a/web/src/lib/crypto/keystore.ts
+++ b/web/src/lib/crypto/keystore.ts
@@ -1,0 +1,120 @@
+/*
+  Where the family key lives between page loads (#214).
+
+  A CryptoKey object can be stored in IndexedDB as is — structured clone
+  keeps it a key, and the page reads it back without ever seeing bytes. So
+  a reload or a PWA relaunch does not demand the password again, and an
+  explicit "Lock" deletes the record. That is the whole persistence story;
+  the password-derived wrap key is never stored anywhere.
+
+  Storage is behind a small interface so tests (Node has no IndexedDB) and
+  a browser that refuses site data (private mode, storage blocked) both
+  fall back to memory: the hub then asks for the password on every load,
+  which is degraded, not broken.
+*/
+
+export interface KeyRecord {
+  familyKey: CryptoKey;
+  /** Which family this key belongs to, so a key never crosses subdomains in one browser profile. */
+  scope: string;
+  savedAt: string;
+}
+
+export interface KeyBackend {
+  get(): Promise<KeyRecord | null>;
+  put(record: KeyRecord): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class MemoryBackend implements KeyBackend {
+  private record: KeyRecord | null = null;
+  async get() {
+    return this.record;
+  }
+  async put(record: KeyRecord) {
+    this.record = record;
+  }
+  async clear() {
+    this.record = null;
+  }
+}
+
+const DB_NAME = 'neiliro-keys';
+const STORE = 'keys';
+const RECORD_ID = 'family';
+
+export class IndexedDbBackend implements KeyBackend {
+  private open(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error ?? new Error('IndexedDB refused'));
+    });
+  }
+  private async tx<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    const db = await this.open();
+    try {
+      return await new Promise<T>((resolve, reject) => {
+        const req = run(db.transaction(STORE, mode).objectStore(STORE));
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error ?? new Error('IndexedDB request failed'));
+      });
+    } finally {
+      db.close();
+    }
+  }
+  async get(): Promise<KeyRecord | null> {
+    const rec = await this.tx<KeyRecord | undefined>('readonly', (s) => s.get(RECORD_ID));
+    return rec ?? null;
+  }
+  async put(record: KeyRecord): Promise<void> {
+    await this.tx('readwrite', (s) => s.put(record, RECORD_ID));
+  }
+  async clear(): Promise<void> {
+    await this.tx('readwrite', (s) => s.delete(RECORD_ID));
+  }
+}
+
+export class KeyStore {
+  constructor(
+    private readonly backend: KeyBackend,
+    /** The family's identity from the page's point of view: the hostname. */
+    private readonly scope: string,
+  ) {}
+
+  /** The key if this browser holds one for this family, else null (locked). */
+  async load(): Promise<CryptoKey | null> {
+    try {
+      const rec = await this.backend.get();
+      if (!rec || rec.scope !== this.scope) return null;
+      return rec.familyKey;
+    } catch {
+      return null;
+    }
+  }
+
+  async save(familyKey: CryptoKey): Promise<void> {
+    try {
+      await this.backend.put({ familyKey, scope: this.scope, savedAt: new Date().toISOString() });
+    } catch {
+      // Storage refused: the key lives for this page load only. Degraded,
+      // and the caller need not know.
+    }
+  }
+
+  /** "Lock": forget the key on this device. The next load asks for the password. */
+  async lock(): Promise<void> {
+    try {
+      await this.backend.clear();
+    } catch {
+      // Nothing to forget where nothing could be stored
+    }
+  }
+}
+
+export function defaultKeyStore(): KeyStore {
+  const scope = typeof location !== 'undefined' ? location.hostname : 'test';
+  const backend: KeyBackend = typeof indexedDB !== 'undefined' ? new IndexedDbBackend() : new MemoryBackend();
+  return new KeyStore(backend, scope);
+}

--- a/web/src/lib/crypto/recovery.ts
+++ b/web/src/lib/crypto/recovery.ts
@@ -1,0 +1,74 @@
+import { expandSecret, importWrapKey } from './kdf';
+import { randomBytes, type Bytes } from './encoding';
+
+/*
+  The recovery code (#210): the door that stays open when every password
+  is gone. 128 bits of randomness shown once as 26 letters and digits,
+  grouped for reading aloud over the phone to the other parent:
+
+    K7QX-3M9D-PRV2-H8TC-WJ5N-6B4F-AZ
+
+  Alphabet without 0/O, 1/I/L and U (Crockford's base32, minus U): a code
+  written on paper and typed back a year later must not fail on a letter
+  that looks like a digit. Input is normalised — case, dashes and spaces
+  do not matter, and the four look-alikes are mapped back.
+
+  The code has full entropy, so unlike a password it needs no stretching:
+  HKDF expands it straight into a wrap key, with its own info string so a
+  code and a password can never produce the same key.
+*/
+
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const CODE_BITS = 128;
+const CODE_CHARS = Math.ceil(CODE_BITS / 5); // 26
+const RECOVERY_INFO = 'neiliro/recovery-wrap/v1';
+
+export class RecoveryCodeError extends Error {}
+
+export function generateRecoveryCode(): string {
+  const bytes = randomBytes(16);
+  let bits = 0n;
+  for (const b of bytes) bits = (bits << 8n) | BigInt(b);
+  // Left-align 128 bits in 130 so the last symbol carries two zero bits
+  bits <<= 2n;
+  let out = '';
+  for (let i = CODE_CHARS - 1; i >= 0; i--) {
+    out = ALPHABET[Number((bits >> BigInt(i * 5)) & 31n)]! + out;
+  }
+  return format(out);
+}
+
+export function format(raw: string): string {
+  return raw.match(/.{1,4}/g)!.join('-');
+}
+
+/** Case, separators and look-alike letters are the user's problem no more. */
+export function normalizeRecoveryCode(input: string): string {
+  const cleaned = input
+    .toUpperCase()
+    .replace(/[\s-]/g, '')
+    .replace(/O/g, '0')
+    .replace(/[IL]/g, '1')
+    .replace(/U/g, 'V');
+  if (cleaned.length !== CODE_CHARS || [...cleaned].some((c) => !ALPHABET.includes(c))) {
+    throw new RecoveryCodeError('That does not look like a recovery code');
+  }
+  return cleaned;
+}
+
+function codeBytes(normalized: string): Bytes {
+  let bits = 0n;
+  for (const c of normalized) bits = (bits << 5n) | BigInt(ALPHABET.indexOf(c));
+  bits >>= 2n; // drop the two padding bits
+  const out = new Uint8Array(16);
+  for (let i = 15; i >= 0; i--) {
+    out[i] = Number(bits & 0xffn);
+    bits >>= 8n;
+  }
+  return out;
+}
+
+export async function recoveryWrapKey(code: string): Promise<CryptoKey> {
+  const material = await expandSecret(codeBytes(normalizeRecoveryCode(code)), RECOVERY_INFO);
+  return importWrapKey(material);
+}


### PR DESCRIPTION
Closes #214 (phase 1 of #208, ADR 0001). A pure library under `web/src/lib/crypto/` — no server change, no UI, no dependency, WebCrypto only. 21 tests; the suite is 107 green, typecheck and lint clean.

**Decisions taken here, written into the code comments**

- **PBKDF2-SHA256 at 600 000 iterations, not Argon2.** Argon2 in a browser is WASM, which needs `'wasm-unsafe-eval'` in the strict CSP plus a dependency to audit. PBKDF2 is native, zero bundle bytes, and Bitwarden's default. `KDF_VERSION` exists so this can change without guessing.
- **The salt is derived from the login address**, not fetched. A per-user salt means a pre-login endpoint, and one that answers differently for existing and unknown addresses is the account oracle the password reset goes to lengths to avoid. Normalisation mirrors `emailField` on the server; two frozen vectors (fast and production iteration count) are the contract with the server twin in #211.
- **HKDF split** into `authKey` (sent in place of the password, scrypt-hashed server-side as today) and `wrapKey` (never leaves the browser, non-extractable). Neither derives from the other.
- **Field envelope `e1:nonce:ct`** with AAD `table/column/id`: a value cannot be moved between rows or columns by editing the database. Legacy plaintext passes through `readField`, so modules migrate row by row.
- **Wrapped-key envelope `w1:`** with AAD `envelope/kind/owner`: a member's envelope cannot be relabelled as another member's. The unwrapped family key is extractable on purpose — invites and re-admission must wrap it for others, and non-extractable would buy little against a script that can already use it.
- **File format** `NE1 | chunkSize | noncePrefix | chunks`, 1 MiB chunks, per-chunk nonce and AAD with index and last-flag: truncation, reordering and cross-file substitution all fail.
- **Recovery code**: 128 bits as 26 symbols in Crockford's alphabet minus U, forgiving case, separators and 0/O, 1/I/L look-alikes. Full entropy, so HKDF straight to a wrap key with its own info string.
- **Key store**: `CryptoKey` in IndexedDB scoped to the hostname (one browser profile, two families, no crossover); `lock()` forgets; refused storage degrades to a password prompt per load.

**Deferred to #215** (first module): the `api.ts` encrypt-on-write / decrypt-on-read hooks and the "new text column without a field-map entry fails the build" guard — both need a real field map to exist.

Docs: one line in `docs/architecture.md` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
