### PR TITLE
fix(crypto): decode nothing until the provider has settled the key

### DIFF
--- a/web/src/lib/codec.test.ts
+++ b/web/src/lib/codec.test.ts
@@ -339,3 +339,32 @@ describe('mail (#223)', () => {
     expect((rewritten['subject'] as string).startsWith('e1:')).toBe(true);
   });
 });
+
+describe('readiness (#249)', () => {
+  it('holds a response until the provider settles the key, then opens it with the key that arrived', async () => {
+    const family = await generateFamilyKey();
+    setVault({ key: family, familyHasKey: true });
+    const sealed = (await encodeRequest('PATCH', `/notes/${NOTE_ID}`, { title: 'Late key' })) as Row;
+
+    // A fresh page load: the provider is still looking, no key in the vault yet
+    setVault({ key: null, familyHasKey: true, settled: false });
+    let opened: Row | null = null;
+    const pending = decodeResponse('GET', `/notes/${NOTE_ID}`, { id: NOTE_ID, title: sealed['title'], body_md: '' }).then((r) => {
+      opened = r as Row;
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(opened).toBeNull();
+
+    // The key lands: the held response decodes with it, not into placeholders
+    setVault({ key: family, familyHasKey: true, settled: true });
+    await pending;
+    expect(opened!['title']).toBe('Late key');
+  });
+
+  it('does not wait when the provider has already answered', async () => {
+    setVault({ key: null, familyHasKey: false });
+    const t = performance.now();
+    await decodeResponse('GET', '/notes', []);
+    expect(performance.now() - t).toBeLessThan(50);
+  });
+});

--- a/web/src/lib/codec.ts
+++ b/web/src/lib/codec.ts
@@ -1,7 +1,7 @@
 import { ENCRYPTED_FIELDS } from './crypto/field-map';
 import { isEncrypted } from './crypto/envelope';
 import { excerptOf, extractLinks, normalizeWikiLinks } from './notes';
-import { openFields, openRows, sealFields } from './vault';
+import { openFields, openRows, sealFields, vaultReady } from './vault';
 
 /*
   Encrypt on the way out, decrypt on the way in (ADR 0001, phase 2).
@@ -243,6 +243,8 @@ export type Requester = (path: string, method: string, body?: unknown) => Promis
 
 export async function encodeRequest(method: string, path: string, body: unknown): Promise<unknown> {
   if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  // A write racing the key's first load must not be refused as "locked" (#249)
+  await vaultReady();
   const b = body as Body;
   let m: RegExpMatchArray | null;
 
@@ -332,6 +334,9 @@ export async function decodeResponse(
   request?: Requester,
 ): Promise<unknown> {
   if (data === null || typeof data !== 'object') return data;
+  // Decoded with the key at hand, not with whatever the vault held a few
+  // milliseconds after page load (#249)
+  await vaultReady();
   let m: RegExpMatchArray | null;
 
   // Notes

--- a/web/src/lib/family-key.tsx
+++ b/web/src/lib/family-key.tsx
@@ -217,7 +217,9 @@ export function KeyProvider({ children, store }: { children: ReactNode; store?: 
   // is true for every state but `absent` — while the answer is still
   // loading a write must refuse rather than fall through to plaintext.
   useEffect(() => {
-    setVault({ key: familyKey, familyHasKey: status !== 'absent' });
+    // `settled` gates the codec: while the key is still being looked up, a
+    // response is not decoded yet rather than decoded into placeholders (#249)
+    setVault({ key: familyKey, familyHasKey: status !== 'absent', settled: status !== 'loading' });
   }, [familyKey, status]);
 
   const unlockWithRecoveryCode = useCallback(

--- a/web/src/lib/files.ts
+++ b/web/src/lib/files.ts
@@ -1,6 +1,6 @@
 import { t } from './i18n';
 import { decryptFile, encryptFile, openSealedFile } from './crypto';
-import { hasFamilyKey, openFields, sealFields, vaultKey, VaultLockedError } from './vault';
+import { hasFamilyKey, openFields, sealFields, vaultKey, vaultReady, VaultLockedError } from './vault';
 
 /*
   Attachments under the family key (#222).
@@ -34,6 +34,7 @@ const bytesOf = async (file: Blob): Promise<Uint8Array<ArrayBuffer>> => new Uint
 
 /** Upload files to a notes or transactions attachment route, sealed when the key is here. */
 export async function uploadAttachments(path: string, files: File[]): Promise<UploadedFile[]> {
+  await vaultReady();
   const key = vaultKey();
   if (!key && hasFamilyKey()) throw new VaultLockedError();
 
@@ -78,6 +79,7 @@ export function attachmentUrl(id: string, mime?: string): Promise<string> {
     if (!res.ok) throw new Error(t('File not found'));
     const kind = Number(res.headers.get('X-Neiliro-Encryption') ?? '0');
     if (kind === 0) return `/api/attachments/${id}`;
+    await vaultReady();
     const key = vaultKey();
     if (!key) throw new VaultLockedError();
     const bytes = new Uint8Array(await res.arrayBuffer());
@@ -93,6 +95,7 @@ export function attachmentUrl(id: string, mime?: string): Promise<string> {
 
 /** The one-time job: fetch a plaintext file, seal it under its own id, put it back in place. */
 export async function encryptExistingAttachment(id: string, filename: string, mime: string): Promise<void> {
+  await vaultReady();
   const key = vaultKey();
   if (!key) throw new VaultLockedError();
   const res = await fetch(`/api/attachments/${id}`);

--- a/web/src/lib/token-key.ts
+++ b/web/src/lib/token-key.ts
@@ -1,5 +1,5 @@
 import { exportFamilyKey, toBase64url } from './crypto';
-import { vaultKey } from './vault';
+import { vaultKey, vaultReady } from './vault';
 
 /*
   The two links that feed other people's software — the calendar
@@ -13,6 +13,7 @@ import { vaultKey } from './vault';
   for that request only (server/src/lib/envelope.ts).
 */
 export async function familyKeySuffix(): Promise<string> {
+  await vaultReady();
   const key = vaultKey();
   if (!key) return '';
   return `~${toBase64url(await exportFamilyKey(key))}`;

--- a/web/src/lib/token-key.ts
+++ b/web/src/lib/token-key.ts
@@ -13,10 +13,9 @@ import { vaultKey, vaultReady } from './vault';
   for that request only (server/src/lib/envelope.ts).
 */
 export async function familyKeySuffix(): Promise<string> {
-<<<<<<< HEAD
+  // Not before the provider has settled the key (#249): a link built a few
+  // milliseconds into a fresh load would otherwise miss its key half
   await vaultReady();
-  const key = vaultKey();
-=======
   return suffixForKey(vaultKey());
 }
 
@@ -27,7 +26,6 @@ export async function familyKeySuffix(): Promise<string> {
  * (#251).
  */
 export async function suffixForKey(key: CryptoKey | null): Promise<string> {
->>>>>>> origin/master
   if (!key) return '';
   return `~${toBase64url(await exportFamilyKey(key))}`;
 }

--- a/web/src/lib/vault.ts
+++ b/web/src/lib/vault.ts
@@ -24,9 +24,42 @@ import { isSealed, openSealedField } from './crypto/seal';
 let familyKey: CryptoKey | null = null;
 let familyHasKey = false;
 
-export function setVault(state: { key: CryptoKey | null; familyHasKey: boolean }): void {
+/*
+  Readiness (#249). On a fresh page load the pages ask for their data the
+  moment the session is known — in parallel with the provider reading the
+  key from IndexedDB. A response decoded in that gap has no key to open it
+  with, comes back as placeholders, and nothing re-decodes when the key
+  lands a few milliseconds later. So the codec waits, once per load, until
+  the provider says it has settled: unlocked, locked or absent — any answer
+  but "still looking". A bounded wait: offline, or a provider that never
+  reports, must not hang every request forever.
+*/
+let settled = true;
+let waiters: (() => void)[] = [];
+const READY_TIMEOUT_MS = 2_500;
+
+export function setVault(state: { key: CryptoKey | null; familyHasKey: boolean; settled?: boolean }): void {
   familyKey = state.key;
   familyHasKey = state.familyHasKey;
+  if (state.settled === false) {
+    settled = false;
+    return;
+  }
+  settled = true;
+  for (const wake of waiters) wake();
+  waiters = [];
+}
+
+/** Resolves once the provider has settled the key's state, or after a bounded wait. */
+export function vaultReady(): Promise<void> {
+  if (settled) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, READY_TIMEOUT_MS);
+    waiters.push(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 }
 
 export function vaultKey(): CryptoKey | null {


### PR DESCRIPTION
On a fresh page load the pages fetch their data right after `/api/auth/me`, in parallel with `KeyProvider` reading the key from IndexedDB. Responses decoded in that gap came back as `••••••` and nothing re-decoded when the key landed: the mail list, the money account card and the Inbox chip stayed dots until a client-side navigation. Found on the range during the phase-2 pass.

Fix: `lib/vault.ts` gains a readiness state the provider sets (`settled` once the status is unlocked/locked/absent), and `codec.ts`, `files.ts` and `token-key.ts` `await vaultReady()` before touching a key — bounded to 2.5 s so an offline device never hangs. Writes wait too, so a quick-add racing the first load is not refused as "locked".

Test: a decode issued while the provider is still looking is held and then opens with the key that arrives; a settled vault does not wait.

Closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)