### PR TITLE
fix(calendar): the subscription link in Settings carries the family key

### DIFF
--- a/web/src/components/CalendarFeedSection.tsx
+++ b/web/src/components/CalendarFeedSection.tsx
@@ -2,7 +2,7 @@ import { t } from '../lib/i18n';
 import { useCallback, useEffect, useState } from 'react';
 import { api } from '../lib/api';
 import { useKeys } from '../lib/family-key';
-import { familyKeySuffix } from '../lib/token-key';
+import { suffixForKey } from '../lib/token-key';
 
 /**
  * Subscribe-by-URL for the calendar.
@@ -17,7 +17,7 @@ export function CalendarFeedSection() {
   const [suffix, setSuffix] = useState('');
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
-  const { status } = useKeys();
+  const { status, familyKey } = useKeys();
 
   const load = useCallback(async () => {
     const res = await api.get<{ token: string | null }>('/calendar/feed');
@@ -25,10 +25,12 @@ export function CalendarFeedSection() {
   }, []);
 
   // The key half of the link is appended on this device (#218): the server
-  // never sees it outside the requests the calendar app makes
+  // never sees it outside the requests the calendar app makes. Derived from
+  // the provider's key, not from the vault: this effect runs before the
+  // provider's own, which is how the link once shipped without it (#251).
   useEffect(() => {
-    void familyKeySuffix().then(setSuffix);
-  }, [status]);
+    void suffixForKey(familyKey).then(setSuffix);
+  }, [familyKey]);
 
   useEffect(() => {
     void load();

--- a/web/src/lib/token-key.ts
+++ b/web/src/lib/token-key.ts
@@ -13,7 +13,16 @@ import { vaultKey } from './vault';
   for that request only (server/src/lib/envelope.ts).
 */
 export async function familyKeySuffix(): Promise<string> {
-  const key = vaultKey();
+  return suffixForKey(vaultKey());
+}
+
+/**
+ * The same, for a key a component already holds from the provider. A
+ * component's effect runs before the provider's, so at the moment the key
+ * appears `vaultKey()` may still be null — read the context's key instead
+ * (#251).
+ */
+export async function suffixForKey(key: CryptoKey | null): Promise<string> {
   if (!key) return '';
   return `~${toBase64url(await exportFamilyKey(key))}`;
 }


### PR DESCRIPTION
The feed URL in Settings → Subscribe in your calendar was shown without its `~<key>` half while the text under it promised one; a subscription made from it showed `••••••`. Found on the range during the phase-2 pass.

Cause: `CalendarFeedSection` computed the suffix in an effect keyed on `status` and read the key through `lib/vault.ts`. A child's effect runs before its parent's, so when `status` flipped to `unlocked` the provider's `setVault` had not run and the vault still answered `null`; nothing recomputed. The event and list share links read the vault at click time and were fine.

Fix: `suffixForKey(familyKey)` from the provider's context, effect keyed on the key itself.

Closes #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)