### PR TITLE
fix(money): a transfer into a personal account hides the account's ids too

### DIFF
--- a/server/src/routes/money-semantics.test.ts
+++ b/server/src/routes/money-semantics.test.ts
@@ -412,3 +412,55 @@ describe('the outlook says what is left until the next money arrives', () => {
     expect(nok.left).toBe(70_000);
   });
 });
+
+describe('a transfer into a personal account shows the other member an amount and nothing else', () => {
+  it('masks the destination — name, id, owner, shared flag — for the member who cannot see it', async () => {
+    const bob = hub.join('bob').cookie;
+    const joint = await account('Joint for transfers', 100_000);
+    const wallet = (
+      await hub.as(bob, 'POST', '/api/accounts', { name: 'Bob wallet', currency: 'EUR', shared: false })
+    ).json<{ id: string }>().id;
+    const moved = await hub.as(bob, 'POST', '/api/transactions', {
+      kind: 'transfer',
+      occurred_on: '2026-09-09',
+      account_id: joint,
+      to_account_id: wallet,
+      amount: 2_000,
+      to_amount: 2_000,
+    });
+    expect(moved.statusCode).toBe(201);
+
+    type Row = Record<string, unknown> & { kind: string };
+    const rows = (cookieValue: string) =>
+      hub.as(cookieValue, 'GET', `/api/transactions?account_id=${joint}`).then((r) =>
+        r.json<Row[]>().filter((t) => t.kind === 'transfer'),
+      );
+
+    // Alice, who does not own the wallet: the amount, and a wall
+    const [alicesView] = await rows(cookie);
+    expect(alicesView).toMatchObject({
+      amount: 2_000,
+      to_amount: 2_000,
+      to_currency: 'EUR',
+      to_account_name: 'Personal account',
+      to_account_id: null,
+      to_owner: null,
+      to_shared: null,
+    });
+    // Bob, the owner: the real thing
+    const [bobsView] = await rows(bob);
+    expect(bobsView).toMatchObject({ to_account_id: wallet, to_account_name: 'Bob wallet', to_shared: 0 });
+
+    // The mirror case: money arriving on the shared account from Bob's wallet
+    await hub.as(bob, 'POST', '/api/transactions', {
+      kind: 'transfer',
+      occurred_on: '2026-09-09',
+      account_id: wallet,
+      to_account_id: joint,
+      amount: 500,
+      to_amount: 500,
+    });
+    const incoming = (await rows(cookie)).find((t) => t.amount === 500)!;
+    expect(incoming).toMatchObject({ account_name: 'Personal account', account_owner: null, note: null });
+  });
+});

--- a/server/src/routes/money.ts
+++ b/server/src/routes/money.ts
@@ -526,15 +526,24 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     const visible = visibleAccountIds(userId);
 
     // A transfer to someone else's personal account shows its amount but
-    // not the account name: money leaving a shared account can't be
-    // hidden, or the balance would be wrong
+    // not the account: money leaving a shared account can't be hidden, or
+    // the balance would be wrong. "Not the account" means not its name and
+    // not its ids either (#245) — the id, the owner and the shared flag are
+    // details the other member has no use for and no route to follow, and
+    // a future endpoint that takes an account id must not inherit them.
+    // The currency stays: the amount line needs it.
     return rows.map((row) => {
       const masked = { ...row };
       if (row['to_account_id'] && !visible.has(row['to_account_id'] as string)) {
         masked['to_account_name'] = 'Personal account';
+        masked['to_account_id'] = null;
+        masked['to_owner'] = null;
+        masked['to_shared'] = null;
       }
       if (!visible.has(row['account_id'] as string)) {
         masked['account_name'] = 'Personal account';
+        masked['account_owner'] = null;
+        masked['account_color'] = null;
         masked['note'] = null;
         masked['place'] = null;
         masked['category_name'] = null;


### PR DESCRIPTION
## Why

Closes #245. Found by the QA pass on the range: for a transfer from a shared account into a member's personal one, the other member's row masked `to_account_name` as "Personal account" but still carried `to_account_id`, `to_owner` and `to_shared`; the mirror case (money arriving from a personal account) exposed the source's owner and colour. No readable data leaks — the account itself answers 404 — but the invariant is "an amount, without the account name or details", and a future endpoint taking an account id must not inherit the exposure.

## What

`routes/money.ts`, the transactions list: when the destination is not visible to the requester, `to_account_id`, `to_owner`, `to_shared` are nulled next to the existing name mask; when the source is not visible, `account_owner` and `account_color` join `note`, `place`, `category_name`. `to_currency` stays — the amount line needs it. The owner's own view is unchanged.

Client impact: `TransactionDialog` reads `to_account_id` only to pre-select the destination, and the other member could never save that edit anyway (the server refuses a destination they cannot see) — so nothing that worked stops working.

## How you know it works

New case in `money-semantics.test.ts` with two members: the owner sees the real account (`to_account_id`, name, `to_shared: 0`); the other sees amount, currency, the mask and nulls; the incoming mirror hides the source's name, owner and note. Money suites 37/37, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)