### PR TITLE
fix(mail): a refused reply answers 502 with a sentence, not 500

### DIFF
--- a/server/src/lib/mail.ts
+++ b/server/src/lib/mail.ts
@@ -128,6 +128,22 @@ function mimeDisplayName(name: string): string {
   return `=?UTF-8?B?${Buffer.from(name, 'utf8').toString('base64')}?=`;
 }
 
+/**
+ * The provider (or the family's own SMTP server) would not take the message.
+ * An ordinary event — a compliance hold, an unverified domain, a wrong
+ * password on a self-hosted box — that the person pressing "send" needs to
+ * read as such, not as the hub falling over (#253). The route maps it to 502.
+ */
+export class MailSendError extends Error {
+  constructor(
+    message: string,
+    readonly detail: string,
+  ) {
+    super(message);
+    this.name = 'MailSendError';
+  }
+}
+
 /** The family's own mailbox, over its own SMTP. */
 function accountSender(account: MailAccount): Outgoing {
   const transport = nodemailer.createTransport({
@@ -139,14 +155,18 @@ function accountSender(account: MailAccount): Outgoing {
   return {
     address: account.address,
     async send(message) {
-      await transport.sendMail({
-        from: { name: message.fromName, address: account.address },
-        to: message.to,
-        subject: message.subject,
-        text: message.text,
-        inReplyTo: message.inReplyTo,
-        references: message.inReplyTo,
-      });
+      try {
+        await transport.sendMail({
+          from: { name: message.fromName, address: account.address },
+          to: message.to,
+          subject: message.subject,
+          text: message.text,
+          inReplyTo: message.inReplyTo,
+          references: message.inReplyTo,
+        });
+      } catch (err) {
+        throw new MailSendError('The mail server refused the message', err instanceof Error ? err.message : String(err));
+      }
     },
   };
 }
@@ -209,7 +229,7 @@ async function postToMailgun(form: FormData): Promise<void> {
     // compliance hold — and the person pressing "send reply" is the
     // one who needs to see it.
     const detail = await res.text().catch(() => '');
-    throw new Error(`Mailgun refused the message (${res.status}) ${detail.slice(0, 200)}`.trim());
+    throw new MailSendError('The mail service refused the message', `Mailgun ${res.status} ${detail.slice(0, 200)}`.trim());
   }
 }
 

--- a/server/src/routes/mail-hosted-send.test.ts
+++ b/server/src/routes/mail-hosted-send.test.ts
@@ -190,7 +190,9 @@ describe('hosted reply', () => {
       headers: { host: HOST, cookie },
       payload: { text: 'This one should not be filed.' },
     });
-    expect(res.statusCode).toBeGreaterThanOrEqual(500);
+    // A refusal is a legible 502, not the hub falling over (#253)
+    expect(res.statusCode).toBe(502);
+    expect((res.json() as { error: string }).error).toBe('The mail service refused the message');
     expect(sent).toHaveLength(before + 1);
 
     const thread = await app.inject({

--- a/server/src/routes/mail.ts
+++ b/server/src/routes/mail.ts
@@ -6,10 +6,12 @@ import { isCiphertext } from '../lib/ciphertext.js';
 import {
   familyMailAddress,
   getMailAccount,
+  MailSendError,
   mailSource,
   pollMail,
   sendReply,
 } from '../lib/mail.js';
+import { log } from '../lib/log.js';
 
 /** The seeded Inbox project (migration 004) — the natural home for mail-born tasks. */
 const INBOX_PROJECT_ID = '00000000-0000-4000-8000-000000000001';
@@ -153,8 +155,16 @@ export async function registerMailRoutes(app: FastifyInstance): Promise<void> {
       return reply.code(400).send({ error: 'The browser names the recipient and the subject for an encrypted letter' });
     }
     const user = req.user!;
-    const replyId = await sendReply(message, { to, subject, text: parsed.data.text }, { id: user.id, name: user.name });
-    return reply.code(201).send({ id: replyId });
+    try {
+      const replyId = await sendReply(message, { to, subject, text: parsed.data.text }, { id: user.id, name: user.name });
+      return reply.code(201).send({ id: replyId });
+    } catch (err) {
+      if (!(err instanceof MailSendError)) throw err;
+      // A refusal by the provider is not an outage: 502 with a sentence the
+      // person can act on, the provider's own words in the log for the operator
+      log.warn(`mail reply refused for message ${messageId}: ${err.detail}`);
+      return reply.code(502).send({ error: err.message });
+    }
   });
 
   /** Rewriting a letter's words — for the one-time job that brings old plaintext under the key (#223). */

--- a/web/src/lib/i18n.ru.ts
+++ b/web/src/lib/i18n.ru.ts
@@ -984,6 +984,8 @@ export const ru: Record<string, string> = {
   'An item with this id already exists': 'Пункт с таким id уже есть',
   'A section with this id already exists': 'Раздел с таким id уже есть',
   'An entry with this id already exists': 'Запись с таким id уже есть',
+  'The mail service refused the message': 'Почтовый сервис отказался отправлять письмо',
+  'The mail server refused the message': 'Почтовый сервер отказался отправлять письмо',
   'An attachment with this id already exists': 'Вложение с таким id уже есть',
   'The file name is too long': 'Слишком длинное имя файла',
   'The browser creates the task for an encrypted letter': 'Задачу из зашифрованного письма создаёт браузер',


### PR DESCRIPTION
A provider refusal on `POST /api/mail/:id/reply` propagated as **500 "Internal server error"**; the page showed that text and on production the error-log alert would fire for something that is not an outage. The reply copy was correctly never stored. Found on the range during the phase-2 pass.

- `lib/mail.ts`: `MailSendError` with the provider's words as `detail`; thrown by `postToMailgun` and by the self-hosted SMTP sender alike.
- `routes/mail.ts`: the reply route answers **502** `{ error: 'The mail service refused the message' }` (translated) and logs the detail at WARN for the operator.
- `mail-hosted-send.test.ts` now pins 502 and the sentence instead of `>= 500`.

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)