### PR TITLE
fix(crypto): the key gate must not wait for the request that produces the key — 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neiliro",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neiliro",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "server",
@@ -11514,7 +11514,7 @@
     },
     "server": {
       "name": "@hub/server",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
@@ -11574,7 +11574,7 @@
     },
     "web": {
       "name": "@hub/web",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neiliro",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "workspaces": [
     "server",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/server",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "@hub/web",
   "private": true,
   "license": "AGPL-3.0-only",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/lib/codec.test.ts
+++ b/web/src/lib/codec.test.ts
@@ -361,6 +361,19 @@ describe('readiness (#249)', () => {
     expect(opened!['title']).toBe('Late key');
   });
 
+  it('never holds the provider’s own requests — /keys and sign-in produce the key, they cannot wait for it', async () => {
+    setVault({ key: null, familyHasKey: true, settled: false });
+    const t = performance.now();
+    const keys = await decodeResponse('GET', '/keys', { family: null, handoffs: [] });
+    const me = await decodeResponse('GET', '/auth/me', { id: 'u1' });
+    const envelope = await encodeRequest('PUT', '/keys/envelope', { envelope: 'w1:x' });
+    expect(performance.now() - t).toBeLessThan(200);
+    expect((keys as Row)['handoffs']).toEqual([]);
+    expect((me as Row)['id']).toBe('u1');
+    expect((envelope as Row)['envelope']).toBe('w1:x');
+    setVault({ key: null, familyHasKey: false, settled: true });
+  });
+
   it('does not wait when the provider has already answered', async () => {
     setVault({ key: null, familyHasKey: false });
     const t = performance.now();

--- a/web/src/lib/codec.ts
+++ b/web/src/lib/codec.ts
@@ -236,6 +236,17 @@ async function sealCreate(table: string, b: Body): Promise<Body> {
   return sealFields(table, id, { ...b, id }, F[table]!);
 }
 
+/*
+  Which requests wait for the key (#249, #260). The provider learns whether
+  the family has a key by asking /api/keys — through this same client. If
+  that request waited for the vault to settle, and the vault settled only
+  after that request returned, every page load would deadlock until the
+  bounded wait ran out and then decode into placeholders. So the provider's
+  own routes, and sign-in, never wait; everything that may carry an envelope
+  does.
+*/
+const waitsForKey = (path: string): boolean => !path.startsWith('/keys') && !path.startsWith('/auth/');
+
 // ── The table ─────────────────────────────────────────────────────────────
 
 /** The API client, handed in so the codec can issue the odd follow-up request. */
@@ -244,7 +255,7 @@ export type Requester = (path: string, method: string, body?: unknown) => Promis
 export async function encodeRequest(method: string, path: string, body: unknown): Promise<unknown> {
   if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
   // A write racing the key's first load must not be refused as "locked" (#249)
-  await vaultReady();
+  if (waitsForKey(path)) await vaultReady();
   const b = body as Body;
   let m: RegExpMatchArray | null;
 
@@ -335,8 +346,9 @@ export async function decodeResponse(
 ): Promise<unknown> {
   if (data === null || typeof data !== 'object') return data;
   // Decoded with the key at hand, not with whatever the vault held a few
-  // milliseconds after page load (#249)
-  await vaultReady();
+  // milliseconds after page load (#249) — except for the requests that
+  // produce that key, which must never wait for themselves (#260)
+  if (waitsForKey(path)) await vaultReady();
   let m: RegExpMatchArray | null;
 
   // Notes


### PR DESCRIPTION
Hotfix for 1.9.0. On production, after the test family's key was created, every fresh page load showed `••••••` for the words until a client-side navigation.

`KeyProvider.sync()` asks `/api/keys` through the same client whose codec now waits for the provider to settle — and the provider settles only after that answer. Deadlock until the 2.5 s bound, then every held response decodes without a key. The unit test for #255 never exercised the provider's own request; this one does.

- `codec.ts`: `/keys*` and `/auth/*` never wait for `vaultReady()` — they carry no envelopes and they are what the wait exists for.
- New test: those requests resolve immediately while the vault is unsettled.
- Version 1.9.1 in the three `package.json`.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)