### PR TITLE
fix(mail): the inbound webhook answers only on in.<apex>

### DIFF
--- a/server/src/routes/mail-inbound.test.ts
+++ b/server/src/routes/mail-inbound.test.ts
@@ -87,6 +87,16 @@ async function post(payload: string) {
   });
 }
 
+/** The same delivery, but posted to a family's own subdomain rather than the webhook host. */
+async function postTo(host: string, payload: string) {
+  return app.inject({
+    method: 'POST',
+    url: INBOUND,
+    headers: { host, 'content-type': 'application/x-www-form-urlencoded' },
+    payload,
+  });
+}
+
 /** The Mail section as that family sees it. */
 async function mailbox(slug: string, cookie: string) {
   const res = await app.inject({
@@ -458,5 +468,29 @@ describe('inbound family mail', () => {
 
     const jones = await mailbox(JONES, jonesCookie);
     expect(jones.messages.map((m) => m.subject)).toEqual(['Electricity bill']);
+  });
+});
+
+describe('the webhook belongs to one host (#244)', () => {
+  it('refuses a delivery posted to a family subdomain, with 406, and stores nothing', async () => {
+    const before = (await mailbox(SMITHS, smithsCookie)).messages.length;
+    const res = await postTo(
+      `${SMITHS}.neiliro.test`,
+      delivery({
+        recipient: `${SMITHS}@mail.neiliro.test`,
+        'body-mime': letter('wrong-host@school.example', 'Posted to the family host'),
+      }),
+    );
+    expect(res.statusCode).toBe(406);
+    expect(res.json()).toEqual({ error: 'Wrong host' });
+    expect((await mailbox(SMITHS, smithsCookie)).messages.length).toBe(before);
+    // The reserved host still takes the very same delivery
+    const ok = await post(
+      delivery({
+        recipient: `${SMITHS}@mail.neiliro.test`,
+        'body-mime': letter('wrong-host@school.example', 'Posted to the family host'),
+      }),
+    );
+    expect(ok.statusCode).toBe(200);
   });
 });

--- a/server/src/routes/mail-inbound.ts
+++ b/server/src/routes/mail-inbound.ts
@@ -105,7 +105,23 @@ export async function registerInboundMailRoutes(app: FastifyInstance): Promise<v
     too: a letter that failed for a reason that can pass tomorrow (a full
     disk, a busy database) must NOT be 406, or it is dropped for good.
   */
+  /*
+    The one host this door belongs to. Fastify registers a route for every
+    Host, so without this check the webhook answered on every family's
+    subdomain as well — harmless in effect (the signature still gates it and
+    the family comes from `recipient`, never from the host), but wider than
+    the design says, and a POST endpoint no family subdomain has any use
+    for (#244). A self-hosted hub with MAIL_DOMAIN has no reserved host to
+    insist on, so the check is hosted-only.
+  */
+  const webhookHost = env.hostedMode ? `in.${env.hostedDomain}` : null;
+
   app.post(INBOUND_PATH, { bodyLimit: MAX_INBOUND_BYTES }, async (req, reply) => {
+    const host = (req.headers.host ?? '').split(':')[0]!.toLowerCase();
+    if (webhookHost && host !== webhookHost) {
+      log.warn(`mail inbound: delivery posted to ${host || '(no host)'} instead of ${webhookHost}`);
+      return reply.code(406).send({ error: 'Wrong host' });
+    }
     const form = (req.body ?? {}) as Record<string, string | undefined>;
     const { timestamp, token, signature } = form;
 


### PR DESCRIPTION
## Why

Closes #244. Found by the QA pass on the range: a correctly signed delivery POSTed to `https://<family>.<apex>/api/mail/inbound/mime` was accepted like one on `in.<apex>`. Nothing crossed families (the tenant comes from `recipient`, the HMAC still gated it) — but the docs say the route lives on the reserved host, and every family subdomain carried an unauthenticated POST endpoint it has no use for.

## What

`routes/mail-inbound.ts`: in hosted mode the handler compares `Host` (port stripped, lower-cased) with `in.<apex>` and refuses anything else with **406** — Mailgun's "permanent, do not retry" code, same as every other refusal in this file. Self-hosted with `MAIL_DOMAIN` has no reserved host and is unchanged.

## How you know it works

`mail-inbound.test.ts` gains one case: the same signed delivery posted to `smiths.neiliro.test` → 406 `{"error":"Wrong host"}`, mailbox count unchanged; posted to `in.neiliro.test` → 200. Suite 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)