### PR TITLE
fix(auth): an initialised hub refuses setup before it validates the body

### DIFF
--- a/server/src/routes/setup-oracle.test.ts
+++ b/server/src/routes/setup-oracle.test.ts
@@ -1,0 +1,26 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { buildTestApp, type Harness } from '../test-harness.js';
+
+/*
+  The setup route must not tell a stranger whether a hub exists (#252).
+  A ghost answers 403 "already set up" to anything; a real, initialised
+  hub used to validate the body first and answer 400 to junk — one request
+  with an empty body was enough to tell the two apart. Both now refuse in
+  the same words before looking at the body.
+*/
+let h: Harness;
+
+beforeAll(async () => {
+  h = await buildTestApp();
+  h.join('Alice'); // the hub has its admin: initialised
+});
+
+describe('an initialised hub', () => {
+  it('refuses setup with the ghost’s words whatever the body looks like', async () => {
+    for (const body of [{}, { email: 'not-an-email' }, { name: 'x', email: 'x@y.example', auth_key: 'A'.repeat(43), kdf_salt: '00'.repeat(16), accept_terms: true }]) {
+      const res = await h.as('', 'POST', '/api/auth/setup', body);
+      expect(res.statusCode, JSON.stringify(body)).toBe(403);
+      expect(res.json<{ error: string }>().error).toBe('The hub is already set up');
+    }
+  });
+});

--- a/server/src/routes/setup.ts
+++ b/server/src/routes/setup.ts
@@ -171,6 +171,15 @@ export async function registerSetupRoutes(app: FastifyInstance): Promise<void> {
     if (founderInvited()) {
       return reply.code(403).send({ error: ALREADY_SET_UP });
     }
+    // A hub that already has its admin refuses BEFORE it looks at the body,
+    // exactly as the ghost does above. Validating first gave the game away:
+    // an invalid body drew 400 from a real family and 403 from a ghost, and
+    // that one bit was enough to list the service's customers by name (#252).
+    // The transaction below keeps the check that settles two simultaneous
+    // first runs; this one only fixes what an outsider can observe.
+    if ((db.prepare('SELECT count(*) AS n FROM users').get() as { n: number }).n > 0) {
+      return reply.code(403).send({ error: ALREADY_SET_UP });
+    }
     const parsed = z
       .object({
         name: nameField,


### PR DESCRIPTION
`POST /api/auth/setup` with an invalid body answered **400** on a real family and **403** on a ghost — one unauthenticated request per name was enough to tell which subdomains exist. Reproduces on production today. Found on the range during the phase-2 pass.

Fix: the "already set up" check runs before body validation on the real path, as it already did for the ghost and the founder-invite case. The transactional check that settles a race of two first runs is unchanged. `setup-oracle.test.ts` pins that an initialised hub answers 403 in the ghost's words to an empty body, an invalid one and a valid one alike.

Closes #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)