### PR TITLE
chore: version 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -11514,7 +11514,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -11574,7 +11574,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for the v1.9.0 release (migrations 031–036, client-side encryption phases 1–2, login split). Tag follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)