### PR TITLE
fix(api): a date has to exist, not only look like one

### DIFF
--- a/server/src/lib/date-field.ts
+++ b/server/src/lib/date-field.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/*
+  A date is not a shape (#250). `^\d{4}-\d{2}-\d{2}$` let `2026-13-45`
+  through five routes, and the first `new Date(...).toISOString()` on it —
+  in the recurrence expansion the dashboard and the calendar run — threw
+  `RangeError: Invalid time value` for the whole family until the row was
+  deleted. The browser's date inputs cannot produce such a value; the API
+  can, and one member is enough.
+
+  So the check parses and compares back: a real calendar date round-trips
+  through the Date object unchanged, an impossible one does not.
+*/
+
+const DATE_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_SHAPE = /^\d{2}:\d{2}$/;
+
+export function isRealDate(value: string): boolean {
+  if (!DATE_SHAPE.test(value)) return false;
+  const d = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
+}
+
+function isRealTime(value: string): boolean {
+  if (!TIME_SHAPE.test(value)) return false;
+  const [h, m] = value.split(':').map(Number);
+  return h! < 24 && m! < 60;
+}
+
+/** `YYYY-MM-DD`, and a day that exists. */
+export const dateField = (message = 'Date must be YYYY-MM-DD') => z.string().refine(isRealDate, message);
+
+/** `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM` — an event's wall-clock time. */
+export const dateTimeField = (message = 'Date must be YYYY-MM-DD or YYYY-MM-DDTHH:MM') =>
+  z.string().refine((v) => {
+    const [date, time, ...rest] = v.split('T');
+    return rest.length === 0 && isRealDate(date!) && (time === undefined || isRealTime(time));
+  }, message);
+
+/** `YYYY-MM`, month 01–12. */
+export const monthField = (message = 'Month must be YYYY-MM') =>
+  z.string().refine((v) => /^\d{4}-(0[1-9]|1[0-2])$/.test(v), message);

--- a/server/src/routes/budgets.ts
+++ b/server/src/routes/budgets.ts
@@ -3,9 +3,8 @@ import { z } from 'zod';
 import { db, id, now, today } from '../db/index.js';
 import { expandOccurrences, isValidRecurrence } from '../lib/recurrence.js';
 import { isCiphertext } from '../lib/ciphertext.js';
+import { dateField, monthField } from '../lib/date-field.js';
 
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
-const MONTH = /^\d{4}-\d{2}$/;
 
 const ACCOUNT_VISIBLE = '(a.shared = 1 OR a.owner_id = ?)';
 
@@ -204,7 +203,7 @@ export function runAutoCreate(): number {
 const recurringInput = z.object({
   title: z.string().min(1, 'Enter a title').max(4_000),
   kind: z.enum(['expense', 'income', 'transfer']),
-  start_on: z.string().regex(DATE, 'Date must be YYYY-MM-DD'),
+  start_on: dateField(),
   recurrence_rule: z.string().min(1).max(100),
   account_id: z.string().uuid(),
   amount: z.number().int().positive('Amount must be greater than zero'),
@@ -226,7 +225,7 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
    * would mean duplicating the limit-selection rule there.
    */
   app.get('/api/budgets', (req, reply) => {
-    const parsed = z.object({ month: z.string().regex(MONTH) }).safeParse(req.query);
+    const parsed = z.object({ month: monthField() }).safeParse(req.query);
     if (!parsed.success) return reply.code(400).send({ error: 'Month must be YYYY-MM' });
 
     const { month } = parsed.data;
@@ -279,7 +278,7 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
       .object({
         category_id: z.string().uuid(),
         currency: z.string().regex(/^[A-Z]{3}$/),
-        month: z.string().regex(MONTH).nullable().optional(),
+        month: monthField().nullable().optional(),
         amount: z.number().int().positive('Limit must be greater than zero'),
       })
       .safeParse(req.body);
@@ -446,7 +445,7 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
     const { id: ruleId } = z.object({ id: z.string().uuid() }).parse(req.params);
     const parsed = z
       .object({
-        occurred_on: z.string().regex(DATE),
+        occurred_on: dateField(),
         // The actual amount may differ from the planned one: a salary with
         // a bonus, rent with a changed water bill
         amount: z.number().int().positive().optional(),
@@ -477,7 +476,7 @@ export async function registerBudgetRoutes(app: FastifyInstance): Promise<void> 
 
   app.post('/api/recurring/:id/skip', (req, reply) => {
     const { id: ruleId } = z.object({ id: z.string().uuid() }).parse(req.params);
-    const parsed = z.object({ occurred_on: z.string().regex(DATE) }).safeParse(req.body);
+    const parsed = z.object({ occurred_on: dateField() }).safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: 'Occurrence date is required' });
 
     const rule = db

--- a/server/src/routes/calendar.ts
+++ b/server/src/routes/calendar.ts
@@ -7,8 +7,8 @@ import { buildCalendarFeed, type FeedEvent } from '../lib/ics.js';
 import { expandOccurrences, isValidRecurrence } from '../lib/recurrence.js';
 import { daysBetween, shiftDays } from '../lib/dates.js';
 import { FieldOpener, splitTokenKey } from '../lib/envelope.js';
+import { dateField, dateTimeField, isRealDate } from '../lib/date-field.js';
 
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
 
 /**
@@ -33,18 +33,8 @@ const eventBase = z.object({
   // The message matches due_date in tasks.ts — without one, a malformed
   // date answers with zod's bare "Invalid", which names neither the field
   // nor the shape (#86)
-  starts_at: z
-    .string()
-    .regex(
-      new RegExp(`${DATE.source.slice(0, -1)}(T\\d{2}:\\d{2})?$`),
-      'Date must be YYYY-MM-DD or YYYY-MM-DDTHH:MM',
-    ),
-  ends_at: z
-    .string()
-    .regex(
-      new RegExp(`${DATE.source.slice(0, -1)}(T\\d{2}:\\d{2})?$`),
-      'Date must be YYYY-MM-DD or YYYY-MM-DDTHH:MM',
-    ),
+  starts_at: dateTimeField(),
+  ends_at: dateTimeField(),
   all_day: z.boolean().optional(),
   recurrence_rule: z.string().max(100).nullable().optional(),
   project_id: z.string().uuid().nullable().optional(),
@@ -142,6 +132,10 @@ export function listOccurrences(userId: string, from: string, to: string): Occur
   const result: Occurrence[] = [];
 
   for (const event of events) {
+    // A row with a date the parser cannot place (written before #250, or by
+    // hand) is skipped, not fatal: one bad row must never take the family's
+    // calendar and dashboard down with it
+    if (!isRealDate(event.starts_at.slice(0, 10)) || !isRealDate(event.ends_at.slice(0, 10))) continue;
     const anchor = event.starts_at.slice(0, 10);
     const span = daysBetween(anchor, event.ends_at.slice(0, 10));
 
@@ -306,7 +300,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
 
   app.get('/api/events', (req, reply) => {
     const parsed = z
-      .object({ from: z.string().regex(DATE), to: z.string().regex(DATE) })
+      .object({ from: dateField(), to: dateField() })
       .safeParse(req.query);
     if (!parsed.success) {
       return reply.code(400).send({ error: 'Range boundaries from and to are required' });
@@ -475,7 +469,7 @@ export async function registerCalendarRoutes(app: FastifyInstance): Promise<void
   /** Cancel a single instance of a series without touching the series itself. */
   app.delete('/api/events/:id/occurrences/:date', (req, reply) => {
     const { id: eventId, date } = z
-      .object({ id: z.string().uuid(), date: z.string().regex(DATE) })
+      .object({ id: z.string().uuid(), date: dateField() })
       .parse(req.params);
 
     const event = db

--- a/server/src/routes/dates.test.ts
+++ b/server/src/routes/dates.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+import { runWithDb } from '../db/index.js';
+
+/*
+  A date is not a shape (#250). `2026-13-45` matched the old regex on five
+  routes, and the first recurrence expansion over it threw for the whole
+  family. Two things are pinned: the routes refuse an impossible date with
+  the authored message, and a row that somehow carries one (written before
+  the fix) no longer takes the dashboard and the calendar down.
+*/
+let h: Harness;
+let cookie: string;
+const INBOX = '00000000-0000-4000-8000-000000000001';
+const SHARED = '00000000-0000-4000-8000-000000000201';
+
+beforeAll(async () => {
+  h = await buildTestApp();
+  ({ cookie } = h.join('Alice'));
+});
+
+describe('impossible dates are refused', () => {
+  it('on tasks, events, transactions, rules, reconciliation and birthdays', async () => {
+    const me = (await h.as(cookie, 'GET', '/api/auth/me')).json<{ id: string }>();
+    const account = (await h.as(cookie, 'POST', '/api/accounts', { name: 'Wallet', currency: 'EUR' })).json<{ id: string }>();
+    const cases: [string, string, unknown, string][] = [
+      ['POST', '/api/tasks', { project_id: INBOX, title: 'x', due_date: '2026-13-45' }, 'Date must be YYYY-MM-DD'],
+      ['POST', '/api/tasks', { project_id: INBOX, title: 'x', expected_date: '2026-02-30' }, 'Date must be YYYY-MM-DD'],
+      ['POST', '/api/events', { calendar_id: SHARED, title: 'x', starts_at: '2026-13-45', ends_at: '2026-13-45' }, 'Date must be YYYY-MM-DD or YYYY-MM-DDTHH:MM'],
+      ['POST', '/api/events', { calendar_id: SHARED, title: 'x', starts_at: '2026-09-10T25:00', ends_at: '2026-09-10T25:30' }, 'Date must be YYYY-MM-DD or YYYY-MM-DDTHH:MM'],
+      ['POST', '/api/transactions', { kind: 'expense', occurred_on: '2026-00-10', account_id: account.id, amount: 5 }, 'Date must be YYYY-MM-DD'],
+      ['POST', '/api/recurring', { title: 'x', kind: 'expense', start_on: '2026-04-31', recurrence_rule: 'FREQ=MONTHLY', account_id: account.id, amount: 5 }, 'Date must be YYYY-MM-DD'],
+      ['POST', `/api/accounts/${account.id}/reconcile`, { checked_on: '2026-13-01', actual_balance: 1 }, 'Enter the date and the actual balance'],
+      ['PATCH', `/api/profiles/${me.id}`, { birthday: '1990-13-01' }, 'Date must be YYYY-MM-DD'],
+      ['PUT', '/api/budgets', { category_id: '00000000-0000-4000-8000-000000000000', currency: 'EUR', month: '2026-13', amount: 1 }, 'Month must be YYYY-MM'],
+    ];
+    for (const [method, url, body, message] of cases) {
+      const res = await h.as(cookie, method as 'POST', url, body);
+      expect(res.statusCode, `${method} ${url}`).toBe(400);
+      expect(res.json<{ error: string }>().error, `${method} ${url}`).toBe(message);
+    }
+    // Leap day is a real date; a real datetime passes
+    expect((await h.as(cookie, 'POST', '/api/tasks', { project_id: INBOX, title: 'leap', due_date: '2028-02-29' })).statusCode).toBe(201);
+    expect((await h.as(cookie, 'POST', '/api/events', { calendar_id: SHARED, title: 'ok', starts_at: '2026-09-10T09:00', ends_at: '2026-09-10T09:30' })).statusCode).toBe(201);
+  });
+
+  it('query windows are checked too', async () => {
+    expect((await h.as(cookie, 'GET', '/api/events?from=2026-13-01&to=2026-13-31')).statusCode).toBe(400);
+    expect((await h.as(cookie, 'GET', '/api/budgets?month=2026-13')).statusCode).toBe(400);
+  });
+});
+
+describe('a bad row from before the fix', () => {
+  it('is skipped by the calendar and the dashboard instead of taking them down', async () => {
+    runWithDb(h.db, () => {
+      h.db
+        .prepare(
+          `INSERT INTO events (id, calendar_id, title, starts_at, ends_at, all_day, recurrence_rule, created_at, updated_at)
+           VALUES ('00000000-0000-4000-8000-00000000bad1', ?, 'legacy', '1990-13-01', '1990-13-01', 1, 'FREQ=YEARLY', datetime('now'), datetime('now'))`,
+        )
+        .run(SHARED);
+    });
+    const events = await h.as(cookie, 'GET', '/api/events?from=2026-09-01&to=2026-09-30');
+    expect(events.statusCode).toBe(200);
+    expect(events.json<{ title: string }[]>().some((e) => e.title === 'legacy')).toBe(false);
+    expect((await h.as(cookie, 'GET', '/api/dashboard')).statusCode).toBe(200);
+  });
+});

--- a/server/src/routes/money.ts
+++ b/server/src/routes/money.ts
@@ -5,8 +5,8 @@ import { resolve } from 'node:path';
 import { currentTenant, db, id, now, today } from '../db/index.js';
 import { shiftDays } from '../lib/dates.js';
 import { dueOccurrences } from './budgets.js';
+import { dateField } from '../lib/date-field.js';
 
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * An account is visible if it is shared or belongs to the asker.
@@ -67,7 +67,7 @@ function parentProblem(parentId: string, kind: string): string | null {
 
 const txBase = z.object({
   kind: z.enum(['expense', 'income', 'transfer']),
-  occurred_on: z.string().regex(DATE, 'Date must be YYYY-MM-DD'),
+  occurred_on: dateField(),
   account_id: z.string().uuid(),
   amount: z.number().int().positive('Amount must be greater than zero'),
   to_account_id: z.string().uuid().nullable().optional(),
@@ -331,7 +331,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
     const { id: accountId } = z.object({ id: z.string().uuid() }).parse(req.params);
     const parsed = z
       .object({
-        checked_on: z.string().regex(DATE),
+        checked_on: dateField(),
         actual_balance: z.number().int(),
         note: z.string().max(4_000).nullable().optional(),
       })
@@ -470,8 +470,8 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/transactions', (req) => {
     const q = z
       .object({
-        from: z.string().regex(DATE).optional(),
-        to: z.string().regex(DATE).optional(),
+        from: dateField().optional(),
+        to: dateField().optional(),
         account_id: z.string().uuid().optional(),
         category_id: z.string().uuid().optional(),
         kind: z.enum(['expense', 'income', 'transfer']).optional(),
@@ -725,7 +725,7 @@ export async function registerMoneyRoutes(app: FastifyInstance): Promise<void> {
   /** Totals per currency, separately: no grand total without an exchange rate. */
   app.get('/api/money/summary', (req, reply) => {
     const parsed = z
-      .object({ from: z.string().regex(DATE), to: z.string().regex(DATE) })
+      .object({ from: dateField(), to: dateField() })
       .safeParse(req.query);
     if (!parsed.success) return reply.code(400).send({ error: 'Period boundaries are required' });
 

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
 import { db, id, now } from '../db/index.js';
 import { env } from '../env.js';
+import { dateField } from '../lib/date-field.js';
 
 /*
   Family member profiles (#68): birthday, family role, preferences,
@@ -25,7 +26,6 @@ import { env } from '../env.js';
 
 const FAMILY_ROLES = ['mother', 'father', 'daughter', 'son', 'grandmother', 'grandfather'] as const;
 const SHARED_CALENDAR_ID = '00000000-0000-4000-8000-000000000201';
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /** Self or admin — the #64 boundary, reused verbatim. */
 function canEdit(req: FastifyRequest, userId: string): boolean {
@@ -178,7 +178,7 @@ export async function registerProfileRoutes(app: FastifyInstance): Promise<void>
     if (!canEdit(req, userId)) return forbid(reply);
     const parsed = z
       .object({
-        birthday: z.string().regex(DATE, 'Date must be YYYY-MM-DD').nullable().optional(),
+        birthday: dateField().nullable().optional(),
         family_role: z.enum(FAMILY_ROLES).nullable().optional(),
       })
       .safeParse(req.body);

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 import { db, id, now } from '../db/index.js';
 import { isValidRecurrence, occurrenceAfter } from '../lib/recurrence.js';
 import { isCiphertext } from '../lib/ciphertext.js';
+import { dateField } from '../lib/date-field.js';
 
 const STATUSES = ['backlog', 'todo', 'in_progress', 'done', 'cancelled'] as const;
 const PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
-const DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 /*
   The list is capped, because on the hosted service one process serves
@@ -60,8 +60,8 @@ const createInput = z.object({
   description: z.string().max(40_000).nullable().optional(),
   status: z.enum(STATUSES).optional(),
   priority: z.enum(PRIORITIES).optional(),
-  due_date: z.string().regex(DATE, 'Date must be YYYY-MM-DD').nullable().optional(),
-  expected_date: z.string().regex(DATE, 'Date must be YYYY-MM-DD').nullable().optional(),
+  due_date: dateField().nullable().optional(),
+  expected_date: dateField().nullable().optional(),
   assignee_id: z.string().uuid().nullable().optional(),
   recurrence_rule: z.string().max(100).nullable().optional(),
   // Set by the browser when it spawns the next occurrence of an encrypted
@@ -120,8 +120,8 @@ export async function registerTaskRoutes(app: FastifyInstance): Promise<void> {
         status: z.string().optional(),
         assignee_id: z.string().optional(),
         priority: z.enum(PRIORITIES).optional(),
-        due_before: z.string().regex(DATE).optional(),
-        due_after: z.string().regex(DATE).optional(),
+        due_before: dateField().optional(),
+        due_after: dateField().optional(),
         include_done: z.enum(['true', 'false']).optional(),
         search: z.string().max(200).optional(),
         limit: z.coerce.number().int().min(1).max(LIST_LIMIT_MAX).optional(),


### PR DESCRIPTION
`2026-13-45` matched the shape-only `DATE` regex on five routes (tasks, calendar, money, budgets, profiles); the first recurrence expansion over it threw `RangeError: Invalid time value` and `/api/dashboard` + `/api/events` answered 500 for the whole family until the row was deleted. Found on the range during the phase-2 pass; any member can trigger it through the API.

- `server/src/lib/date-field.ts`: `dateField`, `dateTimeField`, `monthField` — parse and compare back, same authored messages as before (the client translates them by exact match, so Russian is unchanged); event times check `HH:MM` ranges; budget months check `01–12`.
- All five routes use them (create bodies, patch bodies and query windows).
- `listOccurrences` skips a row whose dates it cannot place instead of throwing — a bad row from before this fix no longer takes the calendar and dashboard down.
- `routes/dates.test.ts` pins both halves.

Closes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)