### PR TITLE
feat: the family key, its envelopes, the recovery code and re-admission

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ server/               Fastify + SQLite
   src/routes/         API
 web/                  React + Vite + Tailwind
   src/lib/crypto/     Client-side encryption (ADR 0001): key derivation, envelopes, key store
+  src/lib/family-key.tsx  The family key's life in the browser: create, open, hand on, lock
 scripts/              Certificates, backups, export/import, admin reset
 ```
 
@@ -34,6 +35,8 @@ Search uses FTS5 with the `trigram` tokenizer. It matches substrings, so morphol
 SQLite's built-in `lower()` and `LIKE` are case-insensitive only for Latin, so task-name search registers a custom `ci_contains` function — it folds case in JavaScript and knows every alphabet.
 
 Passwords never reach the server. The browser stretches the password (PBKDF2-SHA256, 600 000 iterations, a random per-account salt the server hands out before sign-in) and splits the result with HKDF into an *auth key*, which is sent in place of the password and scrypt-hashed server-side, and a *wrap key*, which stays in the browser and opens the member's key envelope ([ADR 0001](adr/0001-client-side-encryption.md)). Neither half derives from the other, so a server that sees every sign-in still cannot reproduce the key that protects the family's content. Accounts from before the split cross over at their next sign-in, sending the password one last time; `users.kdf_version` says which kind a hash is. The sessions table stores a sha256 of the token, not the token itself: someone who reads the database cannot impersonate anyone.
+
+**The family key** (migration 033, `routes/keys.ts`, `web/src/lib/family-key.tsx`) is one random 256-bit key per family, generated in the browser of the first adult who signs in with a wrap key in hand, and stored on the server only *wrapped*: `key_envelopes` holds one envelope per door. A `password` envelope per member, opened by the wrap key sign-in derives; one `recovery` envelope for the family, opened by a code shown exactly once at creation and acknowledged on a screen that says what losing it means; and `handoff` envelopes — the key wrapped under a random secret that travels in the fragment of a link, which browsers never send — by which a member who holds the key re-admits one who does not. Every password the browser did not derive a wrap key from (an administrator's reset, the e-mailed reset, `admin-reset.mjs`) retires the member's password envelope rather than leaving one that silently fails to open; a password change carries the re-wrapped envelope in the same request, so there is no moment when the password and the envelope disagree. The X25519 pair the server will seal incoming mail to is derived from the family key by HKDF, so its public half sits in `family_key` and its private half is never stored anywhere. The server cannot verify who holds the key; its proxy is a live password envelope, and that is what gates handing the key on. Nothing is encrypted with it yet — phase 1 of the ADR builds the doors before the first byte goes through them.
 
 ## Time
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -140,6 +140,14 @@ Everything the household owns leaves in one file whenever it wants: Settings →
 
 On the hosted service the same section holds **Delete everything**: the administrator confirms with the password, a two-factor code when one is set, and by typing the family's own address, after which the database and the attachments are gone and the encrypted nightly backups expire on their own within a fortnight. A self-hosted install gets the export but no such button — there, deleting the only family means erasing the instance, and that belongs to whoever owns the machine.
 
+### The family key
+
+Encryption of what the family writes ([ADR 0001](adr/0001-client-side-encryption.md)) starts with a key that belongs to the family and never reaches the server unprotected. It is created in the browser of the first adult who signs in after the hub learns about it, and from then on each member's browser opens it with their own password — the server keeps only sealed envelopes it cannot open. Settings → **Family key** shows whether this device holds it; **Lock this device** forgets it until the next sign-in.
+
+The moment the key is created, the hub shows a **recovery code** once and waits for an explicit acknowledgement, because it is the family's last door: a password reset — by the administrator, by e-mail, or from the server's console — restores access to the account but not to the key, since the new password cannot open an envelope the old one sealed. A member who lost theirs gets it back either from another member (**Re-admit** in Settings → People produces a one-time link; the secret that opens it rides only in the link, never through the server) or by typing the recovery code. A new code can be minted at any time by a member who holds the key; the old one stops working at once.
+
+Nothing is encrypted with the key yet: a device without it sees the hub as before, plus a quiet line offering the two ways back in. The doors are built before the first byte goes through them, on purpose.
+
 ### Sharing one event
 
 Any event can get a public link — "the party is on Saturday at three, here is where" — for people who have no account here and never will. The guest page shows the event and a button that adds it to their own calendar as a file.

--- a/scripts/admin-reset.mjs
+++ b/scripts/admin-reset.mjs
@@ -68,6 +68,23 @@ db.prepare(
     WHERE id = ?`,
 ).run(hash, salt, user.id);
 
+// The key envelope wrapped under the old password is dead to the new one
+// (ADR 0001, #210): this script restores access, not the family key. The
+// member gets the key back from another member (re-admission link in
+// Settings → People) or with the recovery code. Older databases have no
+// such table yet — migrations run when the app starts.
+let keyLost = false;
+try {
+  keyLost =
+    db
+      .prepare(
+        `UPDATE key_envelopes SET retired_at = ? WHERE user_id = ? AND kind = 'password' AND retired_at IS NULL`,
+      )
+      .run(new Date().toISOString(), user.id).changes > 0;
+} catch {
+  // no key_envelopes table: a database from before the family key existed
+}
+
 // Close previous sessions: if the password is being reset, they can't be trusted
 const closed = db.prepare('DELETE FROM sessions WHERE user_id = ?').run(user.id).changes;
 db.close();
@@ -85,6 +102,15 @@ const out = [
 ];
 if (closed > 0) {
   out.push(`  Previous sessions closed: ${closed} — you will have to sign in again everywhere.`);
+}
+if (keyLost) {
+  out.push(
+    '',
+    '  This restores access, not the family key: the new password cannot open',
+    '  the key envelope the old one protected. After signing in, get the key',
+    '  back from another member (Settings → People → Re-admit) or enter the',
+    "  family's recovery code. Encrypted content stays unreadable until then.",
+  );
 }
 out.push(line, '');
 console.log(out.join('\n'));

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -24,6 +24,7 @@ import { registerAuthRoutes } from './routes/auth.js';
 import { registerGoogleRoutes } from './routes/google.js';
 import { registerSetupRoutes } from './routes/setup.js';
 import { registerUserRoutes } from './routes/users.js';
+import { registerKeyRoutes } from './routes/keys.js';
 import { registerProfileRoutes, registerPublicWishlistRoutes } from './routes/profiles.js';
 import { registerProjectRoutes } from './routes/projects.js';
 import { registerListRoutes } from './routes/lists.js';
@@ -291,6 +292,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await registerGoogleRoutes(app);
   await registerSetupRoutes(app);
   await registerUserRoutes(app);
+  await registerKeyRoutes(app);
   await registerProfileRoutes(app);
   await registerPublicWishlistRoutes(app);
   await registerProjectRoutes(app);

--- a/server/src/db/migrations/033_key_envelopes.sql
+++ b/server/src/db/migrations/033_key_envelopes.sql
@@ -1,0 +1,45 @@
+-- The family key and the doors to it (ADR 0001, #210).
+--
+-- The family key is generated in a browser and never reaches the server
+-- in the clear. What the server stores is envelopes: the key wrapped
+-- (AES-GCM, web/src/lib/crypto/envelope.ts, the `w1:` format) under a
+-- key the server does not hold. One envelope per door:
+--
+--   password  — the member's own; opened by the wrap key the browser
+--               derives from their password at sign-in (#211).
+--   recovery  — the family's, user_id NULL; opened by the recovery code
+--               shown once when the key was created. For a family of one
+--               it is the only door after a lost password.
+--   handoff   — a fresh envelope one member wraps for another under a
+--               random secret that travels in a link's URL fragment
+--               (never sent to the server). How a member locked out by a
+--               password reset gets back in, and (#212) how an invited
+--               member receives the key in the first place.
+--
+-- Envelopes are retired, not deleted: a password reset kills the
+-- password envelope (the new password cannot open it), and the row with
+-- retired_at is how the UI knows to offer the other two doors.
+CREATE TABLE key_envelopes (
+  id          TEXT PRIMARY KEY,
+  user_id     TEXT REFERENCES users(id) ON DELETE CASCADE,
+  kind        TEXT NOT NULL CHECK (kind IN ('password', 'recovery', 'handoff')),
+  envelope    TEXT NOT NULL,
+  created_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TEXT NOT NULL,
+  retired_at  TEXT,
+  CHECK ((kind = 'recovery') = (user_id IS NULL))
+);
+CREATE INDEX idx_key_envelopes_user ON key_envelopes(user_id, kind, retired_at);
+
+-- One row: the family has a key, and this is its X25519 public half. The
+-- private half is derived from the family key in the browser and is never
+-- stored anywhere; the public one lets the server seal incoming mail for
+-- the family later (#223) without being able to open it. Its own table
+-- rather than a settings row: /api/settings is writable by every member,
+-- and a public key anyone can replace is a public key for anyone.
+CREATE TABLE family_key (
+  id          INTEGER PRIMARY KEY CHECK (id = 1),
+  public_key  TEXT NOT NULL,
+  created_by  TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TEXT NOT NULL
+);

--- a/server/src/lib/keys.ts
+++ b/server/src/lib/keys.ts
@@ -1,0 +1,88 @@
+import { db, id, now } from '../db/index.js';
+
+/*
+  The server's side of the family key (ADR 0001, #210): it stores envelopes
+  it cannot open and knows which doors a member still has. Every value that
+  arrives here is a wrapped key in the `w1:` format the browser produces
+  (web/src/lib/crypto/envelope.ts): a 12-byte nonce and 48 bytes of
+  ciphertext, base64url. The shape is pinned so nothing else can be stored
+  in these columns — a raw 32-byte key is 43 characters and does not match.
+*/
+export const ENVELOPE_PATTERN = /^w1:[A-Za-z0-9_-]{16}:[A-Za-z0-9_-]{64}$/;
+/** An X25519 public key: 32 bytes as base64url. */
+export const PUBLIC_KEY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+/** A handoff link is one-shot in spirit and a week in practice, like an invite. */
+export const HANDOFF_TTL_MS = 7 * 24 * 60 * 60_000;
+
+export type EnvelopeKind = 'password' | 'recovery' | 'handoff';
+
+export interface FamilyKeyRow {
+  public_key: string;
+  created_at: string;
+}
+
+export function familyKey(): FamilyKeyRow | null {
+  return (
+    (db.prepare('SELECT public_key, created_at FROM family_key WHERE id = 1').get() as
+      | FamilyKeyRow
+      | undefined) ?? null
+  );
+}
+
+/** The member's live envelope of one kind, or null. */
+export function liveEnvelope(userId: string | null, kind: EnvelopeKind): string | null {
+  const row = db
+    .prepare(
+      `SELECT envelope FROM key_envelopes
+        WHERE ${userId === null ? 'user_id IS NULL' : 'user_id = ?'} AND kind = ? AND retired_at IS NULL
+        ORDER BY created_at DESC LIMIT 1`,
+    )
+    .get(...(userId === null ? [kind] : [userId, kind])) as { envelope: string } | undefined;
+  return row?.envelope ?? null;
+}
+
+/**
+ * A member "holds the key" as far as the server can tell when they have a
+ * live password envelope: the server cannot check the key itself, and this
+ * is the one proxy that does not require trusting the request. It gates
+ * the actions that hand the key on (handoff, a new recovery code).
+ */
+export function holdsKey(userId: string): boolean {
+  return liveEnvelope(userId, 'password') !== null;
+}
+
+export function retireEnvelopes(userId: string | null, kind: EnvelopeKind): number {
+  return db
+    .prepare(
+      `UPDATE key_envelopes SET retired_at = ?
+        WHERE ${userId === null ? 'user_id IS NULL' : 'user_id = ?'} AND kind = ? AND retired_at IS NULL`,
+    )
+    .run(...(userId === null ? [now(), kind] : [now(), userId, kind])).changes;
+}
+
+/**
+ * A new password the member's browser never derived a wrap key from — a
+ * reset by the administrator, by e-mail, or by admin-reset.mjs — cannot
+ * open the envelope wrapped under the old one. The envelope is retired so
+ * the member is offered the other doors (re-admission, the recovery code)
+ * instead of an envelope that silently fails to open. Callers run this
+ * inside the transaction that changes the password.
+ */
+export function retirePasswordEnvelope(userId: string): void {
+  retireEnvelopes(userId, 'password');
+}
+
+export function storeEnvelope(
+  userId: string | null,
+  kind: EnvelopeKind,
+  envelope: string,
+  createdBy: string | null,
+): string {
+  const envelopeId = id();
+  db.prepare(
+    `INSERT INTO key_envelopes (id, user_id, kind, envelope, created_by, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(envelopeId, userId, kind, envelope, createdBy, now());
+  return envelopeId;
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { currentTenant, db, now } from '../db/index.js';
 import { hashPassword, verifyPassword } from '../lib/password.js';
 import { AUTH_KEY_PATTERN, decoySalt } from '../lib/kdf.js';
+import { ENVELOPE_PATTERN, retirePasswordEnvelope, storeEnvelope } from '../lib/keys.js';
 import { env } from '../env.js';
 import { googleSignInAvailable } from './google.js';
 import { serviceMailAvailable } from '../lib/mail.js';
@@ -110,6 +111,13 @@ const changeInput = z.object({
   current_auth_key: authKeyField,
   new_auth_key: authKeyField,
   current_password: z.string().min(1).max(500).optional(),
+  // The key envelope re-wrapped under the new password (ADR 0001, #210),
+  // in the same request as the password itself: an envelope under a
+  // password that is not yet set, or a password whose envelope is not yet
+  // rewritten, would both be a window in which the member cannot get in.
+  // A browser that does not hold the key sends none, and the old envelope
+  // is retired — the new password cannot open it anyway.
+  envelope: z.string().regex(ENVELOPE_PATTERN, 'Not a key envelope').optional(),
 });
 
 export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
@@ -655,10 +663,15 @@ export async function registerAuthRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(400).send({ error: 'The current password is incorrect' });
     }
 
-    db.prepare(
-      `UPDATE users SET password_hash = ?, kdf_version = 1, must_change_password = 0, password_changed_at = ?
-        WHERE id = ?`,
-    ).run(await hashPassword(parsed.data.new_auth_key), now(), session.id);
+    const newHash = await hashPassword(parsed.data.new_auth_key);
+    db.transaction(() => {
+      db.prepare(
+        `UPDATE users SET password_hash = ?, kdf_version = 1, must_change_password = 0, password_changed_at = ?
+          WHERE id = ?`,
+      ).run(newHash, now(), session.id);
+      retirePasswordEnvelope(session.id);
+      if (parsed.data.envelope) storeEnvelope(session.id, 'password', parsed.data.envelope, session.id);
+    })();
 
     // A password change signs out every device, the current one included
     destroyAllSessions(session.id);

--- a/server/src/routes/keys.test.ts
+++ b/server/src/routes/keys.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import { SALT, authKey, buildTestApp } from '../test-harness.js';
+import { hashPassword } from '../lib/password.js';
+import { createSession } from '../lib/auth.js';
+import { id, now, runWithDb } from '../db/index.js';
+import { ENVELOPE_PATTERN, PUBLIC_KEY_PATTERN } from '../lib/keys.js';
+
+/*
+  The family key's doors (ADR 0001, #210), from the server's side.
+
+  The server never sees the family key, a wrap key, a recovery code or a
+  handoff secret; it stores envelopes and knows who has which door. The
+  tests here pin exactly that: what the routes accept, what they refuse,
+  and that every password reset kills the envelope the old password
+  protected. Opening envelopes is the browser's business and is tested
+  in web/src/lib/crypto.
+*/
+
+type Harness = Awaited<ReturnType<typeof buildTestApp>>;
+
+// Wire-shaped fixtures: a `w1:` envelope is a 16-char nonce and 64 chars of
+// ciphertext (12 + 48 bytes, base64url); a public key is 32 bytes → 43 chars.
+const b64 = (n: number, c = 'A') => c.repeat(n);
+const envelope = (c = 'A') => `w1:${b64(16, c)}:${b64(64, c)}`;
+const PUBLIC_KEY = b64(43, 'B');
+/** What a raw 32-byte key looks like in base64url — must never be accepted as an envelope. */
+const RAW_KEY = b64(43, 'C');
+
+async function member(h: Harness, name: string, role: 'admin' | 'member' | 'kid' = 'member') {
+  const hash = await hashPassword(await authKey(`${name} password 12`));
+  return runWithDb(h.db, () => {
+    const userId = id();
+    h.db
+      .prepare(
+        `INSERT INTO users (id, email, name, role, password_hash, kdf_version, kdf_salt, created_at)
+         VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      )
+      .run(userId, `${name.toLowerCase()}@hub.local`, name, role, hash, SALT, now());
+    return { userId, cookie: createSession(userId, `${name}-device`) };
+  });
+}
+
+const createKey = (h: Harness, cookie: string, body: unknown = {}) =>
+  h.as(cookie, 'POST', '/api/keys', {
+    public_key: PUBLIC_KEY,
+    envelope: envelope('D'),
+    recovery_envelope: envelope('R'),
+    ...(body as object),
+  });
+
+describe('the wire shape', () => {
+  it('an envelope is a wrapped key, never a bare one', () => {
+    expect(ENVELOPE_PATTERN.test(envelope())).toBe(true);
+    expect(ENVELOPE_PATTERN.test(RAW_KEY)).toBe(false);
+    expect(ENVELOPE_PATTERN.test(`w1:${b64(16)}:${RAW_KEY}`)).toBe(false);
+    expect(ENVELOPE_PATTERN.test(`e1:${b64(16)}:${b64(64)}`)).toBe(false);
+    expect(PUBLIC_KEY_PATTERN.test(PUBLIC_KEY)).toBe(true);
+    expect(PUBLIC_KEY_PATTERN.test(envelope())).toBe(false);
+  });
+});
+
+describe('creating the family key', () => {
+  it('happens once, by an adult, with the recovery door in the same request', async () => {
+    const h = await buildTestApp();
+    const kid = await member(h, 'Kid', 'kid');
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+
+    expect((await h.as(sam.cookie, 'GET', '/api/keys')).json()).toEqual({
+      family: null,
+      password_envelope: null,
+      recovery_envelope: null,
+      handoffs: [],
+    });
+
+    expect((await createKey(h, kid.cookie)).statusCode).toBe(403);
+    // No recovery envelope, no key: a key with a single door must never exist
+    expect((await createKey(h, sam.cookie, { recovery_envelope: undefined })).statusCode).toBe(400);
+    // A raw key in place of an envelope is refused by shape
+    expect((await createKey(h, sam.cookie, { envelope: RAW_KEY })).statusCode).toBe(400);
+
+    expect((await createKey(h, sam.cookie)).statusCode).toBe(201);
+    expect((await createKey(h, ann.cookie)).statusCode).toBe(409);
+
+    const mine = (await h.as(sam.cookie, 'GET', '/api/keys')).json<{
+      family: { public_key: string; created_at: string };
+      password_envelope: string;
+      recovery_envelope: string;
+    }>();
+    expect(mine.family.public_key).toBe(PUBLIC_KEY);
+    expect(mine.password_envelope).toBe(envelope('D'));
+    expect(mine.recovery_envelope).toBe(envelope('R'));
+
+    // Ann has the family's recovery envelope to try a code against, and no envelope of her own yet
+    const hers = (await h.as(ann.cookie, 'GET', '/api/keys')).json<{ password_envelope: null; recovery_envelope: string }>();
+    expect(hers.password_envelope).toBeNull();
+    expect(hers.recovery_envelope).toBe(envelope('R'));
+  });
+
+  it('a member writes their own envelope once they hold the key; before the key exists there is nothing to wrap', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+    expect((await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('E') })).statusCode).toBe(409);
+    await createKey(h, sam.cookie);
+    expect((await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('E') })).statusCode).toBe(200);
+    expect((await h.as(ann.cookie, 'GET', '/api/keys')).json<{ password_envelope: string }>().password_envelope).toBe(
+      envelope('E'),
+    );
+    // Replacing keeps one live envelope, not two
+    await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('F') });
+    expect((await h.as(ann.cookie, 'GET', '/api/keys')).json<{ password_envelope: string }>().password_envelope).toBe(
+      envelope('F'),
+    );
+    const live = runWithDb(h.db, () =>
+      h.db.prepare("SELECT count(*) AS n FROM key_envelopes WHERE user_id = ? AND kind = 'password' AND retired_at IS NULL").get(ann.userId),
+    ) as { n: number };
+    expect(live.n).toBe(1);
+  });
+});
+
+describe('handing the key on', () => {
+  it('only a member with a live envelope can hand off, and only to someone else', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+    const bob = await member(h, 'Bob');
+    const kid = await member(h, 'Kid', 'kid');
+    await createKey(h, sam.cookie);
+
+    // Ann holds nothing yet: she cannot hand on what she does not have
+    expect((await h.as(ann.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('H') })).statusCode).toBe(403);
+    expect((await h.as(sam.cookie, 'POST', '/api/keys/handoff', { user_id: sam.userId, envelope: envelope('H') })).statusCode).toBe(400);
+    expect((await h.as(sam.cookie, 'POST', '/api/keys/handoff', { user_id: '00000000-0000-4000-8000-000000000000', envelope: envelope('H') })).statusCode).toBe(404);
+    expect((await h.as(kid.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('H') })).statusCode).toBe(403);
+
+    const first = await h.as(sam.cookie, 'POST', '/api/keys/handoff', { user_id: ann.userId, envelope: envelope('H') });
+    expect(first.statusCode).toBe(201);
+    const second = await h.as(sam.cookie, 'POST', '/api/keys/handoff', { user_id: ann.userId, envelope: envelope('I') });
+    expect(second.statusCode).toBe(201);
+
+    // Ann sees exactly the latest one, and who made it
+    const hers = (await h.as(ann.cookie, 'GET', '/api/keys')).json<{ handoffs: { id: string; envelope: string; created_by_name: string }[] }>();
+    expect(hers.handoffs).toHaveLength(1);
+    expect(hers.handoffs[0]!.envelope).toBe(envelope('I'));
+    expect(hers.handoffs[0]!.created_by_name).toBe('Sam');
+    // Nobody else sees it
+    expect((await h.as(bob.cookie, 'GET', '/api/keys')).json<{ handoffs: unknown[] }>().handoffs).toEqual([]);
+
+    // Writing her own envelope retires the handoff: it has done its job
+    await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('E') });
+    expect((await h.as(ann.cookie, 'GET', '/api/keys')).json<{ handoffs: unknown[] }>().handoffs).toEqual([]);
+    // ...and now she can hand on herself
+    expect((await h.as(ann.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('J') })).statusCode).toBe(201);
+  });
+
+  it('a handoff is retired by its creator, the administrator or the member it is for — not by a bystander', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+    const bob = await member(h, 'Bob');
+    const kid = await member(h, 'Kid', 'kid');
+    await createKey(h, sam.cookie);
+    await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('E') });
+
+    const { id: byAnn } = (await h.as(ann.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('H') })).json<{ id: string }>();
+    expect((await h.as(kid.cookie, 'DELETE', `/api/keys/handoff/${byAnn}`)).statusCode).toBe(404);
+    expect((await h.as(sam.cookie, 'DELETE', `/api/keys/handoff/${byAnn}`)).statusCode).toBe(200);
+
+    // The member it was made for retires it after opening it — a browser
+    // with no wrap key has no envelope to write and would otherwise leave it live
+    const { id: forBob } = (await h.as(ann.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('L') })).json<{ id: string }>();
+    expect((await h.as(bob.cookie, 'DELETE', `/api/keys/handoff/${forBob}`)).statusCode).toBe(200);
+    expect((await h.as(bob.cookie, 'GET', '/api/keys')).json<{ handoffs: unknown[] }>().handoffs).toEqual([]);
+
+    const { id: again } = (await h.as(ann.cookie, 'POST', '/api/keys/handoff', { user_id: bob.userId, envelope: envelope('K') })).json<{ id: string }>();
+    expect((await h.as(ann.cookie, 'DELETE', `/api/keys/handoff/${again}`)).statusCode).toBe(200);
+  });
+
+  it('a new recovery code replaces the old one and needs a key holder', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+    await createKey(h, sam.cookie);
+    expect((await h.as(ann.cookie, 'POST', '/api/keys/recovery', { recovery_envelope: envelope('S') })).statusCode).toBe(403);
+    expect((await h.as(sam.cookie, 'POST', '/api/keys/recovery', { recovery_envelope: envelope('S') })).statusCode).toBe(200);
+    expect((await h.as(ann.cookie, 'GET', '/api/keys')).json<{ recovery_envelope: string }>().recovery_envelope).toBe(envelope('S'));
+    const live = runWithDb(h.db, () =>
+      h.db.prepare("SELECT count(*) AS n FROM key_envelopes WHERE kind = 'recovery' AND retired_at IS NULL").get(),
+    ) as { n: number };
+    expect(live.n).toBe(1);
+  });
+});
+
+describe('a password the browser never wrapped with kills the envelope', () => {
+  it('the administrator resetting a member', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    const ann = await member(h, 'Ann');
+    await createKey(h, sam.cookie);
+    await h.as(ann.cookie, 'PUT', '/api/keys/envelope', { envelope: envelope('E') });
+
+    const before = (await h.as(sam.cookie, 'GET', '/api/users')).json<{ id: string; key_envelope: number }[]>();
+    expect(before.find((u) => u.id === ann.userId)!.key_envelope).toBe(1);
+
+    expect((await h.as(sam.cookie, 'POST', `/api/users/${ann.userId}/reset-password`, {})).statusCode).toBe(200);
+
+    const after = (await h.as(sam.cookie, 'GET', '/api/users')).json<{ id: string; key_envelope: number }[]>();
+    expect(after.find((u) => u.id === ann.userId)!.key_envelope).toBe(0);
+    // The row is retired, not deleted: the fact that it once existed stays
+    const rows = runWithDb(h.db, () =>
+      h.db.prepare("SELECT retired_at FROM key_envelopes WHERE user_id = ? AND kind = 'password'").all(ann.userId),
+    ) as { retired_at: string | null }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.retired_at).not.toBeNull();
+  });
+
+  it('a password change re-wraps in the same request, or retires when the browser holds no key', async () => {
+    const h = await buildTestApp();
+    const sam = await member(h, 'Sam', 'admin');
+    await createKey(h, sam.cookie);
+
+    const current = await authKey('Sam password 12');
+    const next = await authKey('a brand new password');
+    // A browser holding the key sends the re-wrapped envelope along
+    const changed = await h.as(sam.cookie, 'POST', '/api/auth/change-password', {
+      current_auth_key: current,
+      new_auth_key: next,
+      envelope: envelope('N'),
+    });
+    expect(changed.statusCode).toBe(200);
+    let session = runWithDb(h.db, () => createSession(sam.userId, 'laptop'));
+    expect((await h.as(session, 'GET', '/api/keys')).json<{ password_envelope: string }>().password_envelope).toBe(envelope('N'));
+
+    // A browser that does not hold the key cannot re-wrap: the envelope dies honestly
+    const changedBlind = await h.as(session, 'POST', '/api/auth/change-password', {
+      current_auth_key: next,
+      new_auth_key: await authKey('yet another password'),
+    });
+    expect(changedBlind.statusCode).toBe(200);
+    session = runWithDb(h.db, () => createSession(sam.userId, 'laptop'));
+    expect((await h.as(session, 'GET', '/api/keys')).json<{ password_envelope: null }>().password_envelope).toBeNull();
+    // The recovery door is untouched by any of this
+    expect((await h.as(session, 'GET', '/api/keys')).json<{ recovery_envelope: string }>().recovery_envelope).toBe(envelope('R'));
+  });
+});

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -1,0 +1,185 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { db, now } from '../db/index.js';
+import { log } from '../lib/log.js';
+import {
+  ENVELOPE_PATTERN,
+  HANDOFF_TTL_MS,
+  PUBLIC_KEY_PATTERN,
+  familyKey,
+  holdsKey,
+  liveEnvelope,
+  retireEnvelopes,
+  storeEnvelope,
+} from '../lib/keys.js';
+
+/*
+  The family key's doors (ADR 0001, #210).
+
+  Nothing here can read what it stores. The browser generates the family
+  key, wraps it, and sends envelopes; this file keeps them, says which ones
+  a member still has, and refuses the few things the server *can* refuse:
+  a second family key, a kid creating the key, a handoff from someone who
+  has no envelope of their own. The last is a proxy — the server cannot
+  tell who holds the key, only who has a live door to it — and it is the
+  strongest check available without trusting the request.
+
+  What never arrives: the family key, a wrap key, a recovery code, a
+  handoff secret. The schemas below accept wrapped envelopes and one public
+  key, and the shape of a `w1:` envelope does not fit a raw key — the
+  test pins that.
+*/
+
+const envelopeField = z.string().regex(ENVELOPE_PATTERN, 'Not a key envelope');
+const publicKeyField = z.string().regex(PUBLIC_KEY_PATTERN, 'Not a public key');
+
+export async function registerKeyRoutes(app: FastifyInstance): Promise<void> {
+  /** What this browser needs to open the key, or to learn that it cannot. */
+  app.get('/api/keys', (req) => {
+    const me = req.user!.id;
+    const handoffs = db
+      .prepare(
+        `SELECT k.id, k.envelope, k.created_at, u.name AS created_by_name
+           FROM key_envelopes k LEFT JOIN users u ON u.id = k.created_by
+          WHERE k.user_id = ? AND k.kind = 'handoff' AND k.retired_at IS NULL AND k.created_at > ?
+          ORDER BY k.created_at DESC`,
+      )
+      .all(me, new Date(Date.now() - HANDOFF_TTL_MS).toISOString());
+    return {
+      family: familyKey(),
+      password_envelope: liveEnvelope(me, 'password'),
+      recovery_envelope: liveEnvelope(null, 'recovery'),
+      handoffs,
+    };
+  });
+
+  /*
+    The family key is born here — once. The browser of whoever gets here
+    first with a wrap key in hand sends the public half, its own envelope
+    and the recovery envelope in one request: a key with no recovery door
+    must never exist, not even between two requests. Kids do not create it:
+    the recovery code has to land with an adult.
+  */
+  app.post('/api/keys', (req, reply) => {
+    const user = req.user!;
+    if (user.role === 'kid') {
+      return reply.code(403).send({ error: 'A family member sets up the key, not a kid account' });
+    }
+    const parsed = z
+      .object({
+        public_key: publicKeyField,
+        envelope: envelopeField,
+        recovery_envelope: envelopeField,
+      })
+      .safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'Not a key envelope' });
+
+    const created = db.transaction(() => {
+      if (familyKey()) return false;
+      db.prepare('INSERT INTO family_key (id, public_key, created_by, created_at) VALUES (1, ?, ?, ?)').run(
+        parsed.data.public_key,
+        user.id,
+        now(),
+      );
+      storeEnvelope(user.id, 'password', parsed.data.envelope, user.id);
+      storeEnvelope(null, 'recovery', parsed.data.recovery_envelope, user.id);
+      return true;
+    })();
+    if (!created) return reply.code(409).send({ error: 'The family already has a key' });
+
+    log.info(`family key created by ${user.email}`);
+    return reply.code(201).send({ ok: true });
+  });
+
+  /*
+    The member's own envelope, written by a browser that holds the key and
+    a wrap key: after opening a handoff or the recovery code, or after the
+    first sign-in of an account from before the split. Replaces the previous
+    one and retires any handoff still addressed to this member — it has
+    served its purpose or was never needed.
+  */
+  app.put('/api/keys/envelope', (req, reply) => {
+    const me = req.user!.id;
+    const parsed = z.object({ envelope: envelopeField }).safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'Not a key envelope' });
+    if (!familyKey()) return reply.code(409).send({ error: 'The family has no key yet' });
+    db.transaction(() => {
+      retireEnvelopes(me, 'password');
+      retireEnvelopes(me, 'handoff');
+      storeEnvelope(me, 'password', parsed.data.envelope, me);
+    })();
+    return { ok: true };
+  });
+
+  /*
+    A new recovery code — the old envelope is replaced, never merely
+    removed, so the family is never without that door. Only a member with a
+    live envelope may do it: the code is minted in the browser and wrapped
+    with the key, and this is the server's proxy for "has the key".
+  */
+  app.post('/api/keys/recovery', (req, reply) => {
+    const me = req.user!;
+    if (me.role === 'kid') return reply.code(403).send({ error: 'A family member does this, not a kid account' });
+    const parsed = z.object({ recovery_envelope: envelopeField }).safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'Not a key envelope' });
+    if (!familyKey()) return reply.code(409).send({ error: 'The family has no key yet' });
+    if (!holdsKey(me.id)) {
+      return reply.code(403).send({ error: 'Only a member who holds the key can issue a new recovery code' });
+    }
+    db.transaction(() => {
+      retireEnvelopes(null, 'recovery');
+      storeEnvelope(null, 'recovery', parsed.data.recovery_envelope, me.id);
+    })();
+    log.info(`recovery code replaced by ${me.email}`);
+    return { ok: true };
+  });
+
+  /*
+    Re-admission (#210), and the mechanism invitations reuse (#212): a
+    member holding the key wraps it for another under a random secret. The
+    envelope is stored here; the secret leaves the inviting browser only
+    inside the fragment of a link, which browsers never send. One live
+    handoff per member — a second one replaces the first.
+  */
+  app.post('/api/keys/handoff', (req, reply) => {
+    const me = req.user!;
+    if (me.role === 'kid') return reply.code(403).send({ error: 'A family member does this, not a kid account' });
+    const parsed = z.object({ user_id: z.string().uuid(), envelope: envelopeField }).safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: 'Not a key envelope' });
+    if (!familyKey()) return reply.code(409).send({ error: 'The family has no key yet' });
+    if (!holdsKey(me.id)) {
+      return reply.code(403).send({ error: 'Only a member who holds the key can hand it on' });
+    }
+    if (parsed.data.user_id === me.id) return reply.code(400).send({ error: 'You already hold the key' });
+    const target = db
+      .prepare('SELECT id, name FROM users WHERE id = ? AND disabled_at IS NULL')
+      .get(parsed.data.user_id) as { id: string; name: string } | undefined;
+    if (!target) return reply.code(404).send({ error: 'Member not found' });
+
+    const handoffId = db.transaction(() => {
+      retireEnvelopes(target.id, 'handoff');
+      return storeEnvelope(target.id, 'handoff', parsed.data.envelope, me.id);
+    })();
+    log.info(`key handoff for ${target.name} issued by ${me.email}`);
+    return reply.code(201).send({ id: handoffId });
+  });
+
+  /**
+   * Retire a handoff: its creator revoking it, the administrator, or the
+   * member it was made for once they have opened it (a browser without a
+   * wrap key cannot write the envelope that would retire it otherwise).
+   */
+  app.delete('/api/keys/handoff/:id', (req, reply) => {
+    const me = req.user!;
+    const { id: handoffId } = z.object({ id: z.string().uuid() }).parse(req.params);
+    const result = db
+      .prepare(
+        `UPDATE key_envelopes SET retired_at = ?
+          WHERE id = ? AND kind = 'handoff' AND retired_at IS NULL
+            AND (created_by = ? OR user_id = ? OR ?)`,
+      )
+      .run(now(), handoffId, me.id, me.id, me.role === 'admin' ? 1 : 0);
+    if (result.changes === 0) return reply.code(404).send({ error: 'Handoff not found' });
+    return { ok: true };
+  });
+}

--- a/server/src/routes/password-reset.ts
+++ b/server/src/routes/password-reset.ts
@@ -8,6 +8,7 @@ import { log } from '../lib/log.js';
 import { sendServiceEmail, serviceMailAvailable } from '../lib/mail.js';
 import { hashPassword } from '../lib/password.js';
 import { AUTH_KEY_PATTERN } from '../lib/kdf.js';
+import { retirePasswordEnvelope } from '../lib/keys.js';
 import { familySlug } from '../lib/tenants.js';
 
 /*
@@ -110,6 +111,10 @@ export async function registerPasswordResetRoutes(app: FastifyInstance): Promise
         'UPDATE users SET password_hash = ?, kdf_version = 1, must_change_password = 0 WHERE id = ?',
       ).run(passwordHash, row.user_id);
       db.prepare('UPDATE password_resets SET used_at = ? WHERE id = ?').run(now(), row.id);
+      // A password nobody's browser derived a wrap key from cannot open
+      // the envelope (ADR 0001): access comes back, the key comes back by
+      // re-admission or the recovery code — the reset page says so
+      retirePasswordEnvelope(row.user_id);
       // Every other unused link for this person dies with it
       db.prepare('DELETE FROM password_resets WHERE user_id = ? AND used_at IS NULL').run(row.user_id);
     })();

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -6,6 +6,7 @@ import { log } from '../lib/log.js';
 import { generatePassword, hashPassword } from '../lib/password.js';
 import { deriveAuthKey } from '../lib/kdf.js';
 import { emailVerificationAvailable, sendVerificationEmail } from './email-verify.js';
+import { retirePasswordEnvelope } from '../lib/keys.js';
 
 export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/users', (req, reply) => {
@@ -14,7 +15,10 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
       .prepare(
         `SELECT id, email, name, role, color, created_at, last_login_at,
                 disabled_at, must_change_password,
-                (email_verified_at IS NOT NULL) AS email_verified
+                (email_verified_at IS NOT NULL) AS email_verified,
+                EXISTS (SELECT 1 FROM key_envelopes k
+                         WHERE k.user_id = users.id AND k.kind = 'password' AND k.retired_at IS NULL)
+                  AS key_envelope
            FROM users ORDER BY role, name`,
       )
       .all() as { email_verified: number }[];
@@ -137,10 +141,16 @@ export async function registerUserRoutes(app: FastifyInstance): Promise<void> {
     const authKey = await deriveAuthKey(password, ensureKdfSalt(user.id, user.kdf_salt));
     // A reset is also the recovery path for a dead Google account,
     // so password login gets switched back on
-    db.prepare(
-      `UPDATE users SET password_hash = ?, kdf_version = 1, must_change_password = 1,
-              password_login_disabled = 0 WHERE id = ?`,
-    ).run(await hashPassword(authKey), userId);
+    const hash = await hashPassword(authKey);
+    db.transaction(() => {
+      db.prepare(
+        `UPDATE users SET password_hash = ?, kdf_version = 1, must_change_password = 1,
+                password_login_disabled = 0 WHERE id = ?`,
+      ).run(hash, userId);
+      // The new password opens nothing the old one wrapped (ADR 0001):
+      // access is restored, the key is handed back by re-admission
+      retirePasswordEnvelope(userId);
+    })();
     // A password reset kicks the user off every device
     destroyAllSessions(userId);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,9 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { AuthProvider, useAuth } from './lib/auth';
+import { KeyProvider, useKeys } from './lib/family-key';
+import { RecoveryCodeScreen } from './components/RecoveryCode';
+import { Readmit } from './pages/Readmit';
 import { DialogProvider } from './components/Dialog';
 import { ChangePassword, Login } from './pages/Login';
 import { Dashboard } from './pages/Dashboard';
@@ -26,6 +29,21 @@ function Gate() {
   if (!user) return <Login />;
   if (mustChangePassword) return <ChangePassword />;
 
+  // The family key lives only behind a signed-in, settled account: the
+  // provider mounts here and forgets the key when it unmounts (sign-out)
+  return (
+    <KeyProvider>
+      <KeyGate />
+    </KeyProvider>
+  );
+}
+
+function KeyGate() {
+  const { freshRecoveryCode, acknowledgeRecoveryCode } = useKeys();
+  // The one blocking screen of the whole feature: a recovery code nobody
+  // acknowledged is a code nobody wrote down (ADR 0001)
+  if (freshRecoveryCode) return <RecoveryCodeScreen code={freshRecoveryCode} onDone={acknowledgeRecoveryCode} />;
+
   return (
     <Routes>
       <Route element={<AppShell />}>
@@ -39,6 +57,8 @@ function Gate() {
         <Route path="family" element={<Family />} />
         <Route path="family/:userId" element={<Family />} />
         <Route path="settings" element={<Settings />} />
+        {/* The other end of a re-admission link (#210): signed in, inside the shell */}
+        <Route path="readmit" element={<Readmit />} />
         {/* People management moved into Settings; old bookmarks land there */}
         <Route path="users" element={<Navigate to="/settings" replace />} />
       </Route>

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -9,6 +9,8 @@ import { useFamilyAddress, familyUrl } from '../lib/family-address';
 import { loadLocal, saveLocal } from '../lib/storage';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
+import { useKeys } from '../lib/family-key';
+import { RecoveryCodeDialog } from './RecoveryCode';
 import { applyUpdate, setupPwa } from '../lib/pwa';
 import { clearFailure, useFailure } from '../lib/failures';
 import { QuickAdd } from './QuickAdd';
@@ -401,6 +403,7 @@ export function AppShell() {
       {/* Content */}
       <main className="flex-1 pb-20 md:pb-0">
         <ConfirmAddressNotice />
+        <LockedKeyNotice />
         <Outlet key={refreshKey} />
       </main>
 
@@ -548,6 +551,45 @@ function ConfirmAddressNotice() {
       >
         ×
       </button>
+    </div>
+  );
+}
+
+/*
+  One quiet line when this device does not hold the family key (ADR 0001,
+  #210). Nothing is encrypted yet, so nothing is broken — but the doors
+  back in should be one click away rather than a support ticket: a
+  waiting re-admission link, or the recovery code. Dismissable for the tab.
+*/
+function LockedKeyNotice() {
+  const { status, pendingHandoffs } = useKeys();
+  const [dismissed, setDismissed] = useState(false);
+  const [entering, setEntering] = useState(false);
+
+  if (status !== 'locked' || dismissed) return null;
+  const waiting = pendingHandoffs[0];
+
+  return (
+    <div className="mx-4 mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-card border border-line bg-surface-2 px-4 py-2.5 text-sm md:mx-6">
+      <span className="text-ink">
+        {waiting
+          ? t('A re-admission link from {name} is waiting — open it on this device.', {
+              name: waiting.created_by_name ?? t('a family member'),
+            })
+          : t('This device does not hold the family key. Ask a family member for a re-admission link, or enter the recovery code.')}
+      </span>
+      <button type="button" onClick={() => setEntering(true)} className="font-medium text-accent underline">
+        {t('Enter recovery code')}
+      </button>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        className="ml-auto text-muted hover:text-ink"
+        aria-label={t('Hide')}
+      >
+        ×
+      </button>
+      {entering && <RecoveryCodeDialog onClose={() => setEntering(false)} />}
     </div>
   );
 }

--- a/web/src/components/KeysSection.tsx
+++ b/web/src/components/KeysSection.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { t } from '../lib/i18n';
+import { useAuth } from '../lib/auth';
+import { useKeys } from '../lib/family-key';
+import { RecoveryCodeDialog, RecoveryCodePanel } from './RecoveryCode';
+
+/*
+  Settings → Family key. Every member sees where this device stands and can
+  lock it; adults holding the key can mint a new recovery code. Nothing here
+  reveals the key: the code is shown exactly once when made, like the first.
+*/
+export function KeysSection() {
+  const { user } = useAuth();
+  const { status, lock, newRecoveryCode, pendingHandoffs } = useKeys();
+  const [entering, setEntering] = useState(false);
+  const [fresh, setFresh] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const rowButton =
+    'rounded-lg border border-line px-3 py-1.5 text-sm text-ink transition-colors hover:bg-surface-2 disabled:opacity-50';
+
+  async function mint() {
+    setBusy(true);
+    setError(null);
+    try {
+      setFresh(await newRecoveryCode());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('Something went wrong'));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const statusLine =
+    status === 'unlocked'
+      ? t('This device holds the family key.')
+      : status === 'locked'
+        ? pendingHandoffs.length > 0
+          ? t('A re-admission link from {name} is waiting — open it on this device.', {
+              name: pendingHandoffs[0]!.created_by_name ?? t('a family member'),
+            })
+          : t('This device does not hold the family key. Ask a family member for a re-admission link, or enter the recovery code.')
+        : status === 'absent'
+          ? t('The family has no key yet. It is created when an adult member signs in with a password.')
+          : '…';
+
+  return (
+    <section className="rounded-card border border-line bg-surface p-5">
+      <h2 className="eyebrow mb-4">{t('Family key')}</h2>
+      <p className="text-sm text-muted">
+        {t('The key that will encrypt what the family writes, so that only the family can read it. It lives in your browsers; the server holds it only wrapped under each member’s password.')}
+      </p>
+
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-line pt-4">
+        <p className="text-sm text-ink">{statusLine}</p>
+        {status === 'unlocked' && (
+          <button type="button" className={rowButton} onClick={() => void lock()}>
+            {t('Lock this device')}
+          </button>
+        )}
+        {status === 'locked' && (
+          <button type="button" className={rowButton} onClick={() => setEntering(true)}>
+            {t('Enter recovery code')}
+          </button>
+        )}
+      </div>
+
+      {status === 'unlocked' && user?.role !== 'kid' && (
+        <div className="mt-4 border-t border-line pt-4">
+          {fresh ? (
+            <RecoveryCodePanel code={fresh} onDone={() => setFresh(null)} doneLabel={t('Recorded, hide')} />
+          ) : (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-ink">{t('Recovery code')}</p>
+                <p className="text-xs text-muted">
+                  {t('Lost the paper? Make a new one — the old code stops working the moment this one is shown.')}
+                </p>
+              </div>
+              <button type="button" className={rowButton} disabled={busy} onClick={() => void mint()}>
+                {t('New recovery code')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && <p className="mt-3 text-sm text-urgent">{error}</p>}
+      {entering && <RecoveryCodeDialog onClose={() => setEntering(false)} />}
+    </section>
+  );
+}

--- a/web/src/components/PeopleSection.tsx
+++ b/web/src/components/PeopleSection.tsx
@@ -6,6 +6,7 @@ import { EntityDialog } from './EntityDialog';
 import { dialogField, dialogLabel, inlineDanger, useDialogs } from './Dialog';
 import { reportFailure } from '../lib/failures';
 import { useAuth } from '../lib/auth';
+import { useKeys } from '../lib/family-key';
 
 interface ManagedUser {
   id: string;
@@ -18,6 +19,8 @@ interface ManagedUser {
   must_change_password: number;
   /** null where confirming an address means nothing — a self-hosted hub. */
   email_verified: boolean | null;
+  /** Whether the member still has a live key envelope — a password reset kills it (#210). */
+  key_envelope: number;
 }
 
 const ROLE_LABEL: Record<ManagedUser['role'], string> = {
@@ -26,14 +29,53 @@ const ROLE_LABEL: Record<ManagedUser['role'], string> = {
   kid: t('Kid'),
 };
 
+/**
+ * A re-admission link is shown exactly once too — and it is the key to the
+ * house: the secret that opens it travels only inside the link (#210).
+ */
+function HandoffOnce({ name, link, onClose }: { name: string; link: string; onClose: () => void }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+    } catch {
+      // No clipboard — the link is on screen
+    }
+  }
+  return (
+    <div className="mb-5 rounded-card border border-accent bg-accent-soft p-4">
+      <p className="text-sm font-medium text-ink">{t('Re-admission link for {name}', { name })}</p>
+      <div className="my-3 flex items-center gap-2 rounded-lg border border-line bg-surface p-3">
+        <code className="min-w-0 flex-1 truncate font-mono text-xs text-ink">{link}</code>
+        <button type="button" onClick={() => void copy()} className="shrink-0 text-xs font-medium text-accent underline">
+          {copied ? t('Copied') : t('Copy')}
+        </button>
+      </div>
+      <p className="text-xs text-muted">
+        {t('This link is the family key itself: send it over a channel you trust, and only to {name}. They open it signed in, on the device that should hold the key. It works for a week; a newer link replaces it.', { name })}
+      </p>
+      <button type="button" onClick={onClose} className="mt-3 text-sm font-medium text-accent underline underline-offset-2">
+        {t('Recorded, hide')}
+      </button>
+    </div>
+  );
+}
+
 /** The password is shown exactly once — after that only the owner knows it. */
-function PasswordOnce({ password, onClose }: { password: string; onClose: () => void }) {
+function PasswordOnce({ password, keyLost, onClose }: { password: string; keyLost: boolean; onClose: () => void }) {
   return (
     <div className="mb-5 rounded-card border border-accent bg-accent-soft p-4">
       <p className="text-sm font-medium text-ink">{t('Password created. It is shown only once.')}</p>
       <p className="my-3 font-mono text-lg tracking-wide text-ink select-all">{password}</p>
       <p className="text-xs text-muted">
         {t('Hand it to the account owner. On first sign-in they will be asked to set their own password.')}
+        {keyLost && (
+          <>
+            {' '}
+            {t('The family key did not survive the reset — once they have signed in with the new password, send them a re-admission link from this list.')}
+          </>
+        )}
       </p>
       <button
         type="button"
@@ -170,6 +212,10 @@ export function PeopleSection() {
   const [address, setAddress] = useState('');
   const dialogs = useDialogs();
   const { user, refresh } = useAuth();
+  const keys = useKeys();
+  const [handoff, setHandoff] = useState<{ name: string; link: string } | null>(null);
+  // Whether a password reset also costs the member their key: only once the family has one
+  const familyHasKey = keys.status === 'unlocked' || keys.status === 'locked';
 
   const load = () => api.get<ManagedUser[]>('/users').then(setUsers).catch(() => setUsers([]));
   useEffect(() => {
@@ -192,6 +238,14 @@ export function PeopleSection() {
     }
   }
 
+  async function readmit(member: ManagedUser) {
+    try {
+      setHandoff({ name: member.name, link: await keys.handoffLinkFor(member.id) });
+    } catch (err) {
+      reportFailure(err instanceof Error ? err.message : t('Could not save'));
+    }
+  }
+
   async function toggle(user: ManagedUser) {
     try {
       await api.post(`/users/${user.id}/toggle`, {});
@@ -206,7 +260,8 @@ export function PeopleSection() {
       <h2 className="eyebrow mb-4">{t('People')}</h2>
       <InvitesBlock />
 
-      {password && <PasswordOnce password={password} onClose={() => setPassword(null)} />}
+      {password && <PasswordOnce password={password} keyLost={familyHasKey} onClose={() => setPassword(null)} />}
+      {handoff && <HandoffOnce name={handoff.name} link={handoff.link} onClose={() => setHandoff(null)} />}
 
       {users === null ? (
         <div className="h-32 animate-pulse rounded-card bg-surface-3" />
@@ -242,6 +297,13 @@ export function PeopleSection() {
                         {t('unconfirmed')}
                       </span>
                     )}
+                    {/* The family has a key and this member has no door of
+                        their own to it: a reset took it (#210) */}
+                    {familyHasKey && !u.key_envelope && !u.disabled_at && (
+                      <span className="shrink-0 rounded-full border border-line px-1.5 py-0.5">
+                        {t('no key')}
+                      </span>
+                    )}
                   </p>
                 </div>
               </div>
@@ -263,6 +325,16 @@ export function PeopleSection() {
               >
                 {t('Reset password')}
               </button>
+              {keys.status === 'unlocked' && u.id !== user?.id && !u.disabled_at && (
+                <button
+                  type="button"
+                  onClick={() => void readmit(u)}
+                  className="text-xs text-accent underline underline-offset-2"
+                  title={t('Hand this member the family key through a one-time link')}
+                >
+                  {t('Re-admit')}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => void toggle(u)}

--- a/web/src/components/RecoveryCode.tsx
+++ b/web/src/components/RecoveryCode.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import { t } from '../lib/i18n';
+import { Modal, dialogField, dialogGhost, dialogPrimary } from './Dialog';
+import { doorMessage, useKeys } from '../lib/family-key';
+
+/*
+  The recovery code, shown once (ADR 0001, #210).
+
+  It is the family's last door: after a lost password *and* no other member
+  to re-admit you, this code is the only thing that still opens the key.
+  So it is not a toast and not a help page — a screen that waits for an
+  explicit "I wrote it down", with the consequence said in plain words.
+*/
+export function RecoveryCodePanel({
+  code,
+  onDone,
+  doneLabel,
+}: {
+  code: string;
+  onDone: () => void;
+  doneLabel?: string;
+}) {
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+    } catch {
+      // No clipboard here — the code is on screen to be written down anyway
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted">
+        {t('This is your family’s recovery code. It opens the family key when a password no longer can — after a reset, or on a new device with nobody around to let you in.')}
+      </p>
+      <p className="select-all rounded-lg border border-line bg-surface-2 px-3 py-3 text-center font-mono text-lg tracking-wider text-ink">
+        {code}
+      </p>
+      <div className="flex items-center justify-between gap-3">
+        <button type="button" onClick={() => void copy()} className="text-sm text-accent underline underline-offset-2">
+          {copied ? t('Copied') : t('Copy')}
+        </button>
+        <span className="text-xs text-muted">{t('Case and dashes do not matter when typing it back.')}</span>
+      </div>
+      <label className="flex items-start gap-2.5 text-sm text-ink">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(e) => setAcknowledged(e.target.checked)}
+          className="mt-0.5 size-4 shrink-0 accent-[var(--c-accent)]"
+        />
+        <span>
+          {t('I have written it down somewhere safe. I understand that without my password and without this code, what the family encrypts is gone for good — nobody can recover it, including the people who run Neiliro.')}
+        </span>
+      </label>
+      <button
+        type="button"
+        disabled={!acknowledged}
+        onClick={onDone}
+        className="w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+      >
+        {doneLabel ?? t('Continue')}
+      </button>
+    </div>
+  );
+}
+
+/** The full-screen moment right after the key is created. */
+export function RecoveryCodeScreen({ code, onDone }: { code: string; onDone: () => void }) {
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-surface-2 px-5">
+      <div className="w-full max-w-md rounded-card border border-line bg-surface p-6">
+        <h1 className="eyebrow mb-5">{t('Your family now has a key')}</h1>
+        <p className="mb-4 text-sm text-muted">
+          {t('Encryption of what the family writes starts with this key. It was created in this browser and never leaves it unprotected: the server only holds it wrapped under your password.')}
+        </p>
+        <RecoveryCodePanel code={code} onDone={onDone} />
+      </div>
+    </div>
+  );
+}
+
+/** Typing the code back in — from the locked notice or from Settings. */
+export function RecoveryCodeDialog({ onClose }: { onClose: () => void }) {
+  const { unlockWithRecoveryCode } = useKeys();
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    if (!code.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await unlockWithRecoveryCode(code);
+      onClose();
+    } catch (err) {
+      setError(t(doorMessage(err, 'Something went wrong')));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={t('Recovery code')}
+      onClose={onClose}
+      onSubmit={() => void submit()}
+      footer={
+        <>
+          <button type="button" onClick={onClose} className={dialogGhost}>
+            {t('Cancel')}
+          </button>
+          <button type="button" onClick={() => void submit()} disabled={busy || !code.trim()} className={dialogPrimary}>
+            {busy ? t('Checking') : t('Unlock')}
+          </button>
+        </>
+      }
+    >
+      <p className="mb-3 text-sm text-muted">
+        {t('The code shown when the family key was created. It opens the key on this device and wraps it under your current password, so you will not need it here again.')}
+      </p>
+      <input
+        autoFocus
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XX"
+        autoCapitalize="characters"
+        autoComplete="off"
+        spellCheck={false}
+        className={`${dialogField} font-mono tracking-wider`}
+      />
+      {error && <p className="mt-2 text-sm text-urgent">{error}</p>}
+    </Modal>
+  );
+}

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react';
 import { loginBody } from './credentials';
+import { defaultKeyStore, forgetWrapKey } from './crypto';
 import { ApiError, api } from './api';
 import { lang } from './i18n';
 
@@ -91,6 +92,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await api.post('/auth/logout', {}).catch(() => {});
     } finally {
       setUser(null);
+      // The family key leaves with the session (ADR 0001): a shared device
+      // handed to the next person must not still hold it. The next sign-in
+      // derives the wrap key again and opens the envelope.
+      forgetWrapKey();
+      await defaultKeyStore().lock();
       // The service worker's offline caches hold family data and the
       // last session answer — signing out must not leave them behind
       if ('caches' in window) {

--- a/web/src/lib/crypto/handoff.ts
+++ b/web/src/lib/crypto/handoff.ts
@@ -1,0 +1,39 @@
+import { randomBytes, toBase64url, fromBase64url } from './encoding';
+import { expandSecret, importWrapKey } from './kdf';
+
+/*
+  Handing the family key to another browser (ADR 0001, #210 and #212).
+
+  One member wraps the key under a wrap key derived from a fresh random
+  secret; the wrapped envelope goes to the server, the secret goes into the
+  fragment of a link (`#k=…`), which browsers never send with a request.
+  Whoever opens the link holds both halves and nothing on the server ever
+  held the second. Two doors use it: re-admitting a member whose envelope
+  died with a password reset, and (#212) giving an invited member the key.
+
+  The secret is 32 random bytes — full entropy, so HKDF straight to the
+  wrap key, no stretching, the same shape as the recovery code.
+*/
+const HANDOFF_INFO = 'neiliro/handoff/v1';
+export const HANDOFF_PARAM = 'k';
+
+export function newHandoffSecret(): string {
+  return toBase64url(randomBytes(32));
+}
+
+export async function handoffWrapKey(secret: string): Promise<CryptoKey> {
+  const bytes = fromBase64url(secret);
+  if (bytes.length !== 32) throw new Error('Not a handoff secret');
+  return importWrapKey(await expandSecret(bytes, HANDOFF_INFO));
+}
+
+/** The secret from a link's fragment, or null when the link lost it. */
+export function handoffSecretFromFragment(hash: string): string | null {
+  const params = new URLSearchParams(hash.replace(/^#/, ''));
+  const secret = params.get(HANDOFF_PARAM);
+  return secret && /^[A-Za-z0-9_-]{43}$/.test(secret) ? secret : null;
+}
+
+export function fragmentFor(secret: string): string {
+  return `#${HANDOFF_PARAM}=${secret}`;
+}

--- a/web/src/lib/crypto/index.ts
+++ b/web/src/lib/crypto/index.ts
@@ -8,6 +8,8 @@
     files.ts     the chunked file format for attachments
     recovery.ts  the recovery code and its wrap key
     keystore.ts  the family key between page loads (IndexedDB), and "Lock"
+    x25519.ts    the family's key pair, derived from the family key (#223 seals mail to it)
+    handoff.ts   passing the key to another browser through a link's fragment (#210, #212)
 
   The server never holds a wrapKey, the family key, or a recovery code.
   It stores envelopes it cannot open and ciphertext it cannot read, and
@@ -19,4 +21,6 @@ export * from './envelope';
 export * from './files';
 export * from './recovery';
 export * from './keystore';
+export * from './x25519';
+export * from './handoff';
 export * from './session';

--- a/web/src/lib/crypto/keys.test.ts
+++ b/web/src/lib/crypto/keys.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  exportFamilyKey,
+  familyPrivateKey,
+  familyPublicKey,
+  fragmentFor,
+  generateFamilyKey,
+  generateRecoveryCode,
+  handoffSecretFromFragment,
+  handoffWrapKey,
+  importFamilyKey,
+  newHandoffSecret,
+  publicKeyBytes,
+  recoveryWrapKey,
+  unwrapFamilyKey,
+  wrapFamilyKey,
+} from './index';
+import { deriveCredentialKeys, saltFromHex } from './kdf';
+
+/*
+  The doors to the family key (#210), each as the browser walks it.
+  Node 24's WebCrypto has X25519, so the derivation runs here as in a browser.
+*/
+const SALT = saltFromHex('00112233445566778899aabbccddeeff');
+const FAST = 1000; // iterations: tests exercise the flow, not the cost
+
+describe('the X25519 pair derived from the family key', () => {
+  it('is deterministic, and the public half is what a peer computes from the private one', async () => {
+    const family = await generateFamilyKey();
+    const raw = await exportFamilyKey(family);
+    const again = await importFamilyKey(raw);
+    const pub1 = await familyPublicKey(family);
+    const pub2 = await familyPublicKey(again);
+    expect(pub1).toBe(pub2);
+    expect(publicKeyBytes(pub1)).toHaveLength(32);
+
+    // A different family key, a different pair
+    expect(await familyPublicKey(await generateFamilyKey())).not.toBe(pub1);
+
+    // The pair actually agrees: ECDH from the private half against an
+    // ephemeral peer equals ECDH from the peer against the exported public half
+    const priv = await familyPrivateKey(family);
+    const peer = (await crypto.subtle.generateKey({ name: 'X25519' }, true, ['deriveBits'])) as CryptoKeyPair;
+    const familyPub = await crypto.subtle.importKey('raw', publicKeyBytes(pub1), { name: 'X25519' }, true, []);
+    const a = new Uint8Array(await crypto.subtle.deriveBits({ name: 'X25519', public: peer.publicKey }, priv, 256));
+    const b = new Uint8Array(await crypto.subtle.deriveBits({ name: 'X25519', public: familyPub }, peer.privateKey, 256));
+    expect(Array.from(a)).toEqual(Array.from(b));
+  });
+});
+
+describe('handing the key on through a link', () => {
+  it('the secret rides in the fragment, opens the handoff, and nothing else does', async () => {
+    const family = await generateFamilyKey();
+    const secret = newHandoffSecret();
+    const place = { kind: 'handoff', owner: 'user-ann' };
+    const sealed = await wrapFamilyKey(family, await handoffWrapKey(secret), place);
+
+    const link = `https://smiths.example/readmit?id=abc${fragmentFor(secret)}`;
+    const fromLink = handoffSecretFromFragment(new URL(link).hash);
+    expect(fromLink).toBe(secret);
+    const opened = await unwrapFamilyKey(sealed, await handoffWrapKey(fromLink!), place);
+    expect(Array.from(await exportFamilyKey(opened))).toEqual(Array.from(await exportFamilyKey(family)));
+
+    // Another secret, or the same secret for another member, opens nothing
+    await expect(unwrapFamilyKey(sealed, await handoffWrapKey(newHandoffSecret()), place)).rejects.toThrow();
+    await expect(
+      unwrapFamilyKey(sealed, await handoffWrapKey(secret), { kind: 'handoff', owner: 'user-bob' }),
+    ).rejects.toThrow();
+    // A link that lost its fragment has no secret
+    expect(handoffSecretFromFragment('')).toBeNull();
+    expect(handoffSecretFromFragment('#k=short')).toBeNull();
+  });
+});
+
+describe('the three doors open the same key', () => {
+  it('password envelope, recovery envelope and a re-wrap after a new password', async () => {
+    const family = await generateFamilyKey();
+    const raw = Array.from(await exportFamilyKey(family));
+
+    const old = await deriveCredentialKeys('old password 123', SALT, FAST);
+    const mine = await wrapFamilyKey(family, old.wrapKey, { kind: 'password', owner: 'user-sam' });
+    const code = generateRecoveryCode();
+    const recovery = await wrapFamilyKey(family, await recoveryWrapKey(code), { kind: 'recovery', owner: 'family' });
+
+    // Sign-in with the password opens the member's envelope
+    const viaPassword = await unwrapFamilyKey(mine, old.wrapKey, { kind: 'password', owner: 'user-sam' });
+    expect(Array.from(await exportFamilyKey(viaPassword))).toEqual(raw);
+
+    // A password reset: the new wrap key does not open the old envelope...
+    const fresh = await deriveCredentialKeys('new password 456', SALT, FAST);
+    await expect(unwrapFamilyKey(mine, fresh.wrapKey, { kind: 'password', owner: 'user-sam' })).rejects.toThrow();
+    // ...the recovery code does, and the key is re-wrapped under the new password
+    const viaCode = await unwrapFamilyKey(recovery, await recoveryWrapKey(code), { kind: 'recovery', owner: 'family' });
+    const rewrapped = await wrapFamilyKey(viaCode, fresh.wrapKey, { kind: 'password', owner: 'user-sam' });
+    const opened = await unwrapFamilyKey(rewrapped, fresh.wrapKey, { kind: 'password', owner: 'user-sam' });
+    expect(Array.from(await exportFamilyKey(opened))).toEqual(raw);
+
+    // Another member's password never opens it
+    const ann = await deriveCredentialKeys('old password 123', saltFromHex('ffeeddccbbaa99887766554433221100'), FAST);
+    await expect(unwrapFamilyKey(mine, ann.wrapKey, { kind: 'password', owner: 'user-sam' })).rejects.toThrow();
+  });
+});

--- a/web/src/lib/crypto/x25519.ts
+++ b/web/src/lib/crypto/x25519.ts
@@ -1,0 +1,53 @@
+import { concat, fromBase64url, toBase64url, type Bytes } from './encoding';
+import { exportFamilyKey } from './envelope';
+
+/*
+  The family's X25519 pair (ADR 0001, #210), used from #223 on: the server
+  holds the public half and seals incoming mail to it; only a browser
+  holding the family key can open what was sealed.
+
+  The private half is not a second secret to store. It is derived from the
+  family key with HKDF under its own info string, so the one envelope per
+  member keeps protecting everything, and there is nothing to re-wrap when
+  the pair is first needed. The derivation is versioned in the info string:
+  a different curve some day means a different string, not a guess.
+
+  WebCrypto imports an X25519 private key only in PKCS#8, so the 32 derived
+  bytes are wrapped in the fixed PKCS#8 header for that algorithm (RFC 8410).
+*/
+const X25519_INFO = 'neiliro/x25519/v1';
+
+// SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.110 }, OCTET STRING { OCTET STRING <32 bytes> } }
+const PKCS8_X25519_PREFIX = fromBase64url('MC4CAQAwBQYDK2VuBCIEIA');
+
+async function privateSeed(familyKey: CryptoKey): Promise<Bytes> {
+  const raw = await exportFamilyKey(familyKey);
+  const hkdf = await crypto.subtle.importKey('raw', raw, 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: new TextEncoder().encode(X25519_INFO) },
+    hkdf,
+    256,
+  );
+  raw.fill(0);
+  return new Uint8Array(bits);
+}
+
+/** The family's X25519 private key, derived on demand and never stored. */
+export async function familyPrivateKey(familyKey: CryptoKey): Promise<CryptoKey> {
+  const seed = await privateSeed(familyKey);
+  const pkcs8 = concat(PKCS8_X25519_PREFIX, seed);
+  seed.fill(0);
+  return crypto.subtle.importKey('pkcs8', pkcs8, { name: 'X25519' }, true, ['deriveBits']);
+}
+
+/** The public half, base64url of 32 bytes — what the server stores. */
+export async function familyPublicKey(familyKey: CryptoKey): Promise<string> {
+  const priv = await familyPrivateKey(familyKey);
+  // The JWK of an X25519 private key carries its public point as `x`
+  const jwk = await crypto.subtle.exportKey('jwk', priv);
+  if (!jwk.x) throw new Error('X25519 export without a public point');
+  return jwk.x;
+}
+
+export const publicKeyBytes = (publicKey: string): Bytes => fromBase64url(publicKey);
+export const publicKeyString = (bytes: Bytes): string => toBase64url(bytes);

--- a/web/src/lib/family-key.tsx
+++ b/web/src/lib/family-key.tsx
@@ -1,0 +1,318 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { ApiError, api } from './api';
+import { useAuth } from './auth';
+import {
+  currentWrapKey,
+  defaultKeyStore,
+  familyPublicKey,
+  forgetWrapKey,
+  fragmentFor,
+  generateFamilyKey,
+  generateRecoveryCode,
+  handoffWrapKey,
+  newHandoffSecret,
+  recoveryWrapKey,
+  unwrapFamilyKey,
+  wrapFamilyKey,
+  type KeyStore,
+} from './crypto';
+
+/*
+  The family key's life in this browser (ADR 0001, #210).
+
+  Four states. `absent` — the family has no key yet (an account from
+  before the key existed, signed in from a kid account or without a wrap
+  key; an adult with a wrap key never sees this, they create the key).
+  `unlocked` — this device holds the key. `locked` — the family has a key
+  and this device does not: the member's envelope died with a password
+  reset, or the device is new. `loading` — not yet known.
+
+  Three doors into `unlocked`: the member's own password envelope (opened
+  with the wrap key sign-in left in memory), a handoff link from another
+  member, the recovery code. Whichever opens, the key is saved on the
+  device (crypto/keystore.ts) and — when a wrap key is at hand — re-wrapped
+  into a fresh password envelope, so the next sign-in needs no door at all.
+
+  Nothing is encrypted yet in phase 1: `locked` shows a notice, never a
+  wall. The one screen that does block is the recovery code, once, at the
+  moment the key is created — a code nobody wrote down is a family of one
+  password away from losing every word.
+*/
+
+export type KeyStatus = 'loading' | 'absent' | 'unlocked' | 'locked';
+
+export interface Handoff {
+  id: string;
+  envelope: string;
+  created_at: string;
+  created_by_name: string | null;
+}
+
+export interface KeysResponse {
+  family: { public_key: string; created_at: string } | null;
+  password_envelope: string | null;
+  recovery_envelope: string | null;
+  handoffs: Handoff[];
+}
+
+export const RECOVERY_PLACE = { kind: 'recovery', owner: 'family' } as const;
+export const passwordPlace = (userId: string) => ({ kind: 'password', owner: userId });
+export const handoffPlace = (userId: string) => ({ kind: 'handoff', owner: userId });
+
+export class KeyDoorError extends Error {}
+
+/** What to show a person when a door did not open. Door errors are dictionary keys; anything else is shown as is. */
+export function doorMessage(err: unknown, fallback: string): string {
+  if (err instanceof KeyDoorError) return err.message;
+  return err instanceof Error ? err.message : fallback;
+}
+
+interface KeysState {
+  status: KeyStatus;
+  familyKey: CryptoKey | null;
+  /** A code just minted — shown once, acknowledged, then gone from memory. */
+  freshRecoveryCode: string | null;
+  acknowledgeRecoveryCode: () => void;
+  /** Handoff links waiting for this member, to be opened on this device. */
+  pendingHandoffs: Handoff[];
+  unlockWithRecoveryCode: (code: string) => Promise<void>;
+  unlockWithHandoff: (handoffId: string, secret: string) => Promise<void>;
+  /** A re-admission link for another member: the key wrapped under a secret only the link carries. */
+  handoffLinkFor: (userId: string) => Promise<string>;
+  /** Mint a new recovery code; the old one stops working. Returned once. */
+  newRecoveryCode: () => Promise<string>;
+  /** Forget the key on this device — the next sign-in derives its way back in. */
+  lock: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const KeysContext = createContext<KeysState | null>(null);
+
+export function KeyProvider({ children, store }: { children: ReactNode; store?: KeyStore }) {
+  const { user } = useAuth();
+  const keystore = useMemo(() => store ?? defaultKeyStore(), [store]);
+  const [status, setStatus] = useState<KeyStatus>('loading');
+  const [familyKey, setFamilyKey] = useState<CryptoKey | null>(null);
+  const [freshRecoveryCode, setFreshRecoveryCode] = useState<string | null>(null);
+  const [pendingHandoffs, setPendingHandoffs] = useState<Handoff[]>([]);
+  // A key created in one run of sync must not be created twice by a re-render racing it
+  const creating = useRef(false);
+
+  const userId = user?.id ?? null;
+  const role = user?.role ?? null;
+  const mustChange = Boolean(user?.must_change_password);
+
+  const hold = useCallback(
+    async (key: CryptoKey) => {
+      await keystore.save(key);
+      setFamilyKey(key);
+      setStatus('unlocked');
+    },
+    [keystore],
+  );
+
+  /** Wrap the held key under the wrap key sign-in left behind, if any, and store it as this member's envelope. */
+  const writeOwnEnvelope = useCallback(
+    async (key: CryptoKey) => {
+      const wrap = currentWrapKey();
+      if (!wrap || !userId) return;
+      await api.put('/keys/envelope', { envelope: await wrapFamilyKey(key, wrap, passwordPlace(userId)) });
+    },
+    [userId],
+  );
+
+  /** Create the family key. False when another browser beat this one to it. */
+  const create = useCallback(
+    async (wrap: CryptoKey): Promise<boolean> => {
+      if (creating.current || !userId) return false;
+      creating.current = true;
+      try {
+        const key = await generateFamilyKey();
+        const code = generateRecoveryCode();
+        try {
+          await api.post('/keys', {
+            public_key: await familyPublicKey(key),
+            envelope: await wrapFamilyKey(key, wrap, passwordPlace(userId)),
+            recovery_envelope: await wrapFamilyKey(key, await recoveryWrapKey(code), RECOVERY_PLACE),
+          });
+        } catch (err) {
+          // Somebody else's browser got there first: their key is the family's
+          if (err instanceof ApiError && err.status === 409) return false;
+          throw err;
+        }
+        await hold(key);
+        setFreshRecoveryCode(code);
+        return true;
+      } finally {
+        creating.current = false;
+      }
+    },
+    [hold, userId],
+  );
+
+  const sync = useCallback(async () => {
+    if (!userId || mustChange) {
+      setStatus('loading');
+      return;
+    }
+    const stored = await keystore.load();
+    let keys: KeysResponse;
+    try {
+      keys = await api.get<KeysResponse>('/keys');
+    } catch {
+      // Offline or a server that predates the key: what the device holds is the truth for now
+      if (stored) {
+        setFamilyKey(stored);
+        setStatus('unlocked');
+      } else {
+        setStatus('loading');
+      }
+      return;
+    }
+    setPendingHandoffs(keys.handoffs);
+    const wrap = currentWrapKey();
+
+    if (!keys.family) {
+      if (!wrap || role === 'kid') {
+        setFamilyKey(null);
+        setStatus('absent');
+        return;
+      }
+      if (await create(wrap)) return;
+      // Another browser created it between the two requests: read again, the
+      // envelopes below now exist
+      keys = await api.get<KeysResponse>('/keys');
+    }
+
+    if (stored) {
+      setFamilyKey(stored);
+      setStatus('unlocked');
+      // A reset elsewhere killed the envelope while this device kept the key:
+      // the password just typed can wrap it again, no door needed
+      if (!keys.password_envelope && wrap) await writeOwnEnvelope(stored);
+      return;
+    }
+
+    if (keys.password_envelope && wrap) {
+      try {
+        await hold(await unwrapFamilyKey(keys.password_envelope, wrap, passwordPlace(userId)));
+        return;
+      } catch {
+        // An envelope this password does not open: treated as no envelope
+      }
+    }
+    setFamilyKey(null);
+    setStatus('locked');
+  }, [create, hold, keystore, mustChange, role, userId, writeOwnEnvelope]);
+
+  useEffect(() => {
+    void sync();
+  }, [sync]);
+
+  const unlockWithRecoveryCode = useCallback(
+    async (code: string) => {
+      const keys = await api.get<KeysResponse>('/keys');
+      if (!keys.recovery_envelope) throw new KeyDoorError('The family has no recovery code');
+      let key: CryptoKey;
+      try {
+        key = await unwrapFamilyKey(keys.recovery_envelope, await recoveryWrapKey(code), RECOVERY_PLACE);
+      } catch {
+        throw new KeyDoorError('That is not the recovery code');
+      }
+      await hold(key);
+      await writeOwnEnvelope(key);
+    },
+    [hold, writeOwnEnvelope],
+  );
+
+  const unlockWithHandoff = useCallback(
+    async (handoffId: string, secret: string) => {
+      if (!userId) throw new KeyDoorError('Sign in first');
+      const keys = await api.get<KeysResponse>('/keys');
+      const handoff = keys.handoffs.find((h) => h.id === handoffId);
+      if (!handoff) throw new KeyDoorError('This link has been used or revoked — ask for a new one');
+      let key: CryptoKey;
+      try {
+        key = await unwrapFamilyKey(handoff.envelope, await handoffWrapKey(secret), handoffPlace(userId));
+      } catch {
+        throw new KeyDoorError('This link does not open the key — ask for a new one');
+      }
+      await hold(key);
+      await writeOwnEnvelope(key);
+      // The handoff has done its job. Writing the envelope retires it too,
+      // but a browser without a wrap key (a reload, Google-only) writes none
+      await api.delete(`/keys/handoff/${handoffId}`).catch(() => {});
+      setPendingHandoffs([]);
+    },
+    [hold, userId, writeOwnEnvelope],
+  );
+
+  const handoffLinkFor = useCallback(
+    async (targetId: string) => {
+      if (!familyKey) throw new KeyDoorError('This device does not hold the key');
+      const secret = newHandoffSecret();
+      const envelope = await wrapFamilyKey(familyKey, await handoffWrapKey(secret), handoffPlace(targetId));
+      const { id } = await api.post<{ id: string }>('/keys/handoff', { user_id: targetId, envelope });
+      return `${window.location.origin}/readmit?handoff=${id}${fragmentFor(secret)}`;
+    },
+    [familyKey],
+  );
+
+  const newRecoveryCode = useCallback(async () => {
+    if (!familyKey) throw new KeyDoorError('This device does not hold the key');
+    const code = generateRecoveryCode();
+    await api.post('/keys/recovery', {
+      recovery_envelope: await wrapFamilyKey(familyKey, await recoveryWrapKey(code), RECOVERY_PLACE),
+    });
+    return code;
+  }, [familyKey]);
+
+  // Signing out forgets the key on this device (lib/auth.tsx, logout) — not
+  // an unmount effect here: in development React mounts effects twice, and
+  // a cleanup that forgets the wrap key would run right after sign-in.
+  const lock = useCallback(async () => {
+    await keystore.lock();
+    forgetWrapKey();
+    setFamilyKey(null);
+    setStatus((s) => (s === 'absent' ? s : 'locked'));
+  }, [keystore]);
+
+  const acknowledgeRecoveryCode = useCallback(() => setFreshRecoveryCode(null), []);
+
+  const value = useMemo<KeysState>(
+    () => ({
+      status,
+      familyKey,
+      freshRecoveryCode,
+      acknowledgeRecoveryCode,
+      pendingHandoffs,
+      unlockWithRecoveryCode,
+      unlockWithHandoff,
+      handoffLinkFor,
+      newRecoveryCode,
+      lock,
+      refresh: sync,
+    }),
+    [
+      status,
+      familyKey,
+      freshRecoveryCode,
+      acknowledgeRecoveryCode,
+      pendingHandoffs,
+      unlockWithRecoveryCode,
+      unlockWithHandoff,
+      handoffLinkFor,
+      newRecoveryCode,
+      lock,
+      sync,
+    ],
+  );
+
+  return <KeysContext.Provider value={value}>{children}</KeysContext.Provider>;
+}
+
+export function useKeys(): KeysState {
+  const ctx = useContext(KeysContext);
+  if (!ctx) throw new Error('useKeys called outside KeyProvider');
+  return ctx;
+}

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -885,6 +885,68 @@ export const ru: Record<string, string> = {
   // ── Founder invitation: the hosted first run behind a mailed token (#157) ──
   'The address the invitation came to — already confirmed for password recovery.': 'Адрес, на который пришло приглашение — уже подтверждён для восстановления пароля.',
   'A different address than the invitation came to: we will ask you to confirm it.': 'Адрес отличается от того, куда пришло приглашение: мы попросим его подтвердить.',
+  // ── Family key (ADR 0001, #210) ──────────────────────────────────────────
+  'A re-admission link from {name} is waiting — open it on this device.':
+    'Вас ждёт ссылка на возврат ключа от {name} — откройте её на этом устройстве.',
+  'a family member': 'члена семьи',
+  'This device does not hold the family key. Ask a family member for a re-admission link, or enter the recovery code.':
+    'На этом устройстве нет ключа семьи. Попросите у члена семьи ссылку на возврат ключа или введите код восстановления.',
+  'Enter recovery code': 'Ввести код восстановления',
+  'This device holds the family key.': 'Ключ семьи на этом устройстве есть.',
+  'The family has no key yet. It is created when an adult member signs in with a password.':
+    'У семьи пока нет ключа. Он создаётся, когда взрослый участник входит с паролем.',
+  'Family key': 'Ключ семьи',
+  'The key that will encrypt what the family writes, so that only the family can read it. It lives in your browsers; the server holds it only wrapped under each member’s password.':
+    'Ключ, которым будет шифроваться всё, что пишет семья, — чтобы прочитать это могла только семья. Он живёт в ваших браузерах; сервер хранит его только запечатанным под пароль каждого участника.',
+  'Lock this device': 'Запереть это устройство',
+  'Recovery code': 'Код восстановления',
+  'Lost the paper? Make a new one — the old code stops working the moment this one is shown.':
+    'Потеряли бумажку? Сделайте новый — старый код перестаёт работать в момент показа нового.',
+  'New recovery code': 'Новый код восстановления',
+  'Re-admission link for {name}': 'Ссылка на возврат ключа для {name}',
+  'This link is the family key itself: send it over a channel you trust, and only to {name}. They open it signed in, on the device that should hold the key. It works for a week; a newer link replaces it.':
+    'Эта ссылка — сам ключ семьи: передайте её по каналу, которому доверяете, и только {name}. Открыть её нужно войдя в хаб, на том устройстве, где ключ должен быть. Работает неделю; новая ссылка заменяет прежнюю.',
+  'The family key did not survive the reset — once they have signed in with the new password, send them a re-admission link from this list.':
+    'Ключ семьи сброс не пережил: когда участник войдёт с новым паролем, отправьте ему ссылку на возврат ключа из этого списка.',
+  'no key': 'без ключа',
+  'Hand this member the family key through a one-time link': 'Передать участнику ключ семьи одноразовой ссылкой',
+  'Re-admit': 'Вернуть ключ',
+  'This is your family’s recovery code. It opens the family key when a password no longer can — after a reset, or on a new device with nobody around to let you in.':
+    'Это код восстановления вашей семьи. Он открывает ключ семьи, когда пароль больше не может — после сброса или на новом устройстве, когда рядом некому вас впустить.',
+  'Case and dashes do not matter when typing it back.': 'При вводе регистр и дефисы не важны.',
+  'I have written it down somewhere safe. I understand that without my password and without this code, what the family encrypts is gone for good — nobody can recover it, including the people who run Neiliro.':
+    'Я записал(а) его в надёжном месте. Я понимаю: без моего пароля и без этого кода то, что семья зашифрует, пропадёт навсегда — восстановить его не сможет никто, включая тех, кто держит Neiliro.',
+  'Continue': 'Продолжить',
+  'Your family now has a key': 'У вашей семьи теперь есть ключ',
+  'Encryption of what the family writes starts with this key. It was created in this browser and never leaves it unprotected: the server only holds it wrapped under your password.':
+    'С этого ключа начинается шифрование того, что пишет семья. Он создан в этом браузере и не покидает его незащищённым: сервер хранит его только запечатанным под ваш пароль.',
+  'Unlock': 'Открыть',
+  'The code shown when the family key was created. It opens the key on this device and wraps it under your current password, so you will not need it here again.':
+    'Код, показанный при создании ключа семьи. Он откроет ключ на этом устройстве и запечатает его под ваш текущий пароль — здесь он больше не понадобится.',
+  'This is not a re-admission link.': 'Это не ссылка на возврат ключа.',
+  'This link lost the part after the # — some messengers cut it off. Ask for a new one and paste it whole.':
+    'Ссылка потеряла часть после # — некоторые мессенджеры её обрезают. Попросите новую и вставьте целиком.',
+  'Opening the key…': 'Открываем ключ…',
+  'You hold the family key again on this device. It is also wrapped under your current password, so the next sign-in will not need a link.':
+    'Ключ семьи снова на этом устройстве. Он также запечатан под ваш текущий пароль, так что при следующем входе ссылка не понадобится.',
+  'This device already holds the family key.': 'На этом устройстве ключ семьи уже есть.',
+  // Door errors thrown in lib/family-key.tsx
+  'The family has no recovery code': 'У семьи нет кода восстановления',
+  'That is not the recovery code': 'Это не код восстановления',
+  'Sign in first': 'Сначала войдите',
+  'This link has been used or revoked — ask for a new one': 'Ссылка уже использована или отозвана — попросите новую',
+  'This link does not open the key — ask for a new one': 'Эта ссылка ключ не открывает — попросите новую',
+  'This device does not hold the key': 'На этом устройстве нет ключа',
+  // Server answers, routes/keys.ts
+  'A family member sets up the key, not a kid account': 'Ключ создаёт взрослый участник, а не детский аккаунт',
+  'Not a key envelope': 'Это не конверт ключа',
+  'The family already has a key': 'У семьи уже есть ключ',
+  'The family has no key yet': 'У семьи пока нет ключа',
+  'A family member does this, not a kid account': 'Это делает взрослый участник, а не детский аккаунт',
+  'Only a member who holds the key can issue a new recovery code': 'Новый код восстановления может выдать только участник, у которого есть ключ',
+  'Only a member who holds the key can hand it on': 'Передать ключ может только участник, у которого он есть',
+  'You already hold the key': 'У вас уже есть ключ',
+  'Handoff not found': 'Ссылка на возврат ключа не найдена',
 };
 
 /** one / few / many, keyed by the English singular used in plural() calls. */

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -4,11 +4,14 @@ import { useServiceState } from '../lib/service';
 import { supportLink } from '../lib/support';
 import { useHomeName } from '../lib/home-name';
 import { useEffect, useState, type FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { onEnter } from '../lib/keys';
 import { browserTimezone } from '../lib/timezone';
 import { deriveWith, newCredentials, passwordProblem, prelogin } from '../lib/credentials';
+import { currentWrapKey, defaultKeyStore, wrapFamilyKey } from '../lib/crypto';
+import { passwordPlace } from '../lib/family-key';
 
 /*
   The sign-in screen is the one page a stranger can reach, so its footer
@@ -399,6 +402,7 @@ function TermsConsent({
 }
 
 function Setup() {
+  const { refresh } = useAuth();
   const { state: service } = useServiceState();
   // Null when there is nothing to agree to (self-hosted)
   const apex = service?.hosted ? service.apex : null;
@@ -429,7 +433,9 @@ function Setup() {
         timezone: browserTimezone(),
         ...(apex ? { accept_terms: agreed } : {}),
       });
-      window.location.href = '/';
+      // Not a reload: the wrap key derived a moment ago lives in this tab's
+      // memory, and the family key is about to be created with it (ADR 0001)
+      await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('Something went wrong'));
       setBusy(false);
@@ -631,6 +637,8 @@ interface InviteCheck {
  * exactly as it does on the open first run.
  */
 function Join() {
+  const { refresh } = useAuth();
+  const navigate = useNavigate();
   const token = new URLSearchParams(window.location.search).get('token') ?? '';
   const { state: service } = useServiceState();
   const apex = service?.hosted ? service.apex : null;
@@ -678,7 +686,11 @@ function Join() {
         ...(founder ? { timezone: browserTimezone() } : {}),
         ...(apex ? { accept_terms: agreed } : {}),
       });
-      window.location.href = '/';
+      // Same as the first run: stay in the tab so the wrap key survives.
+      // /join is not a route inside the app, so the router goes home first —
+      // through the router, not history.replaceState, which it would not notice.
+      navigate('/', { replace: true });
+      await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('Something went wrong'));
       setBusy(false);
@@ -768,10 +780,21 @@ export function ChangePassword() {
       // split still holds a hash of the password itself, and proves it the
       // old way this one last time (routes/auth.ts, change-password).
       const { kdf, salt } = await prelogin(user.email);
+      const current_auth_key = await deriveWith(current, salt);
+      // deriveWith leaves the wrap key of the *new* password in memory:
+      // if this device still holds the family key, it is re-wrapped under
+      // that key and travels with the change (ADR 0001, #210) — otherwise
+      // the server retires the old envelope, which the new password could
+      // not have opened anyway
+      const new_auth_key = await deriveWith(next, salt);
+      const held = await defaultKeyStore().load();
+      const wrap = currentWrapKey();
+      const envelope = held && wrap ? await wrapFamilyKey(held, wrap, passwordPlace(user.id)) : undefined;
       await api.post('/auth/change-password', {
-        current_auth_key: await deriveWith(current, salt),
-        new_auth_key: await deriveWith(next, salt),
+        current_auth_key,
+        new_auth_key,
         ...(kdf === 'legacy' ? { current_password: current } : {}),
+        ...(envelope ? { envelope } : {}),
       });
       setDone(true);
     } catch (err) {

--- a/web/src/pages/Readmit.tsx
+++ b/web/src/pages/Readmit.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { t } from '../lib/i18n';
+import { doorMessage, useKeys } from '../lib/family-key';
+import { handoffSecretFromFragment } from '../lib/crypto';
+
+/*
+  /readmit?handoff=<id>#k=<secret> — the other end of a re-admission link
+  (#210). The id is a query parameter and reaches the server; the secret is
+  in the fragment and never does. Opened while signed in as the member the
+  handoff was made for; the key is then held on this device and re-wrapped
+  under the current password.
+*/
+export function Readmit() {
+  const navigate = useNavigate();
+  const { status, unlockWithHandoff } = useKeys();
+  const [outcome, setOutcome] = useState<'working' | 'done' | 'already' | string>('working');
+  // One attempt per page: opening the handoff flips status to unlocked, and
+  // a second pass would read that as "already held" and overwrite the result
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (status === 'loading' || attempted.current) return;
+    attempted.current = true;
+    const handoffId = new URLSearchParams(window.location.search).get('handoff');
+    const secret = handoffSecretFromFragment(window.location.hash);
+    if (status === 'unlocked') {
+      setOutcome('already');
+      return;
+    }
+    if (!handoffId) {
+      setOutcome(t('This is not a re-admission link.'));
+      return;
+    }
+    if (!secret) {
+      setOutcome(
+        t('This link lost the part after the # — some messengers cut it off. Ask for a new one and paste it whole.'),
+      );
+      return;
+    }
+    unlockWithHandoff(handoffId, secret)
+      .then(() => setOutcome('done'))
+      .catch((err: unknown) => setOutcome(t(doorMessage(err, 'Something went wrong'))));
+    // The link's parameters do not change under a mounted page
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
+  return (
+    <div className="mx-auto max-w-md p-6">
+      <div className="rounded-card border border-line bg-surface p-6">
+        <h1 className="eyebrow mb-4">{t('Family key')}</h1>
+        {outcome === 'working' && <p className="text-sm text-muted">{t('Opening the key…')}</p>}
+        {outcome === 'done' && (
+          <p className="text-sm text-ink">
+            {t('You hold the family key again on this device. It is also wrapped under your current password, so the next sign-in will not need a link.')}
+          </p>
+        )}
+        {outcome === 'already' && <p className="text-sm text-ink">{t('This device already holds the family key.')}</p>}
+        {outcome !== 'working' && outcome !== 'done' && outcome !== 'already' && (
+          <p className="text-sm text-urgent">{outcome}</p>
+        )}
+        {outcome !== 'working' && (
+          <button
+            type="button"
+            onClick={() => navigate('/', { replace: true })}
+            className="mt-5 w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white hover:opacity-90"
+          >
+            {t('Continue')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import { onEnter } from '../lib/keys';
 import { PALETTE, addToPalette, loadCustomPalette, removeFromPalette } from '../lib/palette';
 import { COMMON_CURRENCIES, formatAmountInput, parseAmount } from '../lib/money';
 import { PeopleSection } from '../components/PeopleSection';
+import { KeysSection } from '../components/KeysSection';
 import { MailSection } from '../components/MailSection';
 import { TotpSection } from '../components/TotpSection';
 import { CalendarFeedSection } from '../components/CalendarFeedSection';
@@ -745,6 +746,7 @@ export function Settings() {
 
       <div className="mb-5 break-inside-avoid">
         <SignInSection />
+          <KeysSection />
       </div>
 
       <div className="mb-5 break-inside-avoid">


### PR DESCRIPTION
## Why

Phase 1 of client-side encryption (ADR 0001, epic #208). Closes #210 — the part the ADR calls dangerous: nothing is encrypted yet, but the key and every door to it have to exist, with a test per invariant, before the first module (#215) puts a byte through them.

## What

**Server** (migration 033, `routes/keys.ts`, `lib/keys.ts`)

- `key_envelopes`: the family key stored only wrapped, one envelope per door — `password` (per member), `recovery` (the family's, `user_id NULL`), `handoff` (wrapped by a member for another). `family_key`: the X25519 public half, its own table because `/api/settings` is writable by every member.
- `POST /api/keys` creates the key once, by an adult, with the recovery envelope **in the same request** — a key with a single door never exists. `PUT /api/keys/envelope` writes the member's own. `POST /api/keys/handoff` / `DELETE …/:id` hand the key on and retire the handoff. `POST /api/keys/recovery` replaces the recovery envelope, never removes it.
- Every password the browser did not derive a wrap key from — `POST /users/:id/reset-password`, the e-mailed reset, `admin-reset.mjs` — retires the member's password envelope. `change-password` takes the re-wrapped envelope in the same request, so password and envelope never disagree. `GET /api/users` reports `key_envelope` so the People list can show who is locked out.
- The server cannot verify who holds the key; its proxy is a live password envelope, and that gates handing on and a new recovery code. The wire shape is pinned: a `w1:` envelope is 16 + 64 base64url chars and a raw 32-byte key (43) does not match — the test checks exactly that.

**Browser** (`lib/family-key.tsx`, `crypto/x25519.ts`, `crypto/handoff.ts`)

- Four states: `absent` (family has no key), `unlocked`, `locked`, `loading`. The first adult who signs in with a wrap key creates the key and sees the recovery code on a screen that waits for an explicit acknowledgement — the one blocking screen of the feature. A locked device gets one quiet line with the two doors (waiting handoff link / recovery code); nothing else changes, since nothing is encrypted yet.
- Re-admission is a link, not a click: the admitter wraps the key under a fresh secret that travels in the URL fragment (`/readmit?handoff=<id>#k=<secret>`) — there is nothing else to wrap under, the admitter does not have the other member's password. Same mechanism #212 will reuse for invitations.
- X25519 pair derived from the family key by HKDF (info string versioned): public half on the server for #223, private half never stored.
- Settings → **Family key** card (status, Lock this device, New recovery code); People → **Re-admit** and a "no key" badge; the reset dialog says the key did not survive.

## What you considered and rejected

- Keeping the public key in `settings`: any member could overwrite it → own table.
- Re-admission "in one click": impossible without the target's wrap key → link with fragment.
- Forgetting the key in a provider unmount effect: React runs effects twice in development, which wiped the wrap key right after sign-in → moved into `logout()`.
- Reloading the page after first run / invite: loses the wrap key the tab just derived → both now refresh the session in place (and `/join` navigates home through the router, not `history.replaceState`, which the router does not see).

## How you know it works

Walked end to end on a fresh database in the browser pane: first run → recovery-code screen; invited member locked → recovery code typed in lower case with spaces → envelope written; administrator reset → "no key" badge, re-admission link, forced password change → sign-in shows "a link from Sam is waiting" → the link opens the key, writes the envelope, retires the handoff; new recovery code; Lock this device; sign-out leaves no record in IndexedDB.

Tests: server 43 files / 301 (`keys.test.ts` new: creation once and by an adult, refusal of bare keys, handoff rules, revocation by creator/admin/recipient, recovery rotation, retirement on admin reset and on a blind password change); web 110 (`crypto/keys.test.ts` new: X25519 agreement, handoff round trip and AAD binding, the three doors opening one key, another member's password opening nothing). Typecheck and lint clean.

## Anything you are unsure about

- Re-admission needs the recipient signed in on the target device; a Google-only member on a fresh device (#213) is the case that still needs a decision — device-held key, as agreed.
- The runbook in `neiliro/cloud` needs a line about what `admin-reset` now means; separate PR there.

Docs: `docs/architecture.md` (the family key paragraph), `docs/features.md` (Family → The family key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)