### PR TITLE
fix(deploy): prune dangling images on the server before each load

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,17 @@ jobs:
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
 
+      - name: Make room on the server
+        # Every deploy loads a new family-hub:prod and the image it replaces
+        # stays behind untagged. Nothing ever removed those: by 2026-09-06
+        # the demo machine held 147 images, 53 GB of dangling layers, the
+        # load itself died with "no space left on device" and the running
+        # demo answered 500 to every login. Dangling AND unused is all this
+        # removes — every tagged image and anything a container still runs
+        # from stays. Before the load rather than after, so a deploy that
+        # keeps failing still cleans up instead of filling the disk.
+        run: ssh "$DEPLOY" 'docker image prune -f'
+
       - name: Ship the image
         run: |
           docker save family-hub:prod | gzip | \

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -386,6 +386,12 @@ Docker image on its own runner** and delivers it to the server ready-made
 SSH dropped. Push to `master` = production deploy; unfinished work lives
 in branches.
 
+Each deploy also runs `docker image prune -f` on the server before the
+load: the image a deploy replaces stays behind untagged, and left alone
+those layers fill the disk (they once did — 53 GB of them, and the
+deploy died with "no space left on device"). Only dangling, unused
+images go; tagged ones and anything a container runs from stay.
+
 The workflow is a no-op by default so that forks of this repository
 never try to deploy anywhere: it only runs when the repository variable
 `DEPLOY_ENABLED` equals `true`.


### PR DESCRIPTION
## Why

Every deploy loads a new `family-hub:prod` and the image it replaces stays behind untagged; nothing ever removed those. By 2026-09-06 the demo machine held 147 images and 53 GB of dangling layers (`docker system df`), the deploy of #231 died with `no space left on device`, and the running demo answered 500 to every `/api/auth/demo` for two days without an alert.

## What

One step before the load: `ssh "$DEPLOY" 'docker image prune -f'`.

- Removes exactly the dangling, unused images. Every tagged image and anything a container still runs from stays.
- Before the load rather than after, so a deploy that keeps failing still cleans up — merging this heals the current state on the next push instead of needing a hand on the box.
- `docs/deploy-vps.md` says so in the auto-deploy section.

Not in this PR (separate follow-ups): a disk-usage / container-unhealthy alert in `neiliro/infra`, and the 1.3 GB of stale build cache on the demo machine from the days it built on-server (`docker builder prune`, one-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)